### PR TITLE
fix(insurance): add on-chain Defaulted status verification before payout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,6 +768,7 @@ name = "invofi-insurance"
 version = "0.7.0"
 dependencies = [
  "invofi-common",
+ "invofi-registry",
  "soroban-sdk",
 ]
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -277,8 +277,10 @@ pub trait FinancingInterface {
 pub trait InsuranceInterface {
     /// Pay `amount` to `beneficiary` from the insurance pool, capped at the
     /// pool's available balance. Only callable by the configured payout
-    /// caller (the repayment contract). Returns the amount actually paid.
-    fn pay_out(env: Env, beneficiary: Address, amount: i128) -> i128;
+    /// caller (the repayment contract). Verifies on-chain that `invoice_id`
+    /// is in `Defaulted` status before moving any funds. Returns the amount
+    /// actually paid.
+    fn pay_out(env: Env, invoice_id: Symbol, beneficiary: Address, amount: i128) -> i128;
 }
 
 // ─── Reputation Cross-Contract Interface ─────────────────────────────────────

--- a/insurance/Cargo.toml
+++ b/insurance/Cargo.toml
@@ -2,7 +2,7 @@
 name = "invofi-insurance"
 version = "0.7.0"
 edition = "2021"
-description = "Soroban insurance pool contract for InvoFi — stake/unstake with flat pool accounting"
+description = "Soroban insurance pool contract for InvoFi — stake/unstake with flat pool accounting + payout-on-default safety"
 license = "MIT"
 
 [lib]

--- a/insurance/Cargo.toml
+++ b/insurance/Cargo.toml
@@ -15,6 +15,7 @@ invofi-common = { path = "../common" }
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
 invofi-common = { path = "../common", features = ["testutils"] }
+invofi-registry = { path = "../registry", features = ["testutils"] }
 
 [features]
 testutils = ["soroban-sdk/testutils", "invofi-common/testutils"]

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -10,9 +10,9 @@
 //! can never exceed actual pool funds). Yield-rate calculation stays out of
 //! scope.
 
-use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
-use invofi_common::assert_not_paused;
+use invofi_common::{assert_not_paused, InvoiceStatus, RegistryClient};
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -142,6 +142,29 @@ impl InsuranceContract {
         env.storage().instance().get(&symbol_short!("paycall"))
     }
 
+    /// Configure the registry contract used to verify invoice status in
+    /// `pay_out`. Admin only. Payouts on Defaulted invoices are rejected
+    /// with a clear error if the registry is not configured or if the
+    /// invoice is not in the Defaulted state (fail-closed).
+    pub fn set_registry(env: Env, admin: Address, registry: Address) {
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only the current admin can set the registry");
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("registry"), &registry);
+    }
+
+    pub fn get_registry(env: Env) -> Option<Address> {
+        env.storage().instance().get(&symbol_short!("registry"))
+    }
+
     // ── Pause / unpause (Task 4A circuit breaker) ───────────────────────────
 
     pub fn pause(env: Env, admin: Address) {
@@ -251,15 +274,24 @@ impl InsuranceContract {
     /// available balance. Only callable by the configured payout caller (the
     /// repayment contract), authorized via implicit contract-invoker auth.
     ///
+    /// **Safety invariants (both checked on-chain before any funds move):**
+    ///
+    /// 1. The invoice identified by `invoice_id` must be in `Defaulted` status
+    ///    in the registry — `Overdue` alone is not sufficient. This is verified
+    ///    via a cross-contract read of the registry, so the check cannot be
+    ///    spoofed by the caller.
+    /// 2. The payout is capped at the pool's available balance. When the pool
+    ///    has insufficient funds the contract pays whatever is left and returns
+    ///    that amount; it never moves more than `pool_total`. A subsequent call
+    ///    against an empty pool returns 0 immediately.
+    ///
     /// Every staker's claim is reduced pro-rata by the payout ratio, and the
     /// pool total drops by exactly the amount paid — so get_stake sums always
-    /// equal get_pool_total and unstake can never overdraw the pool. The
-    /// payout itself is capped at the pool total (pool-depleted case pays
-    /// everything available, then returns 0 on subsequent claims).
+    /// equal get_pool_total and unstake can never overdraw the pool.
     ///
     /// Returns the amount actually paid (may be less than `amount` when the
     /// pool is short).
-    pub fn pay_out(env: Env, beneficiary: Address, amount: i128) -> i128 {
+    pub fn pay_out(env: Env, invoice_id: Symbol, beneficiary: Address, amount: i128) -> i128 {
         assert_not_paused(&env);
         let payout_caller: Address = env
             .storage()
@@ -269,6 +301,25 @@ impl InsuranceContract {
         payout_caller.require_auth();
         assert!(amount > 0, "payout amount must be greater than zero");
 
+        // ── Safety check 1: invoice must be Defaulted, not merely Overdue ──
+        // Cross-contract read from the registry provides on-chain proof that
+        // the credit-loss event has been finalized before any staked funds move.
+        let registry_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("registry"))
+            .unwrap_or_else(|| panic!("Registry not configured"));
+        let registry_client = RegistryClient::new(&env, &registry_addr);
+        let invoice = registry_client.get_invoice(&invoice_id);
+        if invoice.status != InvoiceStatus::Defaulted {
+            panic!("Invoice is not Defaulted");
+        }
+
+        // ── Safety check 2: payout ≤ available pool balance ───────────────
+        // `amount.min(pool_total)` ensures we never transfer more than the
+        // pool holds. An empty pool (pool_total == 0) returns 0 immediately —
+        // the `off_def` protocol event on the caller side carries payout=0 so
+        // indexers can track the shortfall.
         let pool_total = load_pool_total(&env);
         let payout = amount.min(pool_total);
         if payout <= 0 {

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -9,6 +9,8 @@
 //! staker's claim pro-rata so accounting stays exactly consistent (unstake
 //! can never exceed actual pool funds). Yield-rate calculation stays out of
 //! scope.
+//!
+//! Task 10 security: pay_out verifies invoice.status == Defaulted on-chain.
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -561,3 +561,7 @@ fn test_payout_without_registry_panics() {
 
     client.pay_out(&invoice_id, &beneficiary, &500_000);
 }
+
+// NOTE: If test_pause_blocks_all_insurance_state_changes exists after merge,
+// update its pay_out call to:
+// client.pay_out(&soroban_sdk::symbol_short!("inv_x"), &beneficiary, &1_000i128);

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -1,3 +1,4 @@
+
 #![cfg(test)]
 extern crate std;
 

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -2,7 +2,7 @@
 extern crate std;
 
 use super::InsuranceContract;
-use soroban_sdk::{testutils::Address as _, token, Address, Env};
+use soroban_sdk::{testutils::{Address as _, Ledger}, token, Address, Env};
 
 /// Deploy the insurance contract + a staking token, and initialize.
 fn setup<'a>(
@@ -238,6 +238,60 @@ fn test_set_staking_token_admin_only() {
 }
 
 // ─── Payout tests (Task 10) ─────────────────────────────────────────────────
+//
+// Every payout test wires a real registry contract and forces the invoice into
+// Defaulted status before calling pay_out. This proves the on-chain Defaulted
+// check cannot be bypassed — pay_out cross-reads the registry itself.
+
+use invofi_registry::RegistryContract;
+
+/// Register a registry contract and return its address and a minimal
+/// Defaulted invoice id ready for use in payout tests.
+///
+/// The registry is wired to the insurance client via `set_registry`.
+/// The invoice is driven to `Defaulted` via `repayment_marks_defaulted`,
+/// which requires the registry's repayment contract to be configured — we
+/// set it to an arbitrary address and use `mock_all_auths` to authorise it.
+fn setup_with_defaulted_invoice<'a>(
+    env: &'a Env,
+    admin: &Address,
+    payout_caller: &Address,
+    client: &super::InsuranceContractClient<'a>,
+) -> (invofi_registry::RegistryContractClient<'a>, soroban_sdk::Symbol) {
+    use soroban_sdk::symbol_short;
+    // Deploy a registry, wire it to the insurance contract.
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(env, &registry_id);
+    client.set_registry(admin, &registry_id);
+
+    // Use the payout_caller as the authorised repayment contract on the
+    // registry — mock_all_auths covers its auth so we can drive status.
+    reg.set_repayment_contract(admin, payout_caller);
+
+    // Register a minimal invoice and drive it to Defaulted.
+    let originator = Address::generate(env);
+    let invoice_id = symbol_short!("inv_dfl");
+    // due_date in the past so mark_invoice_overdue passes the timestamp guard.
+    let due_date: u64 = 1_000;
+    reg.register_invoice(
+        &invoice_id,
+        &originator,
+        &1_000_000_000i128,
+        &symbol_short!("USDC"),
+        &due_date,
+    );
+    // Pending -> Financed (registry needs a financing contract configured).
+    reg.set_financing_contract(admin, payout_caller);
+    reg.financing_marks_invoice_financed(&invoice_id);
+    // Advance ledger past due_date so mark_invoice_overdue passes.
+    env.ledger().set_timestamp(due_date + 1);
+    // Financed -> Overdue (public, timestamp-gated).
+    reg.mark_invoice_overdue(&invoice_id);
+    // Overdue -> Defaulted via authorized repayment transition.
+    reg.repayment_marks_defaulted(&invoice_id);
+
+    (reg, invoice_id)
+}
 
 #[test]
 fn test_payout_after_default_covers_claim() {
@@ -254,12 +308,14 @@ fn test_payout_after_default_covers_claim() {
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     client.stake(&staker, &1_000_000);
 
-    // Configure the repayment contract as payout caller.
+    // Configure payout caller and registry with a Defaulted invoice.
     client.set_payout_caller(&admin, &payout_caller);
     assert_eq!(client.get_payout_caller(), Some(payout_caller.clone()));
+    let (_reg, invoice_id) =
+        setup_with_defaulted_invoice(&env, &admin, &payout_caller, &client);
 
-    // Default triggers a 400k payout claim — fully covered.
-    let paid = client.pay_out(&beneficiary, &400_000);
+    // Default triggers a 400k payout claim — fully covered by the pool.
+    let paid = client.pay_out(&invoice_id, &beneficiary, &400_000);
     assert_eq!(paid, 400_000);
 
     // Pool accounting: pool 600k, staker claim 600k, lender funded.
@@ -284,10 +340,13 @@ fn test_payout_pool_depleted_pays_whats_left() {
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 100_000);
     client.stake(&staker, &100_000);
     client.set_payout_caller(&admin, &payout_caller);
+    let (_reg, invoice_id) =
+        setup_with_defaulted_invoice(&env, &admin, &payout_caller, &client);
 
     // Claim (1M) far exceeds the pool (100k) — lender gets everything left.
-    let paid = client.pay_out(&beneficiary, &1_000_000);
-    assert_eq!(paid, 100_000);
+    // payout is capped at available reserves; it never exceeds pool_total.
+    let paid = client.pay_out(&invoice_id, &beneficiary, &1_000_000);
+    assert_eq!(paid, 100_000); // capped at available balance, not reverted
 
     assert_eq!(client.get_pool_total(), 0);
     assert_eq!(client.get_stake(&staker), 0);
@@ -296,8 +355,8 @@ fn test_payout_pool_depleted_pays_whats_left() {
     let token_client = token::TokenClient::new(&env, &token_id);
     assert_eq!(token_client.balance(&beneficiary), 100_000);
 
-    // Subsequent claim against an empty pool pays nothing.
-    assert_eq!(client.pay_out(&beneficiary, &1_000_000), 0);
+    // Subsequent call against an already-empty pool returns 0.
+    assert_eq!(client.pay_out(&invoice_id, &beneficiary, &1_000_000), 0);
 }
 
 #[test]
@@ -318,35 +377,133 @@ fn test_payout_pro_rata_multiple_stakers_exact() {
     client.stake(&staker_a, &1_000_000);
     client.stake(&staker_b, &3_000_000);
     client.set_payout_caller(&admin, &payout_caller);
+    let (_reg, invoice_id) =
+        setup_with_defaulted_invoice(&env, &admin, &payout_caller, &client);
 
     // 2M payout -> each staker loses exactly their pro-rata share.
-    let paid = client.pay_out(&beneficiary, &2_000_000);
+    let paid = client.pay_out(&invoice_id, &beneficiary, &2_000_000);
     assert_eq!(paid, 2_000_000);
 
     assert_eq!(client.get_pool_total(), 2_000_000);
-    assert_eq!(client.get_stake(&staker_a), 500_000); // 25% of the loss
-    assert_eq!(client.get_stake(&staker_b), 1_500_000); // 75% of the loss
+    assert_eq!(client.get_stake(&staker_a), 500_000); // 25 % of the loss
+    assert_eq!(client.get_stake(&staker_b), 1_500_000); // 75 % of the loss
     assert_eq!(client.get_contract_token_balance(), 2_000_000);
     let token_client = token::TokenClient::new(&env, &token_id);
     assert_eq!(token_client.balance(&beneficiary), 2_000_000);
 }
 
+// ── Rejection: invoice not Defaulted ─────────────────────────────────────────
+
+/// pay_out must reject when the invoice is in any status other than Defaulted.
+/// We test the most dangerous case: the invoice is Overdue (one step before
+/// Defaulted) — the payout must still revert with a clear error.
+#[test]
+#[should_panic(expected = "Invoice is not Defaulted")]
+fn test_payout_rejected_when_invoice_overdue_not_defaulted() {
+    use invofi_common::InvoiceStatus;
+    use soroban_sdk::symbol_short;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let payout_caller = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    // Deploy registry, wire it — but only advance invoice to Overdue, NOT Defaulted.
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
+    client.set_registry(&admin, &registry_id);
+    reg.set_repayment_contract(&admin, &payout_caller);
+    reg.set_financing_contract(&admin, &payout_caller);
+
+    let originator = Address::generate(&env);
+    let invoice_id = symbol_short!("inv_ovd");
+    reg.register_invoice(
+        &invoice_id,
+        &originator,
+        &1_000_000_000i128,
+        &symbol_short!("USDC"),
+        &1_000u64,
+    );
+    reg.financing_marks_invoice_financed(&invoice_id);
+    // Advance past due_date so mark_invoice_overdue passes.
+    env.ledger().set_timestamp(1_001);
+    // Stopped here — invoice is Overdue, not Defaulted.
+    reg.mark_invoice_overdue(&invoice_id);
+
+    let invoice = reg.get_invoice(&invoice_id);
+    assert_eq!(invoice.status, InvoiceStatus::Overdue);
+
+    // Must panic: "Invoice is not Defaulted"
+    client.pay_out(&invoice_id, &beneficiary, &400_000);
+}
+
+/// pay_out must reject when the invoice is Pending (completely wrong state).
+#[test]
+#[should_panic(expected = "Invoice is not Defaulted")]
+fn test_payout_rejected_when_invoice_pending() {
+    use soroban_sdk::symbol_short;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let payout_caller = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
+    client.set_registry(&admin, &registry_id);
+
+    let originator = Address::generate(&env);
+    let invoice_id = symbol_short!("inv_pnd");
+    reg.register_invoice(
+        &invoice_id,
+        &originator,
+        &1_000_000_000i128,
+        &symbol_short!("USDC"),
+        &1_000_000u64,
+    );
+    // Invoice is still Pending — must panic.
+    client.pay_out(&invoice_id, &beneficiary, &400_000);
+}
+
+// ── Existing guard tests (updated signatures) ─────────────────────────────────
+
 #[test]
 #[should_panic(expected = "No payout caller configured")]
 fn test_payout_without_caller_panics() {
+    use soroban_sdk::symbol_short;
+
     let env = Env::default();
     env.mock_all_auths();
 
     let admin = Address::generate(&env);
     let beneficiary = Address::generate(&env);
     let (_, _, client) = setup(&env, &admin);
+    let invoice_id = symbol_short!("inv_x");
 
-    client.pay_out(&beneficiary, &1_000);
+    client.pay_out(&invoice_id, &beneficiary, &1_000);
 }
 
 #[test]
 #[should_panic(expected = "payout amount must be greater than zero")]
 fn test_payout_zero_amount_panics() {
+    use soroban_sdk::symbol_short;
+
     let env = Env::default();
     env.mock_all_auths();
 
@@ -355,13 +512,16 @@ fn test_payout_zero_amount_panics() {
     let beneficiary = Address::generate(&env);
     let (_, _, client) = setup(&env, &admin);
     client.set_payout_caller(&admin, &payout_caller);
+    let invoice_id = symbol_short!("inv_x");
 
-    client.pay_out(&beneficiary, &0);
+    client.pay_out(&invoice_id, &beneficiary, &0);
 }
 
 #[test]
 #[should_panic(expected = "Contract is paused")]
 fn test_paused_blocks_payout() {
+    use soroban_sdk::symbol_short;
+
     let env = Env::default();
     env.mock_all_auths();
 
@@ -371,6 +531,32 @@ fn test_paused_blocks_payout() {
     let (_, _, client) = setup(&env, &admin);
     client.set_payout_caller(&admin, &payout_caller);
     client.pause(&admin);
+    let invoice_id = symbol_short!("inv_x");
 
-    client.pay_out(&beneficiary, &1_000);
+    client.pay_out(&invoice_id, &beneficiary, &1_000);
+}
+
+// ── Registry not configured guard ─────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Registry not configured")]
+fn test_payout_without_registry_panics() {
+    use soroban_sdk::symbol_short;
+
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let payout_caller = Address::generate(&env);
+    let beneficiary = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+    // Payout caller configured, but NO registry wired — must fail-closed.
+    client.set_payout_caller(&admin, &payout_caller);
+    let invoice_id = symbol_short!("inv_x");
+
+    client.pay_out(&invoice_id, &beneficiary, &500_000);
 }

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -347,7 +347,7 @@ impl RepaymentContract {
         let insurance_opt: Option<Address> = env.storage().instance().get(&symbol_short!("insadd"));
         if let Some(insurance_addr) = insurance_opt {
             let insurance_client = InsuranceClient::new(&env, &insurance_addr);
-            payout = insurance_client.pay_out(&offer.lender, &remaining_due);
+            payout = insurance_client.pay_out(&invoice_id, &offer.lender, &remaining_due);
         }
 
         // Task 11: reputation hook — record the originator's default.

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -844,6 +844,9 @@ fn test_reclaim_triggers_defaulted_payout_and_reputation() {
     );
     ins.stake(&staker, &300_000_000);
     ins.set_payout_caller(&admin, &repayment_id);
+    // Wire the registry into the insurance contract so pay_out can verify
+    // the invoice is Defaulted on-chain before moving staked funds.
+    ins.set_registry(&admin, &registry_id);
 
     // Reputation contract, recorder = repayment.
     let reputation_id = env.register(ReputationContract, (admin.clone(),));


### PR DESCRIPTION
Task 10 security fix: Ensure payout-on-default moves staked funds only after on-chain verification that the invoice is in Defaulted status.

Changes:
- insurance: Add set_registry/get_registry admin functions
- insurance: Update pay_out to accept invoice_id parameter
- insurance: Add cross-contract invoice.status == Defaulted check
- insurance: Panic with clear error if registry not configured (fail-closed)
- insurance: Panic with clear error if invoice not Defaulted
- common: Update InsuranceInterface trait signature with invoice_id
- repayment: Update reclaim_invoice to pass invoice_id to pay_out
- tests: Wire registry in all payout tests with Defaulted invoices
- tests: Add rejection tests for non-Defaulted invoice states
- tests: Add registry-not-configured guard test

Safety guarantees:
✓ Payout ≤ available pool balance (capped at pool_total) ✓ Invoice status verified as Defaulted on-chain before funds move ✓ Cannot be bypassed - check happens inside pay_out before transfer ✓ Fail-closed: rejects if registry missing or invoice not Defaulted

Tests cover:
✓ Full payout when pool sufficient
✓ Capped/partial payout when pool depleted
✓ Rejection when invoice Overdue (not Defaulted)
✓ Rejection when invoice Pending
✓ Rejection when registry not configured

Closes #109 (partial - payout safety only, staked vs reserved accounting separate)

## Summary
<!-- What does this PR change in the contract? -->

## Type of change
- [ ] Bug fix
- [ ] New contract function
- [ ] Data type change
- [ ] Test addition
- [ ] Chore / docs

## Checklist
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes (CI)
- [ ] Soroban Scout security analysis passes (CI)
- [ ] `stellar contract build` succeeds
- [ ] New functions have corresponding tests
- [ ] Breaking changes are documented

> ⚠️ **CI checks are maintainer-managed.** Do not add, remove, rename, or
> reconfigure any CI check or workflow (including Soroban Scout detector
> exclusions in `docs/scout-detectors.md`) in this PR. CI is part of the
> audit story and changes to it go through the maintainers only. If you
> believe a check needs changing, open an issue instead.

## Related issues
Closes #150 
