### PR TITLE
fix: correct validation, query helper, and test struct names

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map, Symbol};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, vec, Address, Env, Map, Symbol, Vec};
 
 /// Grace period after due_date before a lender can mark a Financed offer
 /// Defaulted on an Overdue invoice. 7 days, in seconds.
@@ -206,6 +206,11 @@ impl InvoiceRegistryContract {
         due_date: u64,
     ) -> Invoice {
         originator.require_auth();
+        assert!(amount > 0, "amount must be greater than zero");
+        assert!(
+            due_date > env.ledger().timestamp(),
+            "due_date must be in the future"
+        );
 
         let mut invoices = load_invoices(&env);
         if invoices.contains_key(id.clone()) {
@@ -258,6 +263,8 @@ impl InvoiceRegistryContract {
         duration: u64,
     ) -> FinancingOffer {
         lender.require_auth();
+        assert!(amount > 0, "offer amount must be greater than zero");
+        assert!(interest_rate > 0, "interest_rate must be greater than zero");
 
         // Invoice must exist
         let invoices = load_invoices(&env);
@@ -498,6 +505,18 @@ impl InvoiceRegistryContract {
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
         invoice
+    }
+
+    /// Returns all invoices matching the given status.
+    pub fn get_invoices_by_status(env: Env, status: InvoiceStatus) -> Vec<Invoice> {
+        let invoices = load_invoices(&env);
+        let mut result: Vec<Invoice> = Vec::new(&env);
+        for (_id, inv) in invoices.iter() {
+            if inv.status == status {
+                result.push_back(inv);
+            }
+        }
+        result
     }
 }
 

--- a/test.rs
+++ b/test.rs
@@ -511,59 +511,84 @@ fn test_transfer_admin_unauthorized_panics() {
 
     client.transfer_admin(&not_admin, &new_admin);
 
+    // ── Validation tests ────────────────────────────────────────────────────
+
     #[test]
     #[should_panic(expected = "amount must be greater than zero")]
     fn test_register_invoice_zero_amount() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, InvofiInvoiceRegistry);
-        let client = InvofiInvoiceRegistryClient::new(&env, &contract_id);
-
-        let debtor = Address::generate(&env);
-        let invoice_id = symbol_short!("inv1");
-
-        // due_date in the future
+        env.mock_all_auths();
         env.ledger().set_timestamp(1_000_000);
-        client.register_invoice(&invoice_id, &debtor, &0, &symbol_short!("USDC"), &2_000_000);
+        let contract_id = env.register(InvoiceRegistryContract, ());
+        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+        let originator = Address::generate(&env);
+        client.register_invoice(
+            &symbol_short!("inv_v1"),
+            &originator,
+            &0i128,
+            &symbol_short!("USDC"),
+            &3_000_000u64,
+        );
     }
 
     #[test]
     #[should_panic(expected = "due_date must be in the future")]
     fn test_register_invoice_past_due_date() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, InvofiInvoiceRegistry);
-        let client = InvofiInvoiceRegistryClient::new(&env, &contract_id);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(5_000_000);
+        let contract_id = env.register(InvoiceRegistryContract, ());
+        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
-        let debtor = Address::generate(&env);
-        let invoice_id = symbol_short!("inv2");
-
-        env.ledger().set_timestamp(2_000_000);
-        // due_date is in the past
-        client.register_invoice(&invoice_id, &debtor, &1_000, &symbol_short!("USDC"), &1_000_000);
+        let originator = Address::generate(&env);
+        client.register_invoice(
+            &symbol_short!("inv_v2"),
+            &originator,
+            &1_000i128,
+            &symbol_short!("USDC"),
+            &1_000_000u64, // in the past relative to timestamp 5_000_000
+        );
     }
 
     #[test]
     #[should_panic(expected = "offer amount must be greater than zero")]
     fn test_create_offer_zero_amount() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, InvofiInvoiceRegistry);
-        let client = InvofiInvoiceRegistryClient::new(&env, &contract_id);
-
-        let debtor = Address::generate(&env);
-        let lender = Address::generate(&env);
-        let invoice_id = symbol_short!("inv3");
-        let offer_id = symbol_short!("off1");
-
+        env.mock_all_auths();
         env.ledger().set_timestamp(1_000_000);
-        client.register_invoice(&invoice_id, &debtor, &5_000, &symbol_short!("USDC"), &3_000_000);
-        client.create_offer(&offer_id, &invoice_id, &lender, &0, &symbol_short!("USDC"), &500);
+        let contract_id = env.register(InvoiceRegistryContract, ());
+        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+        let originator = Address::generate(&env);
+        let lender = Address::generate(&env);
+        client.register_invoice(
+            &symbol_short!("inv_v3"),
+            &originator,
+            &5_000i128,
+            &symbol_short!("USDC"),
+            &3_000_000u64,
+        );
+        client.create_offer(
+            &symbol_short!("off_v1"),
+            &symbol_short!("inv_v3"),
+            &lender,
+            &0i128, // zero amount — should panic
+            &symbol_short!("USDC"),
+            &500u32,
+            &86_400u64,
+        );
     }
 
+    // ── Query helper tests ───────────────────────────────────────────────────
 
     #[test]
     fn test_get_invoices_by_status_empty() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, InvofiInvoiceRegistry);
-        let client = InvofiInvoiceRegistryClient::new(&env, &contract_id);
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+        let contract_id = env.register(InvoiceRegistryContract, ());
+        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
         let result = client.get_invoices_by_status(&InvoiceStatus::Pending);
         assert_eq!(result.len(), 0);
@@ -572,19 +597,25 @@ fn test_transfer_admin_unauthorized_panics() {
     #[test]
     fn test_get_invoices_by_status_matching() {
         let env = Env::default();
-        let contract_id = env.register_contract(None, InvofiInvoiceRegistry);
-        let client = InvofiInvoiceRegistryClient::new(&env, &contract_id);
-
-        let debtor = Address::generate(&env);
+        env.mock_all_auths();
         env.ledger().set_timestamp(1_000_000);
+        let contract_id = env.register(InvoiceRegistryContract, ());
+        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
+        let originator = Address::generate(&env);
         client.register_invoice(
-            &symbol_short!("inv_a"),
-            &debtor, &1_000, &symbol_short!("USDC"), &3_000_000,
+            &symbol_short!("q_inv_a"),
+            &originator,
+            &1_000i128,
+            &symbol_short!("USDC"),
+            &3_000_000u64,
         );
         client.register_invoice(
-            &symbol_short!("inv_b"),
-            &debtor, &2_000, &symbol_short!("XLM"), &4_000_000,
+            &symbol_short!("q_inv_b"),
+            &originator,
+            &2_000i128,
+            &symbol_short!("XLM"),
+            &4_000_000u64,
         );
 
         let pending = client.get_invoices_by_status(&InvoiceStatus::Pending);
@@ -593,5 +624,4 @@ fn test_transfer_admin_unauthorized_panics() {
         let financed = client.get_invoices_by_status(&InvoiceStatus::Financed);
         assert_eq!(financed.len(), 0);
     }
-
 }


### PR DESCRIPTION
Fixes three issues from the previous PRs:

1. **lib.rs**: Added `assert!` validation to `register_invoice` (zero amount, past due date) and `create_offer` (zero amount, zero interest_rate) using the correct function signatures (`amount: i128`, `interest_rate: u32`).

2. **lib.rs**: Added `get_invoices_by_status` that properly iterates the `Map<Symbol, Invoice>` storage and returns a `Vec<Invoice>`.

3. **test.rs**: Replaced broken tests that used `InvofiInvoiceRegistry` (wrong name) with correct tests using `InvoiceRegistryContract` and `InvoiceRegistryContractClient`, `env.mock_all_auths()`, and correct argument types.

All `cargo test` cases should pass after this fix.