### PR TITLE
Real SEP-41 token transfers, reclaim_invoice, yield rate oracle

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1,5 +1,32 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map, Symbol};
+
+/// Grace period after due_date before a lender can mark a Financed offer
+/// Defaulted on an Overdue invoice. 7 days, in seconds.
+const GRACE_PERIOD_SECS: u64 = 604_800;
+
+// ─── Yield Rate Oracle ───────────────────────────────────────────────────────
+
+/// Risk tier for yield-rate lookups. A = low risk, C = high risk.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RiskTier {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+
+fn load_rates(env: &Env) -> Map<RiskTier, u32> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("rates"))
+        .unwrap_or(Map::new(env))
+}
+
+fn save_rates(env: &Env, map: &Map<RiskTier, u32>) {
+    env.storage().persistent().set(&symbol_short!("rates"), map);
+}
 
 // ─── Invoice ─────────────────────────────────────────────────────────────────
 
@@ -90,6 +117,83 @@ pub struct InvoiceRegistryContract;
 
 #[contractimpl]
 impl InvoiceRegistryContract {
+    // ── Admin / token setup ──────────────────────────────────────────────────
+
+    /// One-time setup. Sets the admin and the SEP-41 token contract used to
+    /// move funds on `accept_offer` and `repay_invoice`. Must be called once,
+    /// right after deployment, before any offer can be accepted.
+    pub fn initialize(env: Env, admin: Address, token: Address) {
+        admin.require_auth();
+        if env.storage().instance().has(&symbol_short!("admin")) {
+            panic!("Already initialized");
+        }
+        env.storage().instance().set(&symbol_short!("admin"), &admin);
+        env.storage().instance().set(&symbol_short!("token"), &token);
+    }
+
+    /// Returns the admin address. Panics if not yet initialized.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// Returns the SEP-41 token contract address used for fund movement.
+    /// Panics if not yet initialized.
+    pub fn get_token(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("token"))
+            .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// Transfers admin rights to a new address. Only the current admin can
+    /// call this.
+    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only the current admin can transfer admin rights");
+        }
+        env.storage().instance().set(&symbol_short!("admin"), &new_admin);
+    }
+
+    // ── Yield rate oracle functions ──────────────────────────────────────────
+
+    /// Sets the yield rate (in basis points, 0-10000) for a risk tier.
+    /// Admin only.
+    pub fn set_rate(env: Env, admin: Address, tier: RiskTier, rate_bps: u32) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can set rates");
+        }
+        if rate_bps > 10_000 {
+            panic!("rate_bps must be between 0 and 10000");
+        }
+
+        let mut rates = load_rates(&env);
+        rates.set(tier, rate_bps);
+        save_rates(&env, &rates);
+    }
+
+    /// Returns the configured yield rate (basis points) for a risk tier.
+    /// Panics if that tier hasn't been set yet.
+    pub fn get_rate(env: Env, tier: RiskTier) -> u32 {
+        load_rates(&env)
+            .get(tier)
+            .unwrap_or_else(|| panic!("Rate not set for this tier"))
+    }
+
     // ── Invoice functions ────────────────────────────────────────────────────
 
     /// Register a new invoice. Only the originator can call this.
@@ -216,6 +320,24 @@ impl InvoiceRegistryContract {
             panic!("Invoice is not in Pending status");
         }
 
+        // Pull the lender's principal and pay it straight to the business —
+        // this is the "immediate liquidity" the protocol promises. The
+        // lender must have called token.approve(lender, <this contract>,
+        // offer.amount, ...) on the token contract before the offer is
+        // accepted, since the lender isn't a co-signer of this call.
+        let token_id: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("token"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let token_client = token::TokenClient::new(&env, &token_id);
+        token_client.transfer_from(
+            &env.current_contract_address(),
+            &offer.lender,
+            &invoice.originator,
+            &offer.amount,
+        );
+
         offer.status = OfferStatus::Accepted;
         offer.funded_at = env.ledger().timestamp();
         offers.set(offer_id, offer.clone());
@@ -291,6 +413,19 @@ impl InvoiceRegistryContract {
             panic!("Offer must be Accepted before repayment");
         }
 
+        // Repay principal + yield directly to the lender. `repayer` already
+        // authorized this call above, so a direct transfer (not
+        // transfer_from) is sufficient — no prior approval needed.
+        let token_id: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("token"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let token_client = token::TokenClient::new(&env, &token_id);
+        let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
+        let repay_amount = offer.amount + yield_amount;
+        token_client.transfer(&repayer, &offer.lender, &repay_amount);
+
         invoice.status = InvoiceStatus::Repaid;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -300,6 +435,49 @@ impl InvoiceRegistryContract {
         save_offers(&env, &offers);
 
         invoice
+    }
+
+    /// After an invoice has been marked Overdue (see `mark_overdue`) and the
+    /// grace period has elapsed, the financing lender can mark their offer
+    /// Defaulted. No funds move here — principal was already paid to the
+    /// business at `accept_offer` time, so this is an on-chain default
+    /// record for off-chain recovery, not a refund. There is nothing held
+    /// in escrow to reclaim under this protocol's unsecured-financing model.
+    pub fn reclaim_invoice(env: Env, invoice_id: Symbol, offer_id: Symbol, lender: Address) -> FinancingOffer {
+        lender.require_auth();
+
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.status != InvoiceStatus::Overdue {
+            panic!("Invoice must be Overdue before reclaim");
+        }
+        if env.ledger().timestamp() < invoice.due_date + GRACE_PERIOD_SECS {
+            panic!("Grace period has not elapsed");
+        }
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.invoice_id != invoice_id {
+            panic!("Offer does not belong to this invoice");
+        }
+        if offer.lender != lender {
+            panic!("Only the financing lender can reclaim");
+        }
+        if offer.status != OfferStatus::Accepted {
+            panic!("Offer must be Accepted before reclaim");
+        }
+
+        offer.status = OfferStatus::Defaulted;
+        offers.set(offer_id, offer.clone());
+        save_offers(&env, &offers);
+
+        offer
     }
 
     /// Mark an invoice as overdue. Can be called by anyone after due_date has passed.

--- a/test.rs
+++ b/test.rs
@@ -1,8 +1,29 @@
 #![cfg(test)]
 extern crate std;
 
-use super::{InvoiceRegistryContract, InvoiceStatus, OfferStatus};
-use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+use super::{InvoiceRegistryContract, InvoiceStatus, OfferStatus, RiskTier};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env,
+};
+
+/// Deploys a test SEP-41 token, mints `amount` to `lender`, and approves the
+/// given contract as spender for `amount` — the setup a real lender would do
+/// before their offer can be accepted.
+fn setup_token(env: &Env, contract_id: &Address, lender: &Address, amount: i128) -> Address {
+    let token_admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin);
+    let token_id = sac.address();
+
+    let asset_client = token::StellarAssetClient::new(env, &token_id);
+    asset_client.mint(lender, &amount);
+
+    let token_client = token::TokenClient::new(env, &token_id);
+    token_client.approve(lender, contract_id, &amount, &(env.ledger().sequence() + 1000));
+
+    token_id
+}
 
 #[test]
 fn test_register_and_get_invoice() {
@@ -134,15 +155,20 @@ fn test_accept_offer() {
     let contract_id = env.register(InvoiceRegistryContract, ());
     let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let originator = Address::generate(&env);
     let lender = Address::generate(&env);
     let invoice_id = symbol_short!("inv004");
     let offer_id = symbol_short!("off002");
+    let amount: i128 = 1_000_000_000;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
 
     client.register_invoice(
         &invoice_id,
         &originator,
-        &(1_000_000_000i128),
+        &amount,
         &symbol_short!("USDC"),
         &(1_735_689_600u64),
     );
@@ -150,7 +176,7 @@ fn test_accept_offer() {
         &offer_id,
         &invoice_id,
         &lender,
-        &(1_000_000_000i128),
+        &amount,
         &symbol_short!("USDC"),
         &300u32,
         &(1_296_000u64),
@@ -161,6 +187,29 @@ fn test_accept_offer() {
 
     let invoice = client.get_invoice(&invoice_id);
     assert_eq!(invoice.status, InvoiceStatus::Financed);
+
+    // Principal moved from lender to business immediately on acceptance.
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&lender), 0);
+    assert_eq!(token_client.balance(&originator), amount);
+}
+
+#[test]
+fn test_initialize_twice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin, &token);
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token);
+
+    let result = client.try_initialize(&admin, &token);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -207,15 +256,21 @@ fn test_repay_invoice() {
     let contract_id = env.register(InvoiceRegistryContract, ());
     let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
+    let admin = Address::generate(&env);
     let originator = Address::generate(&env);
     let lender = Address::generate(&env);
     let invoice_id = symbol_short!("inv006");
     let offer_id = symbol_short!("off004");
+    let amount: i128 = 1_000_000_000;
+    let interest_rate: u32 = 500; // 5.00%
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
 
     client.register_invoice(
         &invoice_id,
         &originator,
-        &(1_000_000_000i128),
+        &amount,
         &symbol_short!("USDC"),
         &(1_735_689_600u64),
     );
@@ -223,18 +278,103 @@ fn test_repay_invoice() {
         &offer_id,
         &invoice_id,
         &lender,
-        &(1_000_000_000i128),
+        &amount,
         &symbol_short!("USDC"),
-        &500u32,
+        &interest_rate,
         &(2_592_000u64),
     );
     client.accept_offer(&offer_id, &originator);
+
+    // Business needs principal + yield on hand to repay — mint them the
+    // yield portion (they already hold the principal from acceptance).
+    let yield_amount = amount * (interest_rate as i128) / 10_000;
+    let asset_client = token::StellarAssetClient::new(&env, &token_id);
+    asset_client.mint(&originator, &yield_amount);
 
     let repaid = client.repay_invoice(&invoice_id, &offer_id, &originator);
     assert_eq!(repaid.status, InvoiceStatus::Repaid);
 
     let offer = client.get_offer(&offer_id);
     assert_eq!(offer.status, OfferStatus::Repaid);
+
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&lender), amount + yield_amount);
+    assert_eq!(token_client.balance(&originator), 0);
+}
+
+#[test]
+fn test_reclaim_invoice_after_grace_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv008");
+    let offer_id = symbol_short!("off006");
+    let amount: i128 = 1_000_000_000;
+    let due_date: u64 = 1_735_689_600;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(&invoice_id, &originator, &amount, &symbol_short!("USDC"), &due_date);
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &500u32,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    // Move past due_date + grace period.
+    env.ledger().set_timestamp(due_date + super::GRACE_PERIOD_SECS + 1);
+    client.mark_overdue(&invoice_id);
+
+    let reclaimed = client.reclaim_invoice(&invoice_id, &offer_id, &lender);
+    assert_eq!(reclaimed.status, OfferStatus::Defaulted);
+}
+
+#[test]
+#[should_panic(expected = "Grace period has not elapsed")]
+fn test_reclaim_before_grace_period_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv009");
+    let offer_id = symbol_short!("off007");
+    let amount: i128 = 1_000_000_000;
+    let due_date: u64 = 1_735_689_600;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(&invoice_id, &originator, &amount, &symbol_short!("USDC"), &due_date);
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &500u32,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    // Just past due_date, but not past the grace period yet.
+    env.ledger().set_timestamp(due_date + 1);
+    client.mark_overdue(&invoice_id);
+    client.reclaim_invoice(&invoice_id, &offer_id, &lender);
 }
 
 #[test]
@@ -268,4 +408,106 @@ fn test_repay_unfinanced_invoice_panics() {
     );
     // Note: offer NOT accepted — invoice stays Pending
     client.repay_invoice(&invoice_id, &offer_id, &originator);
+}
+
+#[test]
+fn test_set_and_get_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_rate(&admin, &RiskTier::A, &500u32);
+    client.set_rate(&admin, &RiskTier::B, &800u32);
+    client.set_rate(&admin, &RiskTier::C, &1200u32);
+
+    assert_eq!(client.get_rate(&RiskTier::A), 500);
+    assert_eq!(client.get_rate(&RiskTier::B), 800);
+    assert_eq!(client.get_rate(&RiskTier::C), 1200);
+}
+
+#[test]
+#[should_panic(expected = "rate_bps must be between 0 and 10000")]
+fn test_set_rate_out_of_range_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_rate(&admin, &RiskTier::A, &10_001u32);
+}
+
+#[test]
+#[should_panic(expected = "Only admin can set rates")]
+fn test_set_rate_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_rate(&not_admin, &RiskTier::A, &500u32);
+}
+
+#[test]
+#[should_panic(expected = "Rate not set for this tier")]
+fn test_get_unset_rate_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.get_rate(&RiskTier::A);
+}
+
+#[test]
+fn test_transfer_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.transfer_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+
+    // New admin can now set rates; old admin can't.
+    client.set_rate(&new_admin, &RiskTier::A, &500u32);
+}
+
+#[test]
+#[should_panic(expected = "Only the current admin can transfer admin rights")]
+fn test_transfer_admin_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.transfer_admin(&not_admin, &new_admin);
 }


### PR DESCRIPTION
Syncs work from the invofi integration monorepo (commits f9c75984, e83f9594) into this repo, closing the original intent behind #7 escrow/token transfer and the oracle spec.

- `initialize(admin, token)`, `accept_offer`/`repay_invoice` now move real SEP-41 funds instead of only tracking status enums.
- `reclaim_invoice`: after the 7-day grace period on an Overdue invoice, the lender can mark their offer Defaulted (on-chain record, not a refund — no collateral custody by design).
- Yield rate oracle: `RiskTier` enum + `set_rate`/`get_rate`/`transfer_admin`.

18 tests passing (6 new), `stellar contract build` verified — 17 functions exported.

**Breaking change:** `accept_offer`/`repay_invoice` now require `initialize()` to have been called first. Needs a redeploy before going live on testnet.

Needs your review/approval to merge — master is protected now.