### PR TITLE
fix(ci): block scalar for test command - colon-space broke YAML parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Run tests
         # .cargo/config.toml defaults to wasm32v1-none; override to the host
         # so tests actually compile and execute on the runner.
-        run: cargo test --target "$(rustc -vV | sed -n 's/^host: //p')" -- --nocapture
+        run: |
+          cargo test --target "$(rustc -vV | sed -n 's/^host: //p')" -- --nocapture
 
   build:
     name: Build WASM


### PR DESCRIPTION
Follow-up to #30. The `Run tests` step used a plain scalar containing `sed -n 's/^host: //p'` - the colon-space sequence makes the YAML invalid, so GitHub silently skipped the entire CI workflow (that's why only Clippy ran on the last commits of #30).

This moves the command into a `run: |` block scalar, which parses correctly. One-line change.

## Test plan

- [ ] CI workflow (Test + Build WASM) actually triggers on this PR
- [ ] Tests pass