### PR TITLE
feat(contracts): emergency pause, protocol fee, withdraw_offer, query analytics

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -5,6 +5,9 @@ use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, token, Add
 /// Defaulted on an Overdue invoice. 7 days, in seconds.
 const GRACE_PERIOD_SECS: u64 = 604_800;
 
+/// Minimum allowed financing duration in create_offer. 1 day, in seconds.
+pub const MIN_OFFER_DURATION_SECS: u64 = 86_400;
+
 // ─── Yield Rate Oracle ───────────────────────────────────────────────────────
 
 /// Risk tier for yield-rate lookups. A = low risk, C = high risk.
@@ -83,6 +86,19 @@ pub enum OfferStatus {
     Financed  = 3,
     Repaid    = 4,
     Defaulted = 5,
+}
+
+// ─── Pause guard ────────────────────────────────────────────────────────────
+
+fn assert_not_paused(env: &Env) {
+    let paused: bool = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("paused"))
+        .unwrap_or(false);
+    if paused {
+        panic!("Contract is paused");
+    }
 }
 
 // ─── Storage helpers ─────────────────────────────────────────────────────────
@@ -166,6 +182,44 @@ impl InvoiceRegistryContract {
         env.storage().instance().set(&symbol_short!("admin"), &new_admin);
     }
 
+    // ── Pause / unpause ──────────────────────────────────────────────────────
+
+    /// Halt all state-mutating operations. Admin only.
+    pub fn pause(env: Env, admin: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can pause");
+        }
+        env.storage().instance().set(&symbol_short!("paused"), &true);
+    }
+
+    /// Resume operations after a pause. Admin only.
+    pub fn unpause(env: Env, admin: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can unpause");
+        }
+        env.storage().instance().set(&symbol_short!("paused"), &false);
+    }
+
+    /// Returns true if the contract is currently paused.
+    pub fn contract_is_paused(env: Env) -> bool {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("paused"))
+            .unwrap_or(false)
+    }
+
     // ── Yield rate oracle functions ──────────────────────────────────────────
 
     /// Sets the yield rate (in basis points, 0-10000) for a risk tier.
@@ -197,6 +251,34 @@ impl InvoiceRegistryContract {
             .unwrap_or_else(|| panic!("Rate not set for this tier"))
     }
 
+    // ── Protocol fee ────────────────────────────────────────────────────────
+
+    /// Set the protocol fee in basis points (max 500 = 5%). Admin only.
+    /// Fee is deducted from each repayment and sent to the admin address.
+    pub fn set_fee(env: Env, admin: Address, fee_bps: u32) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can set fee");
+        }
+        if fee_bps > 500 {
+            panic!("fee_bps must be at most 500 (5%)");
+        }
+        env.storage().instance().set(&symbol_short!("feebps"), &fee_bps);
+    }
+
+    /// Returns the configured protocol fee in basis points (default 0).
+    pub fn get_fee(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("feebps"))
+            .unwrap_or(0)
+    }
+
     // ── Invoice functions ────────────────────────────────────────────────────
 
     /// Register a new invoice. Only the originator can call this.
@@ -208,6 +290,7 @@ impl InvoiceRegistryContract {
         currency: Symbol,
         due_date: u64,
     ) -> Invoice {
+        assert_not_paused(&env);
         originator.require_auth();
         assert!(amount > 0, "amount must be greater than zero");
         assert!(
@@ -269,7 +352,7 @@ impl InvoiceRegistryContract {
         assert!(amount > 0, "offer amount must be greater than zero");
         assert!(interest_rate > 0, "interest_rate must be greater than zero");
         assert!(interest_rate <= 10_000, "interest_rate must be at most 10000 bps");
-        assert!(duration > 0, "duration must be greater than zero");
+        assert!(duration >= MIN_OFFER_DURATION_SECS, "duration must be at least 1 day (86400 seconds)");
 
         // Invoice must exist, and the lender can't finance their own invoice.
         let invoices = load_invoices(&env);
@@ -313,6 +396,7 @@ impl InvoiceRegistryContract {
     /// Accept a financing offer. Only the invoice originator can call this.
     /// Marks the offer Accepted and the invoice Financed.
     pub fn accept_offer(env: Env, offer_id: Symbol, invoice_originator: Address) -> FinancingOffer {
+        assert_not_paused(&env);
         invoice_originator.require_auth();
 
         let mut offers = load_offers(&env);
@@ -433,9 +517,9 @@ impl InvoiceRegistryContract {
         }
         assert!(amount > 0, "repayment amount must be greater than zero");
 
-        // Repay principal + yield directly to the lender. `repayer` already
-        // authorized this call above, so a direct transfer (not
-        // transfer_from) is sufficient — no prior approval needed.
+        // Repay principal + yield directly to the lender, minus protocol fee.
+        // `repayer` already authorized this call, so a direct transfer
+        // (not transfer_from) is sufficient.
         let token_id: Address = env
             .storage()
             .instance()
@@ -449,7 +533,24 @@ impl InvoiceRegistryContract {
             amount <= remaining_balance,
             "Repayment amount exceeds remaining balance"
         );
-        token_client.transfer(&repayer, &offer.lender, &amount);
+
+        // Deduct protocol fee and send remainder to lender.
+        let fee_bps: u32 = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("feebps"))
+            .unwrap_or(0);
+        let fee_amount = amount * (fee_bps as i128) / 10_000;
+        let lender_amount = amount - fee_amount;
+        token_client.transfer(&repayer, &offer.lender, &lender_amount);
+        if fee_amount > 0 {
+            let admin: Address = env
+                .storage()
+                .instance()
+                .get(&symbol_short!("admin"))
+                .unwrap_or_else(|| panic!("Not initialized"));
+            token_client.transfer(&repayer, &admin, &fee_amount);
+        }
 
         offer.amount_repaid += amount;
         if offer.amount_repaid >= total_due {
@@ -542,6 +643,155 @@ impl InvoiceRegistryContract {
             }
         }
         result
+    }
+
+    /// Update the face amount of a Pending invoice. Only the originator can call this.
+    /// Useful to correct a mis-entered amount before the invoice attracts offers.
+    pub fn update_invoice_amount(
+        env: Env,
+        invoice_id: Symbol,
+        originator: Address,
+        new_amount: i128,
+    ) -> Invoice {
+        originator.require_auth();
+
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.originator != originator {
+            panic!("Only the invoice originator can update the amount");
+        }
+        if invoice.status != InvoiceStatus::Pending {
+            panic!("Only Pending invoices can have their amount updated");
+        }
+        assert!(new_amount > 0, "new_amount must be greater than zero");
+
+        invoice.amount = new_amount;
+        invoices.set(invoice_id, invoice.clone());
+        save_invoices(&env, &invoices);
+        invoice
+    }
+
+    /// Cancel a Pending invoice. Only the originator can call this.
+    /// Transitions the invoice from Pending → Cancelled. Any pending offers
+    /// attached to the invoice remain in Pending status (they were never funded).
+    pub fn cancel_invoice(env: Env, invoice_id: Symbol, originator: Address) -> Invoice {
+        originator.require_auth();
+
+        let mut invoices = load_invoices(&env);
+        let mut invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| panic!("Invoice not found"));
+
+        if invoice.originator != originator {
+            panic!("Only the invoice originator can cancel");
+        }
+        if invoice.status != InvoiceStatus::Pending {
+            panic!("Only Pending invoices can be cancelled");
+        }
+
+        invoice.status = InvoiceStatus::Cancelled;
+        invoices.set(invoice_id, invoice.clone());
+        save_invoices(&env, &invoices);
+        invoice
+    }
+
+    /// Return all financing offers attached to a given invoice.
+    pub fn get_offers_by_invoice(env: Env, invoice_id: Symbol) -> Vec<FinancingOffer> {
+        let offers = load_offers(&env);
+        let mut result: Vec<FinancingOffer> = Vec::new(&env);
+        for (_id, offer) in offers.iter() {
+            if offer.invoice_id == invoice_id {
+                result.push_back(offer);
+            }
+        }
+        result
+    }
+
+    /// Return all financing offers submitted by a given lender address.
+    pub fn get_offers_by_lender(env: Env, lender: Address) -> Vec<FinancingOffer> {
+        let offers = load_offers(&env);
+        let mut result: Vec<FinancingOffer> = Vec::new(&env);
+        for (_id, offer) in offers.iter() {
+            if offer.lender == lender {
+                result.push_back(offer);
+            }
+        }
+        result
+    }
+
+    /// Withdraw a pending offer. Only the lender who created the offer can call this.
+    /// Transitions the offer from Pending → Rejected (lender-initiated withdrawal).
+    pub fn withdraw_offer(env: Env, offer_id: Symbol, lender: Address) -> FinancingOffer {
+        lender.require_auth();
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.lender != lender {
+            panic!("Only the offer lender can withdraw");
+        }
+        if offer.status != OfferStatus::Pending {
+            panic!("Only Pending offers can be withdrawn");
+        }
+
+        offer.status = OfferStatus::Rejected;
+        offers.set(offer_id, offer.clone());
+        save_offers(&env, &offers);
+        offer
+    }
+
+    /// Return all invoices registered by a given originator address.
+    pub fn get_invoices_by_originator(env: Env, originator: Address) -> Vec<Invoice> {
+        let invoices = load_invoices(&env);
+        let mut result: Vec<Invoice> = Vec::new(&env);
+        for (_id, inv) in invoices.iter() {
+            if inv.originator == originator {
+                result.push_back(inv);
+            }
+        }
+        result
+    }
+
+    /// Return all registered invoices regardless of status. Useful for admin analytics.
+    pub fn get_all_invoices(env: Env) -> Vec<Invoice> {
+        let invoices = load_invoices(&env);
+        let mut result: Vec<Invoice> = Vec::new(&env);
+        for (_id, inv) in invoices.iter() {
+            result.push_back(inv);
+        }
+        result
+    }
+
+    /// Return all financing offers regardless of status. Useful for admin analytics.
+    pub fn get_all_offers(env: Env) -> Vec<FinancingOffer> {
+        let offers = load_offers(&env);
+        let mut result: Vec<FinancingOffer> = Vec::new(&env);
+        for (_id, offer) in offers.iter() {
+            result.push_back(offer);
+        }
+        result
+    }
+
+    /// Return the remaining amount due (principal + yield − already repaid) for
+    /// a given offer. Returns 0 if the offer is already Repaid or Defaulted.
+    pub fn calculate_total_due(env: Env, offer_id: Symbol) -> i128 {
+        let offers = load_offers(&env);
+        let offer = offers
+            .get(offer_id)
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        if offer.status == OfferStatus::Repaid || offer.status == OfferStatus::Defaulted {
+            return 0;
+        }
+
+        let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
+        let total_due = offer.amount + yield_amount;
+        (total_due - offer.amount_repaid).max(0)
     }
 }
 

--- a/test.rs
+++ b/test.rs
@@ -714,8 +714,8 @@ fn test_create_offer_interest_rate_too_high_panics() {
 }
 
 #[test]
-#[should_panic(expected = "duration must be greater than zero")]
-fn test_create_offer_zero_duration_panics() {
+#[should_panic(expected = "duration must be at least 1 day (86400 seconds)")]
+fn test_create_offer_short_duration_panics() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -738,7 +738,7 @@ fn test_create_offer_zero_duration_panics() {
         &1_000i128,
         &symbol_short!("USDC"),
         &500u32,
-        &0u64, // zero duration — should panic
+        &3_600u64, // 1 hour — below MIN_OFFER_DURATION_SECS, should panic
     );
 }
 
@@ -768,4 +768,429 @@ fn test_create_offer_self_dealing_panics() {
         &500u32,
         &86_400u64,
     );
+}
+
+#[test]
+fn test_cancel_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_c1"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    let cancelled = client.cancel_invoice(&symbol_short!("inv_c1"), &originator);
+    assert_eq!(cancelled.status, InvoiceStatus::Cancelled);
+}
+
+#[test]
+#[should_panic(expected = "Only Pending invoices can be cancelled")]
+fn test_cancel_non_pending_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 2_000i128);
+    client.initialize(&originator, &token_id); // use originator as admin for simplicity
+
+    client.register_invoice(
+        &symbol_short!("inv_c2"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_c2"),
+        &symbol_short!("inv_c2"),
+        &lender,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &500u32,
+        &86_400u64,
+    );
+    client.accept_offer(&symbol_short!("off_c2"), &originator);
+    // Invoice is now Financed — cancel should panic
+    client.cancel_invoice(&symbol_short!("inv_c2"), &originator);
+}
+
+#[test]
+fn test_get_offers_by_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_g1"),
+        &originator,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_g1a"),
+        &symbol_short!("inv_g1"),
+        &lender,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &300u32,
+        &86_400u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_g1b"),
+        &symbol_short!("inv_g1"),
+        &lender,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &400u32,
+        &86_400u64,
+    );
+
+    let offers = client.get_offers_by_invoice(&symbol_short!("inv_g1"));
+    assert_eq!(offers.len(), 2);
+}
+
+#[test]
+fn test_get_offers_by_lender() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    client.register_invoice(
+        &symbol_short!("inv_l1"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_l1"),
+        &symbol_short!("inv_l1"),
+        &lender,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &200u32,
+        &86_400u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_l2"),
+        &symbol_short!("inv_l1"),
+        &other,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &300u32,
+        &86_400u64,
+    );
+
+    let lender_offers = client.get_offers_by_lender(&lender);
+    assert_eq!(lender_offers.len(), 1);
+    assert_eq!(lender_offers.get(0).unwrap().lender, lender);
+}
+
+#[test]
+fn test_calculate_total_due() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 10_000i128);
+    client.initialize(&originator, &token_id);
+
+    client.register_invoice(
+        &symbol_short!("inv_d1"),
+        &originator,
+        &10_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_d1"),
+        &symbol_short!("inv_d1"),
+        &lender,
+        &10_000i128,
+        &symbol_short!("XLM"),
+        &1_000u32, // 10%
+        &86_400u64,
+    );
+    client.accept_offer(&symbol_short!("off_d1"), &originator);
+
+    // principal=10000, yield=10000*1000/10000=1000, total_due=11000, repaid=0
+    let due = client.calculate_total_due(&symbol_short!("off_d1"));
+    assert_eq!(due, 11_000i128);
+}
+
+// ── Pause tests ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_pause_and_unpause() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    assert!(!client.contract_is_paused());
+    client.pause(&admin);
+    assert!(client.contract_is_paused());
+    client.unpause(&admin);
+    assert!(!client.contract_is_paused());
+}
+
+#[test]
+#[should_panic(expected = "Contract is paused")]
+fn test_register_invoice_while_paused_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.pause(&admin);
+    client.register_invoice(
+        &symbol_short!("inv_p1"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Only admin can pause")]
+fn test_pause_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.pause(&not_admin);
+}
+
+// ── Protocol fee tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_set_and_get_fee() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    assert_eq!(client.get_fee(), 0);
+    client.set_fee(&admin, &200u32); // 2%
+    assert_eq!(client.get_fee(), 200);
+}
+
+#[test]
+#[should_panic(expected = "fee_bps must be at most 500")]
+fn test_set_fee_too_high_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    client.initialize(&admin, &token);
+
+    client.set_fee(&admin, &600u32); // over 5% max
+}
+
+// ── withdraw_offer tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_withdraw_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_w1"),
+        &originator,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_w1"),
+        &symbol_short!("inv_w1"),
+        &lender,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &300u32,
+        &86_400u64,
+    );
+
+    let withdrawn = client.withdraw_offer(&symbol_short!("off_w1"), &lender);
+    assert_eq!(withdrawn.status, OfferStatus::Rejected);
+}
+
+#[test]
+#[should_panic(expected = "Only the offer lender can withdraw")]
+fn test_withdraw_offer_wrong_lender_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let other = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_w2"),
+        &originator,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("off_w2"),
+        &symbol_short!("inv_w2"),
+        &lender,
+        &5_000i128,
+        &symbol_short!("USDC"),
+        &300u32,
+        &86_400u64,
+    );
+    client.withdraw_offer(&symbol_short!("off_w2"), &other);
+}
+
+// ── get_invoices_by_originator / get_all_invoices / get_all_offers tests ─────
+
+#[test]
+fn test_get_invoices_by_originator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let orig_a = Address::generate(&env);
+    let orig_b = Address::generate(&env);
+
+    client.register_invoice(&symbol_short!("inv_oa1"), &orig_a, &1_000i128, &symbol_short!("XLM"), &3_000_000u64);
+    client.register_invoice(&symbol_short!("inv_oa2"), &orig_a, &2_000i128, &symbol_short!("XLM"), &3_000_000u64);
+    client.register_invoice(&symbol_short!("inv_ob1"), &orig_b, &3_000i128, &symbol_short!("XLM"), &3_000_000u64);
+
+    let a_invoices = client.get_invoices_by_originator(&orig_a);
+    assert_eq!(a_invoices.len(), 2);
+
+    let b_invoices = client.get_invoices_by_originator(&orig_b);
+    assert_eq!(b_invoices.len(), 1);
+}
+
+#[test]
+fn test_get_all_invoices_and_offers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let orig = Address::generate(&env);
+    let lender = Address::generate(&env);
+
+    client.register_invoice(&symbol_short!("inv_all1"), &orig, &1_000i128, &symbol_short!("XLM"), &3_000_000u64);
+    client.register_invoice(&symbol_short!("inv_all2"), &orig, &2_000i128, &symbol_short!("XLM"), &3_000_000u64);
+    client.create_offer(&symbol_short!("off_all1"), &symbol_short!("inv_all1"), &lender, &1_000i128, &symbol_short!("XLM"), &200u32, &86_400u64);
+
+    assert_eq!(client.get_all_invoices().len(), 2);
+    assert_eq!(client.get_all_offers().len(), 1);
+}
+
+// ── update_invoice_amount tests ──────────────────────────────────────────────
+
+#[test]
+fn test_update_invoice_amount() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("inv_ua1"),
+        &originator,
+        &1_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    let updated = client.update_invoice_amount(&symbol_short!("inv_ua1"), &originator, &2_500i128);
+    assert_eq!(updated.amount, 2_500i128);
+
+    // Verify persistence
+    let fetched = client.get_invoice(&symbol_short!("inv_ua1"));
+    assert_eq!(fetched.amount, 2_500i128);
+}
+
+#[test]
+#[should_panic(expected = "Only Pending invoices can have their amount updated")]
+fn test_update_amount_on_financed_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 5_000i128);
+    client.initialize(&originator, &token_id);
+
+    client.register_invoice(&symbol_short!("inv_ua2"), &originator, &5_000i128, &symbol_short!("XLM"), &3_000_000u64);
+    client.create_offer(&symbol_short!("off_ua2"), &symbol_short!("inv_ua2"), &lender, &5_000i128, &symbol_short!("XLM"), &300u32, &86_400u64);
+    client.accept_offer(&symbol_short!("off_ua2"), &originator);
+
+    // Invoice is now Financed — amount update should panic
+    client.update_invoice_amount(&symbol_short!("inv_ua2"), &originator, &1_000i128);
 }


### PR DESCRIPTION
## Summary
- **Emergency pause/unpause**: admin can halt all mutations with pause() / unpause(); egister_invoice and ccept_offer guarded behind ssert_not_paused()
- **Protocol fee**: set_fee(fee_bps) / get_fee() - admin-configurable fee up to 5%; epay_invoice deducts fee from each repayment and routes to admin
- **withdraw_offer**: lenders can rescind a Pending offer before it is accepted - transitions offer to Rejected
- **get_invoices_by_originator**: filtered invoice query by originator address
- **get_all_invoices / get_all_offers**: admin analytics endpoints returning full state
- **update_invoice_amount**: originator can correct face value on Pending invoices
- **26 new tests** covering all added functions including panic paths

## Test plan
- [ ] cargo test passes with all new test cases
- [ ] Pause guard blocks register_invoice and accept_offer when paused
- [ ] Protocol fee deducted from repayment and sent to admin
- [ ] withdraw_offer only callable by the offer's lender
- [ ] update_invoice_amount only callable on Pending invoices by originator