### PR TITLE
Fix CI (libudev), stop Dependabot proposing major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # Major bumps to a deployed smart contract's SDK need a deliberate,
+      # reviewed migration (possible ABI/behavior changes), not an automated
+      # PR. Dependabot still proposes minor/patch updates.
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
       - name: Install native build dependencies
-        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config
       - name: Install Stellar CLI
         run: cargo install --locked stellar-cli
       - name: Build contract

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown,wasm32v1-none
       - uses: Swatinem/rust-cache@v2
       - name: Install native build dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config


### PR DESCRIPTION
Build WASM has been failing since this repo's CI was created — first on a missing dbus-1 lib (fixed separately), now on a missing libudev (hidapi, a stellar-cli dependency for hardware wallet support). Also configures Dependabot to stop proposing major version bumps: PR #6 bumps soroban-sdk 22->26, which needs a deliberate, reviewed migration for a live contract's SDK, not an automated merge.