### PR TITLE
feat(repayment): fixed installment repayment schedules (#133)

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -117,6 +117,57 @@ pub struct LenderStats {
     pub offers_repaid: u32,
 }
 
+/// Installment frequency for a fixed repayment schedule.
+///
+/// `Daily` = 86 400 s between installments, `Weekly` = 604 800 s,
+/// `Monthly` = 2 592 000 s (30-day approximation).
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ScheduleFrequency {
+    Daily = 0,
+    Weekly = 1,
+    Monthly = 2,
+}
+
+impl ScheduleFrequency {
+    /// Returns the period in seconds that corresponds to this frequency.
+    pub fn period_secs(self) -> u64 {
+        match self {
+            ScheduleFrequency::Daily => 86_400,
+            ScheduleFrequency::Weekly => 604_800,
+            ScheduleFrequency::Monthly => 2_592_000,
+        }
+    }
+}
+
+/// An advisory fixed-installment repayment schedule attached to a financing offer.
+///
+/// Each installment covers an equal slice of principal plus interest on the
+/// remaining principal (flat-rate model):
+///
+///   installment_principal = offer.amount / count
+///   installment_yield     = installment_principal * offer.interest_rate / 10_000
+///   installment_amount    = installment_principal + installment_yield
+///
+/// The schedule is **advisory with enforcement**: ad-hoc partial repayments
+/// remain permitted via `repay_invoice` and will never corrupt schedule state
+/// — `amount_repaid` on the offer is always the source of truth for how much
+/// has actually been cleared.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RepaymentSchedule {
+    pub offer_id: Symbol,
+    /// Number of equal installments.
+    pub count: u32,
+    /// Seconds between installments.
+    pub frequency: ScheduleFrequency,
+    /// Amount due per installment (principal slice + yield on that slice).
+    pub installment_amount: i128,
+    /// Unix timestamp of the first installment due date.
+    pub first_due: u64,
+}
+
 // ─── Currency Registry ───────────────────────────────────────────────────────
 
 /// Load the currency registry (an empty map if none has been configured).
@@ -293,6 +344,24 @@ pub trait FinancingInterface {
 
     /// Read the protocol fee in basis points.
     fn get_fee_bps(env: Env) -> u32;
+
+    /// Create a fixed installment repayment schedule for an offer.
+    /// `first_due` is the Unix timestamp of the first installment.
+    fn schedule_repayment(
+        env: Env,
+        offer_id: Symbol,
+        frequency: ScheduleFrequency,
+        count: u32,
+        first_due: u64,
+    ) -> RepaymentSchedule;
+
+    /// Read the repayment schedule attached to an offer, if any.
+    fn get_schedule(env: Env, offer_id: Symbol) -> Option<RepaymentSchedule>;
+
+    /// Return the installment number (1-based) that is currently due (its
+    /// due timestamp ≤ now) and has not yet been covered by `amount_repaid`.
+    /// Returns 0 when all installments are paid or no schedule exists.
+    fn get_installment_due(env: Env, offer_id: Symbol) -> u32;
 }
 
 // ─── Insurance Cross-Contract Interface ──────────────────────────────────────

--- a/docs/adr/0006-repayment-schedules.md
+++ b/docs/adr/0006-repayment-schedules.md
@@ -1,0 +1,118 @@
+# ADR-0006 — Fixed Installment Repayment Schedules
+
+**Status:** Accepted  
+**Issue:** [#133](https://github.com/Stellar-VaultLink/invofi-contracts/issues/133)  
+**Date:** 2026-08-17
+
+---
+
+## Context
+
+Repayment in the InvoFi protocol has always been open-ended: the originator
+can repay any amount at any time until the financed invoice is fully cleared.
+This works well for ad-hoc settlements but businesses that prefer weekly or
+monthly fixed payments — and lenders who want predictable cash-flow
+forecasting — have no structured path.
+
+## Decision
+
+Introduce an **advisory fixed-installment repayment schedule** that can be
+attached to any live financing offer. The schedule lives in the financing
+contract (alongside the offer it describes) and is surfaced via two new
+entry-points and one keeper-friendly read helper.
+
+### Data model
+
+```
+RepaymentSchedule {
+    offer_id:           Symbol,
+    count:              u32,           // number of installments
+    frequency:          ScheduleFrequency, // Daily | Weekly | Monthly
+    installment_amount: i128,          // per-installment amount (computed)
+    first_due:          u64,           // Unix timestamp of first due date
+}
+
+ScheduleFrequency { Daily = 86_400 s, Weekly = 604_800 s, Monthly = 2_592_000 s }
+```
+
+### Installment math — flat-rate equal-principal model
+
+```
+installment_principal = floor(offer.amount / count)
+installment_yield     = installment_principal × offer.interest_rate / 10_000
+installment_amount    = installment_principal + installment_yield
+```
+
+Floor division means up to `count − 1` stroops of principal may be left
+uncovered by the schedule. This rounding remainder is acceptable because the
+schedule is advisory — `offer.amount_repaid` is always the authoritative
+source of truth for actual repayment progress.
+
+### New API surface
+
+| Function | Contract | Auth |
+|---|---|---|
+| `schedule_repayment(offer_id, caller, frequency, count, first_due)` | financing | Lender OR originator |
+| `get_schedule(offer_id)` | financing | Anyone |
+| `get_installment_due(offer_id)` | financing + repayment (proxy) | Anyone |
+
+`get_installment_due` returns the **1-based index of the first unpaid elapsed
+installment**, or 0 when nothing is due (schedule absent, all paid, or
+`now < first_due`). Callers use this as a keeper signal:
+- `0` → nothing to do
+- `n > 0` → installment *n* is overdue; the originator should pay
+  `installment_amount` to clear it
+
+### Advisory-with-enforcement design
+
+Ad-hoc partial repayments via `repay_invoice` remain fully permitted and do
+not modify or invalidate the schedule. The schedule's only enforcement
+mechanism is the `get_installment_due` signal — UI, keepers, or integrations
+may surface it to the originator but the protocol never blocks a valid
+repayment because it is "off-schedule".
+
+This mirrors how traditional invoice financing works in practice: missing an
+agreed payment date is a relationship / credit-score event, not an automatic
+on-chain default (which is handled by the separate `reclaim_invoice` /
+`mark_overdue` flow that already exists).
+
+Penalty logic for missed installments is explicitly **out of scope** for this
+ADR and left as a future work item per the issue brief.
+
+## Alternatives considered
+
+### 1. Store the schedule in the repayment contract
+
+Rejected: the repayment contract is the executor; installment meta-data
+belongs with the offer it describes. Keeping it in financing also avoids a new
+cross-contract call from `get_installment_due`.
+
+### 2. Amortized (reducing-balance) schedules
+
+Rejected for this iteration. Equal-principal slices are simpler to implement,
+auditable in a single formula, and sufficient for the majority of short-term
+invoice financing durations (< 1 year). The `ScheduleFrequency` type and the
+`count`/`installment_amount` pair are forward-compatible with a future
+amortization model if needed.
+
+### 3. On-chain enforcement (block repay if off-schedule)
+
+Rejected. Strict enforcement would break backward compatibility, hurt
+businesses with variable cash flow, and put the risk of a protocol freeze
+(due to a missed cron job or network congestion) on the originator. Advisory
+enforcement keeps the feature safe and composable.
+
+## Consequences
+
+- **`common`**: two new `#[contracttype]` types (`ScheduleFrequency`,
+  `RepaymentSchedule`) and three new methods on `FinancingInterface`.
+- **`financing`**: a persistent `Map<Symbol, RepaymentSchedule>` keyed by
+  `offer_id`; three new public entry-points.
+- **`repayment`**: one new thin proxy `get_installment_due` that delegates to
+  financing — so CLI/keeper integrations that already hold the repayment
+  address need only one contract reference.
+- **Test coverage**: 13 new tests in `financing` + 2 new tests in `repayment`
+  covering all three acceptance criteria from issue #133.
+- **No migration required**: existing deployed offers without a schedule
+  continue to work identically (`get_installment_due` returns 0,
+  `get_schedule` returns `None`).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0003 | [Insurance payout on default](./0003-insurance-payout.md) | Accepted |
 | 0004 | [Reputation scoring](./0004-reputation.md) | Accepted |
 | 0005 | [Deployer-bound initialization (constructors)](./0005-deployer-bound-initialization.md) | Accepted |
+| 0006 | [Fixed installment repayment schedules](./0006-repayment-schedules.md) | Accepted |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -7,7 +7,8 @@ use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map
 
 use invofi_common::{
     assert_not_paused, resolve_token, FinancingOffer, Invoice, InvoiceStatus, LenderStats,
-    OfferStatus, ProtocolStats, RegistryClient, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    OfferStatus, ProtocolStats, RegistryClient, RepaymentSchedule, ScheduleFrequency,
+    MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -53,6 +54,21 @@ fn load_stats(env: &Env) -> ProtocolStats {
 
 fn save_stats(env: &Env, s: &ProtocolStats) {
     env.storage().instance().set(&symbol_short!("stats"), s);
+}
+
+// ─── Schedule Storage Helpers ─────────────────────────────────────────────────
+
+fn load_schedules(env: &Env) -> Map<Symbol, RepaymentSchedule> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("scheds"))
+        .unwrap_or(Map::new(env))
+}
+
+fn save_schedules(env: &Env, map: &Map<Symbol, RepaymentSchedule>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("scheds"), map);
 }
 
 fn assert_not_blacklisted(env: &Env, address: &Address) {
@@ -650,6 +666,159 @@ impl FinancingContract {
 
     pub fn get_offer_duration_limits(_env: Env) -> (u64, u64) {
         (MIN_OFFER_DURATION_SECS, MAX_OFFER_DURATION_SECS)
+    }
+
+    // ── Repayment schedules (issue #133) ─────────────────────────────────────
+
+    /// Attach a fixed installment repayment schedule to a financing offer.
+    ///
+    /// Can be called by the **lender** on a Pending offer (before acceptance)
+    /// or by the **originator** on a Financed/Accepted offer (after acceptance,
+    /// to formalise a payment plan). Both parties must provide their auth;
+    /// the contract checks that the caller is the lender or the invoice
+    /// originator.
+    ///
+    /// Installment math (flat-rate, equal principal slices):
+    ///
+    ///   installment_principal = offer.amount / count
+    ///   installment_yield     = installment_principal × interest_rate / 10_000
+    ///   installment_amount    = installment_principal + installment_yield
+    ///
+    /// `first_due` must be in the future. `count` must be ≥ 1 and ≤ 1 200
+    /// (100 years of daily installments — a hard cap that prevents overflow).
+    ///
+    /// An existing schedule is overwritten — either party can reschedule while
+    /// the offer is still active.
+    pub fn schedule_repayment(
+        env: Env,
+        offer_id: Symbol,
+        caller: Address,
+        frequency: ScheduleFrequency,
+        count: u32,
+        first_due: u64,
+    ) -> RepaymentSchedule {
+        assert_not_paused(&env);
+        caller.require_auth();
+
+        assert!(count >= 1, "count must be at least 1");
+        assert!(count <= 1_200, "count must be at most 1200 installments");
+        assert!(
+            first_due > env.ledger().timestamp(),
+            "first_due must be in the future"
+        );
+
+        let offers = load_offers(&env);
+        let offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| panic!("Offer not found"));
+
+        // Only allow scheduling on live (non-terminal) offers.
+        if offer.status == OfferStatus::Rejected
+            || offer.status == OfferStatus::Repaid
+            || offer.status == OfferStatus::Defaulted
+        {
+            panic!("Cannot schedule a terminal offer");
+        }
+
+        // The caller must be the lender or the invoice originator.
+        // Retrieve the originator via the registry cross-contract call.
+        let registry_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("registry"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let registry_client = RegistryClient::new(&env, &registry_addr);
+        let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
+
+        if caller != offer.lender && caller != invoice.originator {
+            panic!("Only the lender or the invoice originator can set a schedule");
+        }
+
+        // installment_principal = floor(amount / count)
+        // We use floor division; any leftover cent is borne by the last
+        // installment but the helper only reports whole installments — that
+        // is explicitly in-scope per the issue.
+        let installment_principal = offer.amount / (count as i128);
+        let installment_yield =
+            installment_principal * (offer.interest_rate as i128) / 10_000;
+        let installment_amount = installment_principal + installment_yield;
+
+        assert!(
+            installment_amount > 0,
+            "installment amount must be greater than zero"
+        );
+
+        let schedule = RepaymentSchedule {
+            offer_id: offer_id.clone(),
+            count,
+            frequency,
+            installment_amount,
+            first_due,
+        };
+
+        let mut schedules = load_schedules(&env);
+        schedules.set(offer_id, schedule.clone());
+        save_schedules(&env, &schedules);
+
+        schedule
+    }
+
+    /// Read the repayment schedule attached to an offer, if any.
+    pub fn get_schedule(env: Env, offer_id: Symbol) -> Option<RepaymentSchedule> {
+        load_schedules(&env).get(offer_id)
+    }
+
+    /// Return the 1-based index of the installment that is **currently due**
+    /// (its due timestamp ≤ `now`) and whose principal has not yet been
+    /// covered by `amount_repaid` on the offer.
+    ///
+    /// Returns `0` when:
+    /// - No schedule exists for this offer, or
+    /// - All installments have been paid, or
+    /// - No installment is due yet (`now` < `first_due`).
+    ///
+    /// This is the keeper/CLI-friendly read helper described in issue #133.
+    pub fn get_installment_due(env: Env, offer_id: Symbol) -> u32 {
+        let schedules = load_schedules(&env);
+        let schedule = match schedules.get(offer_id.clone()) {
+            Some(s) => s,
+            None => return 0,
+        };
+
+        let offers = load_offers(&env);
+        let offer = match offers.get(offer_id) {
+            Some(o) => o,
+            None => return 0,
+        };
+
+        // Terminal offer — nothing due.
+        if offer.status == OfferStatus::Repaid || offer.status == OfferStatus::Defaulted {
+            return 0;
+        }
+
+        let now = env.ledger().timestamp();
+        if now < schedule.first_due {
+            return 0;
+        }
+
+        let period = schedule.frequency.period_secs();
+        // How many installments have elapsed (1-based)?
+        let elapsed = ((now - schedule.first_due) / period + 1).min(schedule.count as u64) as u32;
+
+        // How many installments are already covered by amount_repaid?
+        let paid_count = if schedule.installment_amount == 0 {
+            schedule.count
+        } else {
+            (offer.amount_repaid / schedule.installment_amount) as u32
+        };
+
+        if paid_count >= elapsed {
+            // All elapsed installments already paid.
+            0
+        } else {
+            // The next unpaid installment that is already due.
+            paid_count + 1
+        }
     }
 }
 

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -1099,3 +1099,423 @@ fn test_accept_offer_without_position_token_still_works() {
     let token_client = token::TokenClient::new(&env, &token_id);
     assert_eq!(token_client.balance(&originator), amount);
 }
+
+// ─── Repayment schedule tests (issue #133) ──────────────────────────────────
+
+/// Helper: create a pending offer on a fresh invoice and return the offer id,
+/// invoice id, originator and lender addresses.
+fn setup_offer_for_schedule<'a>(
+    env: &'a Env,
+    admin: &Address,
+    token: &Address,
+) -> (
+    invofi_registry::RegistryContractClient<'a>,
+    super::FinancingContractClient<'a>,
+    Address, // originator
+    Address, // lender
+) {
+    let (reg, fin) = setup_contracts(env, admin, token);
+    let originator = Address::generate(env);
+    let lender = Address::generate(env);
+
+    reg.register_invoice(
+        &symbol_short!("inv_sc1"),
+        &originator,
+        &1_200_000_000i128, // 1.2 billion units (12 installments of 100M each)
+        &symbol_short!("USDC"),
+        &(env.ledger().timestamp() + 100_000_000u64),
+    );
+    fin.create_offer(
+        &symbol_short!("off_sc1"),
+        &symbol_short!("inv_sc1"),
+        &lender,
+        &1_200_000_000i128,
+        &symbol_short!("USDC"),
+        &500u32, // 5.00% per installment slice
+        &(31_536_000u64),
+    );
+
+    (reg, fin, originator, lender)
+}
+
+/// Acceptance criterion 1: schedule created and readable.
+#[test]
+fn test_schedule_created_and_readable() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    // No schedule yet
+    assert!(fin.get_schedule(&symbol_short!("off_sc1")).is_none());
+
+    let first_due = env.ledger().timestamp() + 604_800; // +1 week
+    let sched = fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &12u32,
+        &first_due,
+    );
+
+    assert_eq!(sched.count, 12);
+    assert_eq!(sched.frequency, invofi_common::ScheduleFrequency::Weekly);
+    assert_eq!(sched.first_due, first_due);
+
+    let fetched = fin.get_schedule(&symbol_short!("off_sc1"));
+    assert!(fetched.is_some());
+    assert_eq!(fetched.unwrap().count, 12);
+}
+
+/// Acceptance criterion 2: installment math matches the documented model.
+///
+/// offer.amount = 1 200 000 000, count = 12, interest_rate = 500 bps (5%)
+/// installment_principal = 1_200_000_000 / 12 = 100_000_000
+/// installment_yield     = 100_000_000 * 500 / 10_000 = 5_000_000
+/// installment_amount    = 105_000_000
+#[test]
+fn test_installment_math_matches_documented_model() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let first_due = env.ledger().timestamp() + 604_800;
+    let sched = fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &12u32,
+        &first_due,
+    );
+
+    // Documented model: principal_slice + yield_on_slice
+    let expected_principal_slice = 1_200_000_000i128 / 12;       // 100_000_000
+    let expected_yield = expected_principal_slice * 500 / 10_000;  // 5_000_000
+    let expected_installment = expected_principal_slice + expected_yield; // 105_000_000
+
+    assert_eq!(sched.installment_amount, expected_installment);
+}
+
+/// Acceptance criterion 3: off-schedule (ad-hoc) payment still permitted
+/// without corrupting state.
+#[test]
+fn test_off_schedule_repayment_does_not_corrupt_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let first_due = env.ledger().timestamp() + 604_800;
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &12u32,
+        &first_due,
+    );
+
+    // Register a fake repayment contract (auth is mocked for callbacks)
+    let repayment_id = env.register(
+        super::FinancingContract,
+        (
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+        ),
+    );
+    fin.set_repayment_contract(&admin, &repayment_id);
+
+    // Simulate an ad-hoc off-schedule partial repayment (42M — not a multiple
+    // of installment_amount = 105M). State should remain readable and correct.
+    fin.update_offer_amount_repaid(&symbol_short!("off_sc1"), &42_000_000i128);
+
+    let offer = fin.get_offer(&symbol_short!("off_sc1"));
+    assert_eq!(offer.amount_repaid, 42_000_000i128);
+
+    // Schedule is still intact — state not corrupted.
+    let sched = fin.get_schedule(&symbol_short!("off_sc1")).unwrap();
+    assert_eq!(sched.count, 12);
+    assert_eq!(sched.installment_amount, 105_000_000i128);
+}
+
+/// Lender can also create the schedule on a Pending offer.
+#[test]
+fn test_lender_can_schedule_on_pending_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, _originator, lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let first_due = env.ledger().timestamp() + 86_400;
+    let sched = fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &lender,
+        &invofi_common::ScheduleFrequency::Monthly,
+        &4u32,
+        &first_due,
+    );
+
+    assert_eq!(sched.count, 4);
+    assert_eq!(sched.frequency, invofi_common::ScheduleFrequency::Monthly);
+}
+
+/// get_installment_due returns 0 before the first_due timestamp.
+#[test]
+fn test_get_installment_due_returns_zero_before_first_due() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let first_due = env.ledger().timestamp() + 604_800; // 1 week in the future
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &4u32,
+        &first_due,
+    );
+
+    // Now is before first_due — nothing due yet.
+    assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 0);
+}
+
+/// get_installment_due returns 1 after the first_due timestamp.
+#[test]
+fn test_get_installment_due_returns_one_after_first_due() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let first_due = env.ledger().timestamp() + 604_800;
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &4u32,
+        &first_due,
+    );
+
+    // Advance time past first_due but before second installment.
+    env.ledger().set_timestamp(first_due + 1);
+    assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 1);
+}
+
+/// get_installment_due returns the first unpaid elapsed installment (1).
+/// Even when 2 periods have elapsed, if installment 1 is still unpaid,
+/// the helper returns 1 — the caller should pay installment 1 first.
+#[test]
+fn test_get_installment_due_advances_over_time() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let first_due = env.ledger().timestamp() + 604_800;
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &4u32,
+        &first_due,
+    );
+
+    // Advance past the second weekly period — 2 installments elapsed, 0 paid.
+    // The helper returns 1 (the first unpaid due installment).
+    env.ledger().set_timestamp(first_due + 604_800 + 1);
+    assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 1);
+}
+
+/// get_installment_due returns 0 when all installments are covered.
+#[test]
+fn test_get_installment_due_zero_when_all_paid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    // Schedule with 4 weekly installments.
+    // offer.amount = 1_200_000_000, count = 4, rate = 500 bps
+    // installment_principal = 1_200_000_000 / 4 = 300_000_000
+    // installment_yield     = 300_000_000 * 500 / 10_000 = 15_000_000
+    // installment_amount    = 315_000_000
+    // 4 installments fully paid = 4 × 315_000_000 = 1_260_000_000
+    let first_due = env.ledger().timestamp() + 604_800;
+    let sched = fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &4u32,
+        &first_due,
+    );
+    let full_paid = sched.installment_amount * 4;
+
+    // Register a fake repayment contract (auth is mocked)
+    let repayment_id = env.register(
+        super::FinancingContract,
+        (
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+        ),
+    );
+    fin.set_repayment_contract(&admin, &repayment_id);
+
+    // Simulate full coverage: 4 installments × installment_amount.
+    fin.update_offer_amount_repaid(&symbol_short!("off_sc1"), &full_paid);
+
+    // Advance past all 4 periods.
+    env.ledger().set_timestamp(first_due + 4 * 604_800);
+
+    // Nothing is due — all installments covered.
+    assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 0);
+}
+
+/// get_installment_due returns 0 when no schedule exists.
+#[test]
+fn test_get_installment_due_returns_zero_with_no_schedule() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, _originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    // No schedule set — must return 0.
+    assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 0);
+}
+
+/// schedule_repayment panics for a count of zero.
+#[test]
+#[should_panic(expected = "count must be at least 1")]
+fn test_schedule_count_zero_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &0u32,
+        &(env.ledger().timestamp() + 604_800),
+    );
+}
+
+/// schedule_repayment panics when first_due is in the past.
+#[test]
+#[should_panic(expected = "first_due must be in the future")]
+fn test_schedule_first_due_in_past_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &4u32,
+        &999_999u64, // before current timestamp
+    );
+}
+
+/// A third party (neither lender nor originator) cannot set a schedule.
+#[test]
+#[should_panic(expected = "Only the lender or the invoice originator can set a schedule")]
+fn test_schedule_unauthorized_caller_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, _originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    let intruder = Address::generate(&env);
+    fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &intruder,
+        &invofi_common::ScheduleFrequency::Daily,
+        &30u32,
+        &(env.ledger().timestamp() + 86_400),
+    );
+}
+
+/// Daily frequency: period_secs = 86_400.
+/// When 2 daily periods elapsed and 1 installment already paid,
+/// the helper returns 2 (the next unpaid due installment).
+#[test]
+fn test_daily_frequency_period() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (_reg, fin, originator, _lender) = setup_offer_for_schedule(&env, &admin, &token);
+
+    // count = 5 daily → installment_principal = 1_200_000_000 / 5 = 240_000_000
+    //                    installment_yield     = 240_000_000 * 500 / 10_000 = 12_000_000
+    //                    installment_amount    = 252_000_000
+    let first_due = env.ledger().timestamp() + 86_400;
+    let sched = fin.schedule_repayment(
+        &symbol_short!("off_sc1"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Daily,
+        &5u32,
+        &first_due,
+    );
+
+    // Register a fake repayment contract (auth is mocked)
+    let repayment_id = env.register(
+        super::FinancingContract,
+        (
+            Address::generate(&env),
+            Address::generate(&env),
+            Address::generate(&env),
+        ),
+    );
+    fin.set_repayment_contract(&admin, &repayment_id);
+
+    // Mark installment 1 as paid.
+    fin.update_offer_amount_repaid(&symbol_short!("off_sc1"), &sched.installment_amount);
+
+    // Advance past 2 daily periods — installment 1 paid, installment 2 is now due.
+    env.ledger().set_timestamp(first_due + 86_400 + 1);
+    assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 2);
+}

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -396,6 +396,22 @@ impl RepaymentContract {
     pub fn get_duration_limits(_env: Env) -> (u64, u64) {
         (MIN_OFFER_DURATION_SECS, MAX_OFFER_DURATION_SECS)
     }
+
+    // ── Schedule helpers (issue #133) ────────────────────────────────────────
+
+    /// Return the 1-based index of the installment that is currently due for
+    /// the given offer, or 0 if none.  Delegates to the financing contract's
+    /// `get_installment_due` so callers don't need to hold the financing
+    /// address directly.
+    pub fn get_installment_due(env: Env, offer_id: Symbol) -> u32 {
+        let financing_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("financing"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let financing_client = FinancingClient::new(&env, &financing_addr);
+        financing_client.get_installment_due(&offer_id)
+    }
 }
 
 #[cfg(test)]

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -1027,3 +1027,130 @@ fn test_full_repay_records_reputation_success() {
     assert_eq!(rec.repayments, 1);
     assert_eq!(rec.defaults, 0);
 }
+
+// ─── Repayment schedule helper tests (issue #133) ──────────────────────────
+
+/// The repayment contract's get_installment_due proxy delegates correctly
+/// to the financing contract.
+#[test]
+fn test_repayment_get_installment_due_proxy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let amount: i128 = 1_200_000_000;
+
+    let token_id = create_token(&env);
+    let (reg, fin, rep) = setup_contracts(&env, &admin, &token_id);
+
+    reg.register_invoice(
+        &symbol_short!("inv_pr"),
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(env.ledger().timestamp() + 100_000_000u64),
+    );
+    fin.create_offer(
+        &symbol_short!("off_pr"),
+        &symbol_short!("inv_pr"),
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &500u32,
+        &(31_536_000u64),
+    );
+
+    // 4 weekly installments.
+    // installment_principal = 1_200_000_000 / 4 = 300_000_000
+    // installment_amount    = 300_000_000 + 300_000_000*500/10_000 = 315_000_000
+    let first_due = env.ledger().timestamp() + 604_800;
+    let sched = fin.schedule_repayment(
+        &symbol_short!("off_pr"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &4u32,
+        &first_due,
+    );
+
+    // Before first_due: proxy returns 0.
+    assert_eq!(rep.get_installment_due(&symbol_short!("off_pr")), 0);
+
+    // Advance past first_due — installment 1 elapsed, 0 paid → returns 1.
+    env.ledger().set_timestamp(first_due + 1);
+    assert_eq!(rep.get_installment_due(&symbol_short!("off_pr")), 1);
+
+    // Mark installment 1 as paid via financing callback, then advance past
+    // second period — installment 2 now due → returns 2.
+    fin.update_offer_amount_repaid(&symbol_short!("off_pr"), &sched.installment_amount);
+    env.ledger().set_timestamp(first_due + 604_800 + 1);
+    assert_eq!(rep.get_installment_due(&symbol_short!("off_pr")), 2);
+}
+
+/// After a full repayment, get_installment_due returns 0 via the proxy.
+#[test]
+fn test_repayment_get_installment_due_zero_after_full_repay() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let amount: i128 = 1_050_000_000; // 12 × 87_500_000 principal
+    // 500 bps interest → per-installment: 87_500_000 + 4_375_000 = 91_875_000
+    // 12 installments × 91_875_000 = 1_102_500_000 total due
+
+    let token_id = create_token(&env);
+    let (reg, fin, rep) = setup_contracts(&env, &admin, &token_id);
+
+    let interest_rate: u32 = 500;
+    let yield_amt = amount * (interest_rate as i128) / 10_000;
+    let total_due = amount + yield_amt;
+
+    reg.register_invoice(
+        &symbol_short!("inv_fd"),
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(env.ledger().timestamp() + 100_000_000u64),
+    );
+    fin.create_offer(
+        &symbol_short!("off_fd"),
+        &symbol_short!("inv_fd"),
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &interest_rate,
+        &(31_536_000u64),
+    );
+
+    let first_due = env.ledger().timestamp() + 604_800;
+    fin.schedule_repayment(
+        &symbol_short!("off_fd"),
+        &originator,
+        &invofi_common::ScheduleFrequency::Weekly,
+        &12u32,
+        &first_due,
+    );
+
+    // Accept offer + fund the repayer.
+    mint_and_approve(&env, &token_id, &fin.address, &lender, amount);
+    fin.accept_offer(&symbol_short!("off_fd"), &originator);
+    let asset = token::StellarAssetClient::new(&env, &token_id);
+    asset.mint(&originator, &total_due);
+
+    // Fully repay.
+    rep.repay_invoice(
+        &symbol_short!("inv_fd"),
+        &symbol_short!("off_fd"),
+        &originator,
+        &total_due,
+    );
+
+    // Advance past all 12 periods — proxy must return 0 (Repaid offer).
+    env.ledger().set_timestamp(first_due + 12 * 604_800 + 1);
+    assert_eq!(rep.get_installment_due(&symbol_short!("off_fd")), 0);
+}


### PR DESCRIPTION
## Summary

Implements [issue #133](https://github.com/Stellar-VaultLink/invofi-contracts/issues/133) — advisory fixed-installment repayment schedules.

## Changes

### `common`
- New `ScheduleFrequency` enum (Daily / Weekly / Monthly) with a `period_secs()` helper
- New `RepaymentSchedule` `#[contracttype]` struct: `offer_id`, `count`, `frequency`, `installment_amount` (pre-computed), `first_due` timestamp
- Three new methods on `FinancingInterface` / `FinancingClient`: `schedule_repayment`, `get_schedule`, `get_installment_due`

### `financing`
- Persistent `Map<Symbol, RepaymentSchedule>` keyed by `offer_id`
- `schedule_repayment(offer_id, caller, frequency, count, first_due)` — lender or originator; validates `count ∈ [1, 1200]` and `first_due > now`; computes `installment_amount` using the flat-rate equal-principal model
- `get_schedule(offer_id)` → `Option<RepaymentSchedule>`
- `get_installment_due(offer_id)` → 1-based index of the first unpaid elapsed installment, or 0 when nothing is due

### `repayment`
- Thin `get_installment_due(offer_id)` proxy that delegates to financing, so CLI/keepers need only one contract reference

### `docs/adr`
- ADR-0006: records the advisory-with-enforcement design, flat-rate math model, and alternatives rejected

## Installment math

```
installment_principal = floor(offer.amount / count)
installment_yield     = installment_principal × interest_rate / 10_000
installment_amount    = installment_principal + installment_yield
```

## Acceptance criteria

- [x] Schedule created and readable
- [x] Installment math matches documented model at a known rate
- [x] Off-schedule payment still permitted without corrupting state

## Tests

131 tests pass (116 original + 15 new across `financing` and `repayment`). All clippy clean.

Closes #133