### PR TITLE
feat: cancel_invoice, query helpers, calculate_total_due, MIN_OFFER_DURATION (#22 #23 #24 #25 #26)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,617 @@
+#![no_std]
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Address, Env, Map, Symbol, Vec};
+
+/// Grace period after due_date before a lender can mark a Financed offer
+/// Defaulted on an Overdue invoice. 7 days, in seconds.
+const GRACE_PERIOD_SECS: u64 = 604_800;
+
+/// Minimum allowed financing duration in create_offer. 1 day, in seconds.
+pub const MIN_OFFER_DURATION_SECS: u64 = 86_400;
+
+// ─── Yield Rate Oracle ───────────────────────────────────────────────────────
+
+/// Risk tier for yield-rate lookups. A = low risk, C = high risk.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum RiskTier {
+    A = 0,
+    B = 1,
+    C = 2,
+}
+
+fn load_rates(env: &Env) -> Map<RiskTier, u32> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("rates"))
+        .unwrap_or(Map::new(env))
+}
+
+fn save_rates(env: &Env, map: &Map<RiskTier, u32>) {
+    env.storage().persistent().set(&symbol_short!("rates"), map);
+}
+
+// ─── Invoice ─────────────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Invoice {
+    pub id: Symbol,
+    pub originator: Address,
+    pub amount: i128,
+    pub currency: Symbol,
+    pub due_date: u64,
+    pub status: InvoiceStatus,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum InvoiceStatus {
+    Pending   = 0,
+    Financed  = 1,
+    Repaid    = 2,
+    Overdue   = 3,
+    Cancelled = 4,
+}
+
+// ─── Financing Offer ─────────────────────────────────────────────────────────
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FinancingOffer {
+    pub id: Symbol,
+    pub invoice_id: Symbol,
+    pub lender: Address,
+    pub amount: i128,
+    pub currency: Symbol,
+    /// Interest rate in basis points (e.g. 500 = 5.00%)
+    pub interest_rate: u32,
+    /// Financing duration in seconds
+    pub duration: u64,
+    pub status: OfferStatus,
+    /// Unix timestamp when the offer was accepted; 0 if not yet accepted
+    pub funded_at: u64,
+    /// Running total of repayments made against the financing obligation
+    pub amount_repaid: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum OfferStatus {
+    Pending   = 0,
+    Accepted  = 1,
+    Rejected  = 2,
+    Financed  = 3,
+    Repaid    = 4,
+    Defaulted = 5,
+}
+
+// ─── Storage helpers ─────────────────────────────────────────────────────────
+
+fn load_invoices(env: &Env) -> Map<Symbol, Invoice> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("invoices"))
+        .unwrap_or(Map::new(env))
+}
+
+fn save_invoices(env: &Env, map: &Map<Symbol, Invoice>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("invoices"), map);
+}
+
+fn load_offers(env: &Env) -> Map<Symbol, FinancingOffer> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("offers"))
+        .unwrap_or(Map::new(env))
+}
+
+fn save_offers(env: &Env, map: &Map<Symbol, FinancingOffer>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("offers"), map);
+}
+
+// ─── Contract ────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct InvoiceRegistryContract;
+
+#[contractimpl]
+impl InvoiceRegistryContract {
+    // ── Admin / token setup ──────────────────────────────────────────────────
+
+    /// One-time setup. Sets the admin and the SEP-41 token contract used to
+    /// move funds on `accept_offer` and `repay_invoice`. Must be called once,
+    /// right after deployment, before any offer can be accepted.
+    pub fn initialize(env: Env, admin: Address, token: Address) {
+        admin.require_auth();
+        if env.storage().instance().has(&symbol_short!("admin")) {
+            panic!("Already initialized");
+        }
+        env.storage().instance().set(&symbol_short!("admin"), &admin);
+        env.storage().instance().set(&symbol_short!("token"), &token);
+    }
+
+    /// Returns the admin address. Panics if not yet initialized.
+    pub fn get_admin(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// Returns the SEP-41 token contract address used for fund movement.
+    /// Panics if not yet initialized.
+    pub fn get_token(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("token"))
+            .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// Transfers admin rights to a new address. Only the current admin can
+    /// call this.
+    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only the current admin can transfer admin rights");
+        }
+        env.storage().instance().set(&symbol_short!("admin"), &new_admin);
+    }
+
+    // ── Yield rate oracle functions ──────────────────────────────────────────
+
+    /// Sets the yield rate (in basis points, 0-10000) for a risk tier.
+    /// Admin only.
+    pub fn set_rate(env: Env, admin: Address, tier: RiskTier, rate_bps: u32) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can set rates");
+        }
+        if rate_bps > 10_000 {
+            panic!("rate_bps must be between 0 and 10000");
+        }
+
+        let mut rates = load_rates(&env);
+        rates.set(tier, rate_bps);
+        save_rates(&env, &rates);
+    }
+
+    /// Returns the configured yield rate (basis points) for a risk tier.
+    /// Panics if that tier hasn't been set yet.
+    pub fn get_rate(env: Env, tier: RiskTier) -> u32 {
+        load_rates(&env)
+            .get(tier)
+            .unwrap_or_else(|| panic!("Rate not set for this tier"))
+    }
+
+    // ── Invoice functions ────────────────────────────────────────────────────
+
+    /// Register a new invoice. Only the originator can call this.
+    pub fn register_invoice(
+        env: Env,
+        id: Symbol,
+        originator: Address,
+        amount: i128,
+        currency: Symbol,
+        due_date: u64,
+    ) -> Invoice {
+        originator.require_auth();
+        assert!(amount > 0, "amount must be greater than zero");
+        assert!(
+            due_date > env.ledger().timestamp(),
+            "due_date must be in the future"
+        );
+
+        let mut invoices = load_invoices(&env);
+        if invoices.contains_key(id.clone()) {
+            panic!("Invoice with this ID already exists");
+        }
+
+        let invoice = Invoice {
+            id: id.clone(),
+            originator,
+            amount,
+            currency,
+            due_date,
+            status: InvoiceStatus::Pending,
+        };
+        invoices.set(id, invoice.clone());
+        save_invoices(&env, &invoices);
+        invoice
+    }
+
+    /// Get an invoice by ID.
+    pub fn get_invoice(env: Env, id: Symbol) -> Invoice {
+        load_invoices(&env)
+            .get(id)
+            .unwrap_or_else(|| panic!("Invoice not found"))
+    }
+
+    /// Update the status of an invoice. Restricted to originator or contract logic.
+    pub fn update_invoice_status(env: Env, id: Symbol, new_status: InvoiceStatus) -> Invoice {
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+        invoice.status = new_status;
+        invoices.set(id, invoice.clone());
+        save_invoices(&env, &invoices);
+        invoice
+    }
+
+    // ── Financing offer functions ─────────────────────────────────────────────
+
+    /// Create a financing offer on an invoice. Only the lender can call this.
+    pub fn create_offer(
+        env: Env,
+        offer_id: Symbol,
+        invoice_id: Symbol,
+        lender: Address,
+        amount: i128,
+        currency: Symbol,
+        interest_rate: u32,
+        duration: u64,
+    ) -> FinancingOffer {
+        lender.require_auth();
+        assert!(amount > 0, "offer amount must be greater than zero");
+        assert!(interest_rate > 0, "interest_rate must be greater than zero");
+        assert!(interest_rate <= 10_000, "interest_rate must be at most 10000 bps");
+        assert!(duration >= MIN_OFFER_DURATION_SECS, "duration must be at least 1 day (86400 seconds)");
+
+        // Invoice must exist, and the lender can't finance their own invoice.
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+        assert!(
+            lender != invoice.originator,
+            "lender cannot finance their own invoice"
+        );
+
+        let mut offers = load_offers(&env);
+        if offers.contains_key(offer_id.clone()) {
+            panic!("Offer with this ID already exists");
+        }
+
+        let offer = FinancingOffer {
+            id: offer_id.clone(),
+            invoice_id,
+            lender,
+            amount,
+            currency,
+            interest_rate,
+            duration,
+            status: OfferStatus::Pending,
+            funded_at: 0,
+            amount_repaid: 0,
+        };
+        offers.set(offer_id, offer.clone());
+        save_offers(&env, &offers);
+        offer
+    }
+
+    /// Get a financing offer by ID.
+    pub fn get_offer(env: Env, id: Symbol) -> FinancingOffer {
+        load_offers(&env)
+            .get(id)
+            .unwrap_or_else(|| panic!("Offer not found"))
+    }
+
+    /// Accept a financing offer. Only the invoice originator can call this.
+    /// Marks the offer Accepted and the invoice Financed.
+    pub fn accept_offer(env: Env, offer_id: Symbol, invoice_originator: Address) -> FinancingOffer {
+        invoice_originator.require_auth();
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.status != OfferStatus::Pending {
+            panic!("Offer is not in Pending status");
+        }
+
+        // Verify caller is the invoice originator
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(offer.invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.originator != invoice_originator {
+            panic!("Only the invoice originator can accept offers");
+        }
+        if invoice.status != InvoiceStatus::Pending {
+            panic!("Invoice is not in Pending status");
+        }
+
+        // Pull the lender's principal and pay it straight to the business —
+        // this is the "immediate liquidity" the protocol promises. The
+        // lender must have called token.approve(lender, <this contract>,
+        // offer.amount, ...) on the token contract before the offer is
+        // accepted, since the lender isn't a co-signer of this call.
+        let token_id: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("token"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let token_client = token::TokenClient::new(&env, &token_id);
+        token_client.transfer_from(
+            &env.current_contract_address(),
+            &offer.lender,
+            &invoice.originator,
+            &offer.amount,
+        );
+
+        offer.status = OfferStatus::Accepted;
+        offer.funded_at = env.ledger().timestamp();
+        offers.set(offer_id, offer.clone());
+        save_offers(&env, &offers);
+
+        invoice.status = InvoiceStatus::Financed;
+        invoices.set(offer.invoice_id.clone(), invoice);
+        save_invoices(&env, &invoices);
+
+        offer
+    }
+
+    /// Reject a financing offer. Only the invoice originator can call this.
+    pub fn reject_offer(env: Env, offer_id: Symbol, invoice_originator: Address) -> FinancingOffer {
+        invoice_originator.require_auth();
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.status != OfferStatus::Pending {
+            panic!("Offer is not in Pending status");
+        }
+
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(offer.invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.originator != invoice_originator {
+            panic!("Only the invoice originator can reject offers");
+        }
+
+        offer.status = OfferStatus::Rejected;
+        offers.set(offer_id, offer.clone());
+        save_offers(&env, &offers);
+
+        offer
+    }
+
+    /// Mark part or all of an invoice as repaid. Only the invoice originator
+    /// (debtor) can call this. Partial payments keep the invoice/offer in
+    /// Financed status until the outstanding balance is fully cleared.
+    pub fn repay_invoice(
+        env: Env,
+        invoice_id: Symbol,
+        offer_id: Symbol,
+        repayer: Address,
+        amount: i128,
+    ) -> Invoice {
+        repayer.require_auth();
+
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.originator != repayer {
+            panic!("Only the invoice originator can repay");
+        }
+        if invoice.status != InvoiceStatus::Financed {
+            panic!("Invoice must be Financed before repayment");
+        }
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.invoice_id != invoice_id {
+            panic!("Offer does not belong to this invoice");
+        }
+        if offer.status != OfferStatus::Accepted && offer.status != OfferStatus::Financed {
+            panic!("Offer must be Accepted or Financed before repayment");
+        }
+        assert!(amount > 0, "repayment amount must be greater than zero");
+
+        // Repay principal + yield directly to the lender. `repayer` already
+        // authorized this call above, so a direct transfer (not
+        // transfer_from) is sufficient — no prior approval needed.
+        let token_id: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("token"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let token_client = token::TokenClient::new(&env, &token_id);
+        let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
+        let total_due = offer.amount + yield_amount;
+        let remaining_balance = total_due - offer.amount_repaid;
+        assert!(
+            amount <= remaining_balance,
+            "Repayment amount exceeds remaining balance"
+        );
+        token_client.transfer(&repayer, &offer.lender, &amount);
+
+        offer.amount_repaid += amount;
+        if offer.amount_repaid >= total_due {
+            invoice.status = InvoiceStatus::Repaid;
+            offer.status = OfferStatus::Repaid;
+        } else {
+            invoice.status = InvoiceStatus::Financed;
+            offer.status = OfferStatus::Financed;
+        }
+
+        invoices.set(invoice_id, invoice.clone());
+        save_invoices(&env, &invoices);
+
+        offers.set(offer_id, offer);
+        save_offers(&env, &offers);
+
+        invoice
+    }
+
+    /// After an invoice has been marked Overdue (see `mark_overdue`) and the
+    /// grace period has elapsed, the financing lender can mark their offer
+    /// Defaulted. No funds move here — principal was already paid to the
+    /// business at `accept_offer` time, so this is an on-chain default
+    /// record for off-chain recovery, not a refund. There is nothing held
+    /// in escrow to reclaim under this protocol's unsecured-financing model.
+    pub fn reclaim_invoice(env: Env, invoice_id: Symbol, offer_id: Symbol, lender: Address) -> FinancingOffer {
+        lender.require_auth();
+
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.status != InvoiceStatus::Overdue {
+            panic!("Invoice must be Overdue before reclaim");
+        }
+        if env.ledger().timestamp() < invoice.due_date + GRACE_PERIOD_SECS {
+            panic!("Grace period has not elapsed");
+        }
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.invoice_id != invoice_id {
+            panic!("Offer does not belong to this invoice");
+        }
+        if offer.lender != lender {
+            panic!("Only the financing lender can reclaim");
+        }
+        if offer.status != OfferStatus::Accepted && offer.status != OfferStatus::Financed {
+            panic!("Offer must be Accepted or Financed before reclaim");
+        }
+
+        offer.status = OfferStatus::Defaulted;
+        offers.set(offer_id, offer.clone());
+        save_offers(&env, &offers);
+
+        offer
+    }
+
+    /// Mark an invoice as overdue. Can be called by anyone after due_date has passed.
+    pub fn mark_overdue(env: Env, invoice_id: Symbol) -> Invoice {
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.status != InvoiceStatus::Financed {
+            panic!("Only Financed invoices can be marked Overdue");
+        }
+        if env.ledger().timestamp() <= invoice.due_date {
+            panic!("Invoice due date has not passed");
+        }
+
+        invoice.status = InvoiceStatus::Overdue;
+        invoices.set(invoice_id, invoice.clone());
+        save_invoices(&env, &invoices);
+        invoice
+    }
+
+    /// Returns all invoices matching the given status.
+    pub fn get_invoices_by_status(env: Env, status: InvoiceStatus) -> Vec<Invoice> {
+        let invoices = load_invoices(&env);
+        let mut result: Vec<Invoice> = Vec::new(&env);
+        for (_id, inv) in invoices.iter() {
+            if inv.status == status {
+                result.push_back(inv);
+            }
+        }
+        result
+    }
+
+    /// Cancel a Pending invoice. Only the originator can call this.
+    /// Transitions the invoice from Pending → Cancelled. Any pending offers
+    /// attached to the invoice remain in Pending status (they were never funded).
+    pub fn cancel_invoice(env: Env, invoice_id: Symbol, originator: Address) -> Invoice {
+        originator.require_auth();
+
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.originator != originator {
+            panic!("Only the invoice originator can cancel");
+        }
+        if invoice.status != InvoiceStatus::Pending {
+            panic!("Only Pending invoices can be cancelled");
+        }
+
+        invoice.status = InvoiceStatus::Cancelled;
+        invoices.set(invoice_id, invoice.clone());
+        save_invoices(&env, &invoices);
+        invoice
+    }
+
+    /// Return all financing offers attached to a given invoice.
+    pub fn get_offers_by_invoice(env: Env, invoice_id: Symbol) -> Vec<FinancingOffer> {
+        let offers = load_offers(&env);
+        let mut result: Vec<FinancingOffer> = Vec::new(&env);
+        for (_id, offer) in offers.iter() {
+            if offer.invoice_id == invoice_id {
+                result.push_back(offer);
+            }
+        }
+        result
+    }
+
+    /// Return all financing offers submitted by a given lender address.
+    pub fn get_offers_by_lender(env: Env, lender: Address) -> Vec<FinancingOffer> {
+        let offers = load_offers(&env);
+        let mut result: Vec<FinancingOffer> = Vec::new(&env);
+        for (_id, offer) in offers.iter() {
+            if offer.lender == lender {
+                result.push_back(offer);
+            }
+        }
+        result
+    }
+
+    /// Return the remaining amount due (principal + yield − already repaid) for
+    /// a given offer. Returns 0 if the offer is already Repaid or Defaulted.
+    pub fn calculate_total_due(env: Env, offer_id: Symbol) -> i128 {
+        let offers = load_offers(&env);
+        let offer = offers
+            .get(offer_id)
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.status == OfferStatus::Repaid || offer.status == OfferStatus::Defaulted {
+            return 0;
+        }
+
+        let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
+        let total_due = offer.amount + yield_amount;
+        (total_due - offer.amount_repaid).max(0)
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,0 +1,946 @@
+#![cfg(test)]
+extern crate std;
+
+use super::{InvoiceRegistryContract, InvoiceStatus, OfferStatus, RiskTier};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Ledger as _},
+    token, Address, Env,
+};
+
+/// Deploys a test SEP-41 token, mints `amount` to `lender`, and approves the
+/// given contract as spender for `amount` — the setup a real lender would do
+/// before their offer can be accepted.
+fn setup_token(env: &Env, contract_id: &Address, lender: &Address, amount: i128) -> Address {
+    let token_admin = Address::generate(env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin);
+    let token_id = sac.address();
+
+    let asset_client = token::StellarAssetClient::new(env, &token_id);
+    asset_client.mint(lender, &amount);
+
+    let token_client = token::TokenClient::new(env, &token_id);
+    token_client.approve(lender, contract_id, &amount, &(env.ledger().sequence() + 1000));
+
+    token_id
+}
+
+#[test]
+fn test_register_and_get_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let invoice_id = symbol_short!("inv001");
+    let amount: i128 = 1_000_000_000;
+    let currency = symbol_short!("USDC");
+    let due_date: u64 = 1_735_689_600;
+
+    let registered = client.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &currency,
+        &due_date,
+    );
+
+    assert_eq!(registered.id, invoice_id);
+    assert_eq!(registered.originator, originator);
+    assert_eq!(registered.amount, amount);
+    assert_eq!(registered.currency, currency);
+    assert_eq!(registered.due_date, due_date);
+    assert_eq!(registered.status, InvoiceStatus::Pending);
+
+    let fetched = client.get_invoice(&invoice_id);
+    assert_eq!(fetched, registered);
+}
+
+#[test]
+#[should_panic(expected = "Invoice with this ID already exists")]
+fn test_duplicate_invoice_id_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let invoice_id = symbol_short!("dup001");
+    let amount: i128 = 500_000_000;
+    let currency = symbol_short!("XLM");
+    let due_date: u64 = 1_735_689_600;
+
+    client.register_invoice(&invoice_id, &originator, &amount, &currency, &due_date);
+    client.register_invoice(&invoice_id, &originator, &amount, &currency, &due_date);
+}
+
+#[test]
+#[should_panic(expected = "Invoice not found")]
+fn test_get_non_existent_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    client.get_invoice(&symbol_short!("nope"));
+}
+
+#[test]
+fn test_update_invoice_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let invoice_id = symbol_short!("inv002");
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &(1_000_000_000i128),
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+
+    let updated = client.update_invoice_status(&invoice_id, &InvoiceStatus::Financed);
+    assert_eq!(updated.status, InvoiceStatus::Financed);
+}
+
+#[test]
+fn test_create_and_get_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv003");
+    let offer_id = symbol_short!("off001");
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &(2_000_000_000i128),
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+
+    let offer = client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &(2_000_000_000i128),
+        &symbol_short!("USDC"),
+        &500u32,
+        &(2_592_000u64),
+    );
+
+    assert_eq!(offer.id, offer_id);
+    assert_eq!(offer.invoice_id, invoice_id);
+    assert_eq!(offer.lender, lender);
+    assert_eq!(offer.status, OfferStatus::Pending);
+    assert_eq!(offer.funded_at, 0u64);
+
+    let fetched = client.get_offer(&offer_id);
+    assert_eq!(fetched.id, offer_id);
+}
+
+#[test]
+fn test_accept_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv004");
+    let offer_id = symbol_short!("off002");
+    let amount: i128 = 1_000_000_000;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &300u32,
+        &(1_296_000u64),
+    );
+
+    let accepted = client.accept_offer(&offer_id, &originator);
+    assert_eq!(accepted.status, OfferStatus::Accepted);
+
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Financed);
+
+    // Principal moved from lender to business immediately on acceptance.
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&lender), 0);
+    assert_eq!(token_client.balance(&originator), amount);
+}
+
+#[test]
+fn test_initialize_twice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    client.initialize(&admin, &token);
+    assert_eq!(client.get_admin(), admin);
+    assert_eq!(client.get_token(), token);
+
+    let result = client.try_initialize(&admin, &token);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_reject_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv005");
+    let offer_id = symbol_short!("off003");
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &(1_000_000_000i128),
+        &symbol_short!("XLM"),
+        &(1_735_689_600u64),
+    );
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &(1_000_000_000i128),
+        &symbol_short!("XLM"),
+        &200u32,
+        &(864_000u64),
+    );
+
+    let rejected = client.reject_offer(&offer_id, &originator);
+    assert_eq!(rejected.status, OfferStatus::Rejected);
+
+    // Invoice should remain Pending
+    let invoice = client.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Pending);
+}
+
+#[test]
+fn test_repay_invoice_partial_then_full() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv006");
+    let offer_id = symbol_short!("off004");
+    let amount: i128 = 1_000_000_000;
+    let interest_rate: u32 = 500; // 5.00%
+    let yield_amount = amount * (interest_rate as i128) / 10_000;
+    let total_due = amount + yield_amount;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &interest_rate,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    let asset_client = token::StellarAssetClient::new(&env, &token_id);
+    asset_client.mint(&originator, &total_due);
+
+    let partial_amount = amount / 2;
+    let repaid = client.repay_invoice(&invoice_id, &offer_id, &originator, &partial_amount);
+    assert_eq!(repaid.status, InvoiceStatus::Financed);
+
+    let offer = client.get_offer(&offer_id);
+    assert_eq!(offer.status, OfferStatus::Financed);
+    assert_eq!(offer.amount_repaid, partial_amount);
+
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&lender), partial_amount);
+    assert_eq!(token_client.balance(&originator), amount + total_due - partial_amount);
+
+    let final_amount = total_due - partial_amount;
+    let repaid_final = client.repay_invoice(&invoice_id, &offer_id, &originator, &final_amount);
+    assert_eq!(repaid_final.status, InvoiceStatus::Repaid);
+
+    let settled_offer = client.get_offer(&offer_id);
+    assert_eq!(settled_offer.status, OfferStatus::Repaid);
+    assert_eq!(settled_offer.amount_repaid, total_due);
+    assert_eq!(token_client.balance(&lender), total_due);
+    assert_eq!(token_client.balance(&originator), amount);
+}
+
+#[test]
+#[should_panic(expected = "Repayment amount exceeds remaining balance")]
+fn test_repay_invoice_overpayment_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv010");
+    let offer_id = symbol_short!("off008");
+    let amount: i128 = 1_000_000_000;
+    let interest_rate: u32 = 500;
+    let yield_amount = amount * (interest_rate as i128) / 10_000;
+    let total_due = amount + yield_amount;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &interest_rate,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    let asset_client = token::StellarAssetClient::new(&env, &token_id);
+    asset_client.mint(&originator, &total_due);
+
+    client.repay_invoice(&invoice_id, &offer_id, &originator, &(total_due + 1));
+}
+
+#[test]
+fn test_reclaim_invoice_after_grace_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv008");
+    let offer_id = symbol_short!("off006");
+    let amount: i128 = 1_000_000_000;
+    let due_date: u64 = 1_735_689_600;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(&invoice_id, &originator, &amount, &symbol_short!("USDC"), &due_date);
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &500u32,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    // Move past due_date + grace period.
+    env.ledger().set_timestamp(due_date + super::GRACE_PERIOD_SECS + 1);
+    client.mark_overdue(&invoice_id);
+
+    let reclaimed = client.reclaim_invoice(&invoice_id, &offer_id, &lender);
+    assert_eq!(reclaimed.status, OfferStatus::Defaulted);
+}
+
+#[test]
+#[should_panic(expected = "Grace period has not elapsed")]
+fn test_reclaim_before_grace_period_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv009");
+    let offer_id = symbol_short!("off007");
+    let amount: i128 = 1_000_000_000;
+    let due_date: u64 = 1_735_689_600;
+
+    let token_id = setup_token(&env, &contract_id, &lender, amount);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(&invoice_id, &originator, &amount, &symbol_short!("USDC"), &due_date);
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &500u32,
+        &(2_592_000u64),
+    );
+    client.accept_offer(&offer_id, &originator);
+
+    // Just past due_date, but not past the grace period yet.
+    env.ledger().set_timestamp(due_date + 1);
+    client.mark_overdue(&invoice_id);
+    client.reclaim_invoice(&invoice_id, &offer_id, &lender);
+}
+
+#[test]
+#[should_panic(expected = "Invoice must be Financed before repayment")]
+fn test_repay_unfinanced_invoice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv007");
+    let offer_id = symbol_short!("off005");
+
+    client.register_invoice(
+        &invoice_id,
+        &originator,
+        &(1_000_000_000i128),
+        &symbol_short!("USDC"),
+        &(1_735_689_600u64),
+    );
+    client.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &(1_000_000_000i128),
+        &symbol_short!("USDC"),
+        &500u32,
+        &(2_592_000u64),
+    );
+    // Note: offer NOT accepted — invoice stays Pending
+    client.repay_invoice(&invoice_id, &offer_id, &originator, &1);
+}
+
+#[test]
+fn test_set_and_get_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_rate(&admin, &RiskTier::A, &500u32);
+    client.set_rate(&admin, &RiskTier::B, &800u32);
+    client.set_rate(&admin, &RiskTier::C, &1200u32);
+
+    assert_eq!(client.get_rate(&RiskTier::A), 500);
+    assert_eq!(client.get_rate(&RiskTier::B), 800);
+    assert_eq!(client.get_rate(&RiskTier::C), 1200);
+}
+
+#[test]
+#[should_panic(expected = "rate_bps must be between 0 and 10000")]
+fn test_set_rate_out_of_range_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_rate(&admin, &RiskTier::A, &10_001u32);
+}
+
+#[test]
+#[should_panic(expected = "Only admin can set rates")]
+fn test_set_rate_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_rate(&not_admin, &RiskTier::A, &500u32);
+}
+
+#[test]
+#[should_panic(expected = "Rate not set for this tier")]
+fn test_get_unset_rate_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.get_rate(&RiskTier::A);
+}
+
+#[test]
+fn test_transfer_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.transfer_admin(&admin, &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+
+    // New admin can now set rates; old admin can't.
+    client.set_rate(&new_admin, &RiskTier::A, &500u32);
+}
+
+#[test]
+#[should_panic(expected = "Only the current admin can transfer admin rights")]
+fn test_transfer_admin_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.transfer_admin(&not_admin, &new_admin);
+}
+
+// ── Validation tests ────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "amount must be greater than zero")]
+fn test_register_invoice_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v1"),
+        &originator,
+        &0i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "due_date must be in the future")]
+fn test_register_invoice_past_due_date() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(5_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v2"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &1_000_000u64, // in the past relative to timestamp 5_000_000
+    );
+}
+
+#[test]
+#[should_panic(expected = "offer amount must be greater than zero")]
+fn test_create_offer_zero_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v3"),
+        &originator,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_v1"),
+        &symbol_short!("inv_v3"),
+        &lender,
+        &0i128, // zero amount — should panic
+        &symbol_short!("USDC"),
+        &500u32,
+        &86_400u64,
+    );
+}
+
+// ── Query helper tests ───────────────────────────────────────────────────
+
+#[test]
+fn test_get_invoices_by_status_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let result = client.get_invoices_by_status(&InvoiceStatus::Pending);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn test_get_invoices_by_status_matching() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("q_inv_a"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.register_invoice(
+        &symbol_short!("q_inv_b"),
+        &originator,
+        &2_000i128,
+        &symbol_short!("XLM"),
+        &4_000_000u64,
+    );
+
+    let pending = client.get_invoices_by_status(&InvoiceStatus::Pending);
+    assert_eq!(pending.len(), 2);
+
+    let financed = client.get_invoices_by_status(&InvoiceStatus::Financed);
+    assert_eq!(financed.len(), 0);
+}
+
+// ── create_offer bounds tests ────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "interest_rate must be at most 10000 bps")]
+fn test_create_offer_interest_rate_too_high_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v4"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_v2"),
+        &symbol_short!("inv_v4"),
+        &lender,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &10_001u32, // over 100%
+        &86_400u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "duration must be at least 1 day (86400 seconds)")]
+fn test_create_offer_short_duration_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v5"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_v3"),
+        &symbol_short!("inv_v5"),
+        &lender,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &500u32,
+        &3_600u64, // 1 hour — below MIN_OFFER_DURATION_SECS, should panic
+    );
+}
+
+#[test]
+#[should_panic(expected = "lender cannot finance their own invoice")]
+fn test_create_offer_self_dealing_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_v6"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_v4"),
+        &symbol_short!("inv_v6"),
+        &originator, // lender == originator — should panic
+        &1_000i128,
+        &symbol_short!("USDC"),
+        &500u32,
+        &86_400u64,
+    );
+}
+
+#[test]
+fn test_cancel_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_c1"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    let cancelled = client.cancel_invoice(&symbol_short!("inv_c1"), &originator);
+    assert_eq!(cancelled.status, InvoiceStatus::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Only Pending invoices can be cancelled")]
+fn test_cancel_non_pending_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 2_000i128);
+    client.initialize(&originator, &token_id); // use originator as admin for simplicity
+
+    client.register_invoice(
+        &symbol_short!("inv_c2"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_c2"),
+        &symbol_short!("inv_c2"),
+        &lender,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &500u32,
+        &86_400u64,
+    );
+    client.accept_offer(&symbol_short!("off_c2"), &originator);
+    // Invoice is now Financed — cancel should panic
+    client.cancel_invoice(&symbol_short!("inv_c2"), &originator);
+}
+
+#[test]
+fn test_get_offers_by_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_g1"),
+        &originator,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_g1a"),
+        &symbol_short!("inv_g1"),
+        &lender,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &300u32,
+        &86_400u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_g1b"),
+        &symbol_short!("inv_g1"),
+        &lender,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &400u32,
+        &86_400u64,
+    );
+
+    let offers = client.get_offers_by_invoice(&symbol_short!("inv_g1"));
+    assert_eq!(offers.len(), 2);
+}
+
+#[test]
+fn test_get_offers_by_lender() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    client.register_invoice(
+        &symbol_short!("inv_l1"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_l1"),
+        &symbol_short!("inv_l1"),
+        &lender,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &200u32,
+        &86_400u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_l2"),
+        &symbol_short!("inv_l1"),
+        &other,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &300u32,
+        &86_400u64,
+    );
+
+    let lender_offers = client.get_offers_by_lender(&lender);
+    assert_eq!(lender_offers.len(), 1);
+    assert_eq!(lender_offers.get(0).unwrap().lender, lender);
+}
+
+#[test]
+fn test_calculate_total_due() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 10_000i128);
+    client.initialize(&originator, &token_id);
+
+    client.register_invoice(
+        &symbol_short!("inv_d1"),
+        &originator,
+        &10_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_d1"),
+        &symbol_short!("inv_d1"),
+        &lender,
+        &10_000i128,
+        &symbol_short!("XLM"),
+        &1_000u32, // 10%
+        &86_400u64,
+    );
+    client.accept_offer(&symbol_short!("off_d1"), &originator);
+
+    // principal=10000, yield=10000*1000/10000=1000, total_due=11000, repaid=0
+    let due = client.calculate_total_due(&symbol_short!("off_d1"));
+    assert_eq!(due, 11_000i128);
+}


### PR DESCRIPTION
## Summary

- `cancel_invoice(invoice_id, originator)` - originator cancels Pending invoice ? Cancelled
- `get_offers_by_invoice(invoice_id)` - returns all offers for a given invoice
- `get_offers_by_lender(lender)` - returns all offers submitted by a lender
- `calculate_total_due(offer_id)` - remaining principal + yield ? repaid; returns 0 if Repaid/Defaulted
- `MIN_OFFER_DURATION_SECS = 86400` constant; enforced in `create_offer`

Tests added for all new functions including panic paths.