### PR TITLE
feat: protocol events v0.3.0 - emit on every state transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 All notable changes to InvoFi Contracts are documented here.
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.3.0] – 2026-07-13
+
+### Added
+- **Protocol events** — every state-mutating function now publishes a Soroban
+  contract event, enabling off-chain indexers, activity feeds, and real-time
+  UI updates without polling:
+
+  | Event topic | Emitted by | Data payload |
+  |---|---|---|
+  | `inv_reg`  | `register_invoice` | `(originator, amount, due_date)` |
+  | `off_new`  | `create_offer` | `(invoice_id, lender, amount, interest_rate)` |
+  | `off_acc`  | `accept_offer` | `(invoice_id, lender, amount)` |
+  | `off_rej`  | `reject_offer` | `invoice_id` |
+  | `off_wdr`  | `withdraw_offer` | `lender` |
+  | `off_def`  | `reclaim_invoice` | `(invoice_id, lender)` |
+  | `inv_rep`  | `repay_invoice` | `(offer_id, amount, fully_repaid)` |
+  | `inv_ovd`  | `mark_overdue` | `due_date` |
+  | `inv_cxl`  | `cancel_invoice` | `originator` |
+  | `inv_dsp`  | `raise_dispute` | `originator` |
+  | `inv_rsl`  | `resolve_dispute` | `new_status` |
+
+  Every event carries the subject's `Symbol` id as its second topic, so
+  indexers can filter by invoice or offer without decoding payloads.
+- Event emission tests covering register, offer create/accept, repayment,
+  and cancellation flows
+
+### Changed
+- `version()` returns `soroban_sdk::String` (was `&'static str`, which is not
+  a valid Soroban return type)
+
 ## [0.2.0] – 2026-07-12
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "invofi-invoice-registry"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 description = "Soroban contract for InvoFi invoice registry"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ register_invoice()  →  create_offer()  →  accept_offer()
 
 ---
 
+## Protocol Events
+
+Every state-mutating function publishes a Soroban contract event (v0.3.0+).
+Topics are `(event_name, subject_id)` — indexers can filter by invoice or
+offer id without decoding payloads.
+
+| Event | Emitted by | Data payload |
+|---|---|---|
+| `inv_reg` | `register_invoice` | `(originator, amount, due_date)` |
+| `off_new` | `create_offer` | `(invoice_id, lender, amount, interest_rate)` |
+| `off_acc` | `accept_offer` | `(invoice_id, lender, amount)` |
+| `off_rej` | `reject_offer` | `invoice_id` |
+| `off_wdr` | `withdraw_offer` | `lender` |
+| `off_def` | `reclaim_invoice` | `(invoice_id, lender)` |
+| `inv_rep` | `repay_invoice` | `(offer_id, amount, fully_repaid)` |
+| `inv_ovd` | `mark_overdue` | `due_date` |
+| `inv_cxl` | `cancel_invoice` | `originator` |
+| `inv_dsp` | `raise_dispute` | `originator` |
+| `inv_rsl` | `resolve_dispute` | `new_status` |
+
+---
+
 ## Constants
 
 | Constant | Value | Description |

--- a/lib.rs
+++ b/lib.rs
@@ -404,6 +404,10 @@ impl InvoiceRegistryContract {
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
         let mut s = load_stats(&env); s.total_invoices += 1; save_stats(&env, &s);
+        env.events().publish(
+            (symbol_short!("inv_reg"), invoice.id.clone()),
+            (invoice.originator.clone(), amount, due_date),
+        );
         invoice
     }
 
@@ -484,6 +488,10 @@ impl InvoiceRegistryContract {
         lstats.offers_pending += 1;
         save_lender_stats(&env, &offer.lender, &lstats);
 
+        env.events().publish(
+            (symbol_short!("off_new"), offer.id.clone()),
+            (offer.invoice_id.clone(), offer.lender.clone(), amount, interest_rate),
+        );
         offer
     }
 
@@ -549,6 +557,10 @@ impl InvoiceRegistryContract {
         invoices.set(offer.invoice_id.clone(), invoice);
         save_invoices(&env, &invoices);
 
+        env.events().publish(
+            (symbol_short!("off_acc"), offer.id.clone()),
+            (offer.invoice_id.clone(), offer.lender.clone(), offer.amount),
+        );
         offer
     }
 
@@ -578,6 +590,10 @@ impl InvoiceRegistryContract {
         offers.set(offer_id, offer.clone());
         save_offers(&env, &offers);
 
+        env.events().publish(
+            (symbol_short!("off_rej"), offer.id.clone()),
+            offer.invoice_id.clone(),
+        );
         offer
     }
 
@@ -654,7 +670,8 @@ impl InvoiceRegistryContract {
         }
 
         offer.amount_repaid += amount;
-        if offer.amount_repaid >= total_due {
+        let fully_repaid = offer.amount_repaid >= total_due;
+        if fully_repaid {
             invoice.status = InvoiceStatus::Repaid;
             offer.status = OfferStatus::Repaid;
         } else {
@@ -665,9 +682,13 @@ impl InvoiceRegistryContract {
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
 
-        offers.set(offer_id, offer);
+        offers.set(offer_id.clone(), offer);
         save_offers(&env, &offers);
 
+        env.events().publish(
+            (symbol_short!("inv_rep"), invoice.id.clone()),
+            (offer_id, amount, fully_repaid),
+        );
         invoice
     }
 
@@ -711,6 +732,10 @@ impl InvoiceRegistryContract {
         offers.set(offer_id, offer.clone());
         save_offers(&env, &offers);
 
+        env.events().publish(
+            (symbol_short!("off_def"), offer.id.clone()),
+            (offer.invoice_id.clone(), offer.lender.clone()),
+        );
         offer
     }
 
@@ -731,6 +756,10 @@ impl InvoiceRegistryContract {
         invoice.status = InvoiceStatus::Overdue;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
+        env.events().publish(
+            (symbol_short!("inv_ovd"), invoice.id.clone()),
+            invoice.due_date,
+        );
         invoice
     }
 
@@ -796,6 +825,10 @@ impl InvoiceRegistryContract {
         invoice.status = InvoiceStatus::Cancelled;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
+        env.events().publish(
+            (symbol_short!("inv_cxl"), invoice.id.clone()),
+            invoice.originator.clone(),
+        );
         invoice
     }
 
@@ -843,6 +876,10 @@ impl InvoiceRegistryContract {
         offer.status = OfferStatus::Rejected;
         offers.set(offer_id, offer.clone());
         save_offers(&env, &offers);
+        env.events().publish(
+            (symbol_short!("off_wdr"), offer.id.clone()),
+            offer.lender.clone(),
+        );
         offer
     }
 
@@ -1077,6 +1114,10 @@ impl InvoiceRegistryContract {
         invoice.status = InvoiceStatus::Disputed;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
+        env.events().publish(
+            (symbol_short!("inv_dsp"), invoice.id.clone()),
+            invoice.originator.clone(),
+        );
         invoice
     }
 
@@ -1114,6 +1155,10 @@ impl InvoiceRegistryContract {
         invoice.status = target_status;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
+        env.events().publish(
+            (symbol_short!("inv_rsl"), invoice.id.clone()),
+            invoice.status.clone(),
+        );
         invoice
     }
 

--- a/test.rs
+++ b/test.rs
@@ -4,7 +4,7 @@ extern crate std;
 use super::{InvoiceRegistryContract, InvoiceStatus, OfferStatus, RiskTier};
 use soroban_sdk::{
     symbol_short,
-    testutils::{Address as _, Ledger as _},
+    testutils::{Address as _, Events as _, Ledger as _},
     token, Address, Env,
 };
 
@@ -2043,4 +2043,133 @@ fn test_blacklisted_cannot_raise_dispute() {
     // Now the originator can dispute again (no longer blacklisted)
     let disputed = client.raise_dispute(&symbol_short!("inv1"), &originator);
     assert_eq!(disputed.status, super::InvoiceStatus::Disputed);
+}
+
+
+// ─── Protocol event tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_register_invoice_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("ev1"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &2_000_000u64,
+    );
+
+    let events = env.events().all();
+    assert!(!events.is_empty(), "register_invoice should emit an event");
+    let (emitter, _topics, _data) = events.last().unwrap();
+    assert_eq!(emitter, contract_id);
+}
+
+#[test]
+fn test_create_and_accept_offer_emit_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 500_000_000i128);
+    client.initialize(&originator, &token_id);
+
+    client.register_invoice(
+        &symbol_short!("ev2"),
+        &originator,
+        &1_000_000_000i128,
+        &symbol_short!("XLM"),
+        &2_000_000u64,
+    );
+
+    client.create_offer(
+        &symbol_short!("ev2_off"),
+        &symbol_short!("ev2"),
+        &lender,
+        &500_000_000i128,
+        &symbol_short!("XLM"),
+        &300u32,
+        &86_400u64,
+    );
+    let events = env.events().all();
+    assert!(!events.is_empty(), "create_offer should emit an event");
+
+    client.accept_offer(&symbol_short!("ev2_off"), &originator);
+    let events = env.events().all();
+    assert!(!events.is_empty(), "accept_offer should emit an event");
+    let (emitter, _topics, _data) = events.last().unwrap();
+    assert_eq!(emitter, contract_id);
+}
+
+#[test]
+fn test_repay_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let token_id = setup_token(&env, &contract_id, &lender, 500_000_000i128);
+    client.initialize(&originator, &token_id);
+
+    client.register_invoice(
+        &symbol_short!("ev3"),
+        &originator,
+        &1_000_000_000i128,
+        &symbol_short!("XLM"),
+        &2_000_000u64,
+    );
+    client.create_offer(
+        &symbol_short!("ev3_off"),
+        &symbol_short!("ev3"),
+        &lender,
+        &500_000_000i128,
+        &symbol_short!("XLM"),
+        &300u32,
+        &86_400u64,
+    );
+    client.accept_offer(&symbol_short!("ev3_off"), &originator);
+
+    // Partial repayment — originator holds the 500M principal from accept
+    client.repay_invoice(&symbol_short!("ev3"), &symbol_short!("ev3_off"), &originator, &100_000_000i128);
+    let events = env.events().all();
+    assert!(!events.is_empty(), "repay_invoice should emit an event");
+    let (emitter, _topics, _data) = events.last().unwrap();
+    assert_eq!(emitter, contract_id);
+}
+
+#[test]
+fn test_cancel_invoice_emits_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(InvoiceRegistryContract, ());
+    let client = super::InvoiceRegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("ev4"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &2_000_000u64,
+    );
+    client.cancel_invoice(&symbol_short!("ev4"), &originator);
+
+    let events = env.events().all();
+    assert!(!events.is_empty(), "cancel_invoice should emit an event");
+    let (emitter, _topics, _data) = events.last().unwrap();
+    assert_eq!(emitter, contract_id);
 }


### PR DESCRIPTION
## Summary

Every state-mutating contract function now publishes a Soroban contract event, giving off-chain indexers, activity feeds, and the frontend a way to track protocol activity in real time without polling contract state.

### Event schema

Topics are `(event_name, subject_id)` so indexers can filter by invoice or offer id without decoding payloads:

| Event | Emitted by | Data payload |
|---|---|---|
| `inv_reg` | register_invoice | (originator, amount, due_date) |
| `off_new` | create_offer | (invoice_id, lender, amount, interest_rate) |
| `off_acc` | accept_offer | (invoice_id, lender, amount) |
| `off_rej` | reject_offer | invoice_id |
| `off_wdr` | withdraw_offer | lender |
| `off_def` | reclaim_invoice | (invoice_id, lender) |
| `inv_rep` | repay_invoice | (offer_id, amount, fully_repaid) |
| `inv_ovd` | mark_overdue | due_date |
| `inv_cxl` | cancel_invoice | originator |
| `inv_dsp` | raise_dispute | originator |
| `inv_rsl` | resolve_dispute | new_status |

### Also in this PR

- 4 new event-emission tests (75 total)
- CHANGELOG 0.3.0 entry with the full event table
- README Protocol Events section
- Version bump 0.2.0 ? 0.3.0

## Test plan

- [ ] CI Test job passes (75 tests)
- [ ] Build WASM succeeds
- [ ] Clippy clean