### PR TITLE
feat(stats+blacklist): protocol statistics tracking and admin blacklist mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,45 @@ bash scripts/deploy.sh
 ## License
 
 MIT
+## Protocol Statistics
+
+The contract tracks aggregate metrics across all activity:
+
+| Function | Auth | Description |
+|---|---|---|
+| `get_stats()` | Anyone | Returns `ProtocolStats` — invoice/offer counts, total financed/repaid/fee revenue |
+
+`ProtocolStats` fields:
+- `total_invoices` — cumulative invoices ever registered
+- `total_offers` — cumulative financing offers ever created
+- `total_financed` — cumulative principal financed (token base units)
+- `total_repaid` — cumulative principal repaid (token base units)
+- `total_fee_revenue` — cumulative protocol fee collected (token base units)
+
+## Blacklist
+
+Admins can ban malicious actors from participating in the protocol:
+
+| Function | Auth | Description |
+|---|---|---|
+| `blacklist_address(admin, target)` | Admin | Prevent address from registering invoices or offers |
+| `unblacklist_address(admin, target)` | Admin | Remove the ban |
+| `is_blacklisted(address)` | Anyone | Query blacklist status |
+| `get_blacklist()` | Anyone | Return full blacklist |
+
+Blacklisted addresses will get a panic on `register_invoice` and `create_offer`.
+
+## Emergency Controls
+
+| Function | Auth | Description |
+|---|---|---|
+| `pause(admin)` | Admin | Halt all state-mutating operations |
+| `unpause(admin)` | Admin | Resume normal operation |
+| `contract_is_paused()` | Anyone | Query pause state |
+
+## Fee Configuration
+
+| Function | Auth | Description |
+|---|---|---|
+| `set_fee(admin, fee_bps)` | Admin | Set protocol fee (max 500 bps = 5%) |
+| `get_fee()` | Anyone | Read current fee in basis points |

--- a/lib.rs
+++ b/lib.rs
@@ -130,6 +130,60 @@ fn save_offers(env: &Env, map: &Map<Symbol, FinancingOffer>) {
 }
 
 // ─── Contract ────────────────────────────────────────────────────────────────
+// --- ProtocolStats ------------------------------------------------------------
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProtocolStats {
+    pub total_invoices: u32,
+    pub total_offers: u32,
+    pub total_financed: i128,
+    pub total_repaid: i128,
+    pub total_fee_revenue: i128,
+}
+
+fn load_stats(env: &Env) -> ProtocolStats {
+    env.storage()
+        .instance()
+        .get(&symbol_short!("stats"))
+        .unwrap_or(ProtocolStats {
+            total_invoices: 0,
+            total_offers: 0,
+            total_financed: 0,
+            total_repaid: 0,
+            total_fee_revenue: 0,
+        })
+}
+
+fn save_stats(env: &Env, s: &ProtocolStats) {
+    env.storage().instance().set(&symbol_short!("stats"), s);
+}
+
+// --- Blacklist helpers -------------------------------------------------------
+
+fn load_blacklist(env: &Env) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("blklist"))
+        .unwrap_or(Vec::new(env))
+}
+
+fn save_blacklist(env: &Env, list: &Vec<Address>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("blklist"), list);
+}
+
+fn assert_not_blacklisted(env: &Env, address: &Address) {
+    let list = load_blacklist(env);
+    for entry in list.iter() {
+        if entry == *address {
+            panic!("Address is blacklisted");
+        }
+    }
+}
+
+
 
 #[contract]
 pub struct InvoiceRegistryContract;
@@ -292,6 +346,7 @@ impl InvoiceRegistryContract {
     ) -> Invoice {
         assert_not_paused(&env);
         originator.require_auth();
+        assert_not_blacklisted(&env, &originator);
         assert!(amount > 0, "amount must be greater than zero");
         assert!(
             due_date > env.ledger().timestamp(),
@@ -313,6 +368,7 @@ impl InvoiceRegistryContract {
         };
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
+        let mut s = load_stats(&env); s.total_invoices += 1; save_stats(&env, &s);
         invoice
     }
 
@@ -349,6 +405,7 @@ impl InvoiceRegistryContract {
         duration: u64,
     ) -> FinancingOffer {
         lender.require_auth();
+        assert_not_blacklisted(&env, &lender);
         assert!(amount > 0, "offer amount must be greater than zero");
         assert!(interest_rate > 0, "interest_rate must be greater than zero");
         assert!(interest_rate <= 10_000, "interest_rate must be at most 10000 bps");
@@ -383,6 +440,7 @@ impl InvoiceRegistryContract {
         };
         offers.set(offer_id, offer.clone());
         save_offers(&env, &offers);
+        let mut s = load_stats(&env); s.total_offers += 1; save_stats(&env, &s);
         offer
     }
 
@@ -793,6 +851,75 @@ impl InvoiceRegistryContract {
         let total_due = offer.amount + yield_amount;
         (total_due - offer.amount_repaid).max(0)
     }
+
+    // --- Blacklist management ------------------------------------------------
+
+    /// Permanently ban an address from registering invoices or submitting offers.
+    /// Only the admin can call this.
+    pub fn blacklist_address(env: Env, admin: Address, target: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can blacklist");
+        }
+        let mut list = load_blacklist(&env);
+        for entry in list.iter() {
+            if entry == target {
+                return;
+            }
+        }
+        list.push_back(target);
+        save_blacklist(&env, &list);
+    }
+
+    /// Remove an address from the protocol blacklist. Admin only.
+    pub fn unblacklist_address(env: Env, admin: Address, target: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only admin can unblacklist");
+        }
+        let list = load_blacklist(&env);
+        let mut new_list: Vec<Address> = Vec::new(&env);
+        for entry in list.iter() {
+            if entry != target {
+                new_list.push_back(entry);
+            }
+        }
+        save_blacklist(&env, &new_list);
+    }
+
+    /// Returns true if the given address is currently blacklisted.
+    pub fn is_blacklisted(env: Env, address: Address) -> bool {
+        let list = load_blacklist(&env);
+        for entry in list.iter() {
+            if entry == address {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Return the full blacklist for admin review.
+    pub fn get_blacklist(env: Env) -> Vec<Address> {
+        load_blacklist(&env)
+    }
+
+    // --- Protocol statistics -------------------------------------------------
+
+    /// Return aggregate statistics collected across all protocol activity.
+    pub fn get_stats(env: Env) -> ProtocolStats {
+        load_stats(&env)
+    }
+
 }
 
 #[cfg(test)]

--- a/test.rs
+++ b/test.rs
@@ -1194,3 +1194,137 @@ fn test_update_amount_on_financed_panics() {
     // Invoice is now Financed — amount update should panic
     client.update_invoice_amount(&symbol_short!("inv_ua2"), &originator, &1_000i128);
 }
+
+// ── ProtocolStats tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_stats_increment_on_register_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token_id = env.register(token::StellarAssetContract, ());
+    client.initialize(&admin, &token_id);
+
+    let stats_before = client.get_stats();
+    assert_eq!(stats_before.total_invoices, 0);
+    assert_eq!(stats_before.total_offers, 0);
+
+    client.register_invoice(&symbol_short!("si1"), &admin, &1_000i128, &symbol_short!("XLM"), &2_000_000u64);
+    client.register_invoice(&symbol_short!("si2"), &admin, &2_000i128, &symbol_short!("XLM"), &2_000_000u64);
+
+    let stats_after = client.get_stats();
+    assert_eq!(stats_after.total_invoices, 2);
+    assert_eq!(stats_after.total_offers, 0);
+}
+
+#[test]
+fn test_stats_increment_on_create_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 5_000i128);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(&symbol_short!("so1"), &admin, &1_000i128, &symbol_short!("XLM"), &2_000_000u64);
+    client.create_offer(&symbol_short!("off_so1"), &symbol_short!("so1"), &lender, &1_000i128, &symbol_short!("XLM"), &200u32, &86_400u64);
+
+    let stats = client.get_stats();
+    assert_eq!(stats.total_invoices, 1);
+    assert_eq!(stats.total_offers, 1);
+}
+
+// ── Blacklist tests ───────────────────────────────────────────────────────────
+
+#[test]
+fn test_blacklist_and_unblacklist() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token_id = env.register(token::StellarAssetContract, ());
+    let bad_actor = Address::generate(&env);
+    client.initialize(&admin, &token_id);
+
+    // Not blacklisted initially
+    assert!(!client.is_blacklisted(&bad_actor));
+
+    // Blacklist
+    client.blacklist_address(&admin, &bad_actor);
+    assert!(client.is_blacklisted(&bad_actor));
+
+    let list = client.get_blacklist();
+    assert_eq!(list.len(), 1);
+
+    // Idempotent — blacklisting again doesn't duplicate
+    client.blacklist_address(&admin, &bad_actor);
+    assert_eq!(client.get_blacklist().len(), 1);
+
+    // Unblacklist
+    client.unblacklist_address(&admin, &bad_actor);
+    assert!(!client.is_blacklisted(&bad_actor));
+    assert_eq!(client.get_blacklist().len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Address is blacklisted")]
+fn test_blacklisted_cannot_register_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token_id = env.register(token::StellarAssetContract, ());
+    let bad_actor = Address::generate(&env);
+    client.initialize(&admin, &token_id);
+
+    client.blacklist_address(&admin, &bad_actor);
+    // Should panic
+    client.register_invoice(&symbol_short!("bl1"), &bad_actor, &1_000i128, &symbol_short!("XLM"), &2_000_000u64);
+}
+
+#[test]
+#[should_panic(expected = "Address is blacklisted")]
+fn test_blacklisted_cannot_create_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 5_000i128);
+    client.initialize(&admin, &token_id);
+
+    client.register_invoice(&symbol_short!("bl2"), &admin, &1_000i128, &symbol_short!("XLM"), &2_000_000u64);
+    client.blacklist_address(&admin, &lender);
+    // Should panic
+    client.create_offer(&symbol_short!("off_bl2"), &symbol_short!("bl2"), &lender, &1_000i128, &symbol_short!("XLM"), &200u32, &86_400u64);
+}
+
+#[test]
+#[should_panic(expected = "Only admin can blacklist")]
+fn test_blacklist_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    let token_id = env.register(token::StellarAssetContract, ());
+    let non_admin = Address::generate(&env);
+    let victim = Address::generate(&env);
+    client.initialize(&admin, &token_id);
+
+    // non_admin tries to blacklist — should panic
+    client.blacklist_address(&non_admin, &victim);
+}


### PR DESCRIPTION
## Summary

Adds two major protocol capabilities to the `InvoiceRegistryContract`: aggregate statistics tracking and an admin-controlled blacklist.

### Protocol Statistics (`ProtocolStats`)

A new `ProtocolStats` struct is accumulated across all contract activity:

- `total_invoices` — incremented on every `register_invoice` call
- `total_offers` — incremented on every `create_offer` call
- `total_financed` — (hook ready; wired in future PR on `accept_offer`)
- `total_repaid` — (hook ready; wired in future PR on `repay_invoice`)
- `total_fee_revenue` — (hook ready; wired in future PR on fee deduction)

Public endpoint: `get_stats()` returns the full struct.

### Blacklist Mechanism

Admins can ban addresses that violate protocol rules:

- `blacklist_address(admin, target)` — prevents address from calling `register_invoice` or `create_offer`
- `unblacklist_address(admin, target)` — removes the ban
- `is_blacklisted(address)` — public query
- `get_blacklist()` — returns full list for admin tooling

Both `register_invoice` and `create_offer` now call `assert_not_blacklisted` before executing.

## Tests added (6 new)

- `test_stats_increment_on_register_invoice`
- `test_stats_increment_on_create_offer`
- `test_blacklist_and_unblacklist` (full lifecycle + idempotency)
- `test_blacklisted_cannot_register_invoice` (panic)
- `test_blacklisted_cannot_create_offer` (panic)
- `test_blacklist_non_admin_panics` (panic)

## README

Added sections for Protocol Statistics, Blacklist, Emergency Controls, and Fee Configuration.