### PR TITLE
Fix: 5 tests silently never ran due to a missing brace

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, vec, Address, Env, Map, Symbol, Vec};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
 /// Grace period after due_date before a lender can mark a Financed offer
 /// Defaulted on an Overdue invoice. 7 days, in seconds.

--- a/test.rs
+++ b/test.rs
@@ -510,118 +510,118 @@ fn test_transfer_admin_unauthorized_panics() {
     client.initialize(&admin, &token);
 
     client.transfer_admin(&not_admin, &new_admin);
+}
 
-    // ── Validation tests ────────────────────────────────────────────────────
+// ── Validation tests ────────────────────────────────────────────────────
 
-    #[test]
-    #[should_panic(expected = "amount must be greater than zero")]
-    fn test_register_invoice_zero_amount() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1_000_000);
-        let contract_id = env.register(InvoiceRegistryContract, ());
-        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+#[test]
+#[should_panic(expected = "amount must be greater than zero")]
+fn test_register_invoice_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
-        let originator = Address::generate(&env);
-        client.register_invoice(
-            &symbol_short!("inv_v1"),
-            &originator,
-            &0i128,
-            &symbol_short!("USDC"),
-            &3_000_000u64,
-        );
-    }
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v1"),
+        &originator,
+        &0i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+}
 
-    #[test]
-    #[should_panic(expected = "due_date must be in the future")]
-    fn test_register_invoice_past_due_date() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(5_000_000);
-        let contract_id = env.register(InvoiceRegistryContract, ());
-        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+#[test]
+#[should_panic(expected = "due_date must be in the future")]
+fn test_register_invoice_past_due_date() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(5_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
-        let originator = Address::generate(&env);
-        client.register_invoice(
-            &symbol_short!("inv_v2"),
-            &originator,
-            &1_000i128,
-            &symbol_short!("USDC"),
-            &1_000_000u64, // in the past relative to timestamp 5_000_000
-        );
-    }
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v2"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &1_000_000u64, // in the past relative to timestamp 5_000_000
+    );
+}
 
-    #[test]
-    #[should_panic(expected = "offer amount must be greater than zero")]
-    fn test_create_offer_zero_amount() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1_000_000);
-        let contract_id = env.register(InvoiceRegistryContract, ());
-        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+#[test]
+#[should_panic(expected = "offer amount must be greater than zero")]
+fn test_create_offer_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
-        let originator = Address::generate(&env);
-        let lender = Address::generate(&env);
-        client.register_invoice(
-            &symbol_short!("inv_v3"),
-            &originator,
-            &5_000i128,
-            &symbol_short!("USDC"),
-            &3_000_000u64,
-        );
-        client.create_offer(
-            &symbol_short!("off_v1"),
-            &symbol_short!("inv_v3"),
-            &lender,
-            &0i128, // zero amount — should panic
-            &symbol_short!("USDC"),
-            &500u32,
-            &86_400u64,
-        );
-    }
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v3"),
+        &originator,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_v1"),
+        &symbol_short!("inv_v3"),
+        &lender,
+        &0i128, // zero amount — should panic
+        &symbol_short!("USDC"),
+        &500u32,
+        &86_400u64,
+    );
+}
 
-    // ── Query helper tests ───────────────────────────────────────────────────
+// ── Query helper tests ───────────────────────────────────────────────────
 
-    #[test]
-    fn test_get_invoices_by_status_empty() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1_000_000);
-        let contract_id = env.register(InvoiceRegistryContract, ());
-        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+#[test]
+fn test_get_invoices_by_status_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
-        let result = client.get_invoices_by_status(&InvoiceStatus::Pending);
-        assert_eq!(result.len(), 0);
-    }
+    let result = client.get_invoices_by_status(&InvoiceStatus::Pending);
+    assert_eq!(result.len(), 0);
+}
 
-    #[test]
-    fn test_get_invoices_by_status_matching() {
-        let env = Env::default();
-        env.mock_all_auths();
-        env.ledger().set_timestamp(1_000_000);
-        let contract_id = env.register(InvoiceRegistryContract, ());
-        let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+#[test]
+fn test_get_invoices_by_status_matching() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
 
-        let originator = Address::generate(&env);
-        client.register_invoice(
-            &symbol_short!("q_inv_a"),
-            &originator,
-            &1_000i128,
-            &symbol_short!("USDC"),
-            &3_000_000u64,
-        );
-        client.register_invoice(
-            &symbol_short!("q_inv_b"),
-            &originator,
-            &2_000i128,
-            &symbol_short!("XLM"),
-            &4_000_000u64,
-        );
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("q_inv_a"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.register_invoice(
+        &symbol_short!("q_inv_b"),
+        &originator,
+        &2_000i128,
+        &symbol_short!("XLM"),
+        &4_000_000u64,
+    );
 
-        let pending = client.get_invoices_by_status(&InvoiceStatus::Pending);
-        assert_eq!(pending.len(), 2);
+    let pending = client.get_invoices_by_status(&InvoiceStatus::Pending);
+    assert_eq!(pending.len(), 2);
 
-        let financed = client.get_invoices_by_status(&InvoiceStatus::Financed);
-        assert_eq!(financed.len(), 0);
-    }
+    let financed = client.get_invoices_by_status(&InvoiceStatus::Financed);
+    assert_eq!(financed.len(), 0);
 }


### PR DESCRIPTION
test_transfer_admin_unauthorized_panics was missing its closing brace, so everything after it (the validation tests from #13 and the get_invoices_by_status tests from #14/#15) got parsed as inner items nested inside that function body instead of top-level tests. Rust allows fn-in-fn definitions, so this compiled fine with only a dead-code warning ('function is never used') -- cargo test silently ran 18 tests instead of 23, and nobody noticed because nothing failed.

Also removes an unused vec import that surfaced once the file compiled cleanly.

Verified: cargo test now runs and passes all 23 tests. Found while syncing this repo against the monorepo.