### PR TITLE
feat(repayment): accrue overdue penalty interest (ADR-0006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,49 @@ and are enforced by commitlint in CI.
   and registry ↔ repayment (overdue/delegate). At least one happy-path and
   one negative test per boundary. Existing per-crate unit tests are untouched
   (issue #103).
+- **Overdue penalty interest (issue #49)** — `repayment` now accrues a
+  penalty on obligations past their invoice due date, threaded through
+  `calculate_total_due`, `repay_invoice`, and the `reclaim_invoice` payout
+  math. Design in `docs/adr/0007-overdue-penalty-interest.md`.
+  - Accrual is anchored on `invoice.due_date` (not the permissionless
+    Overdue status transition, which would be gameable by withholding a
+    keeper call) and runs in whole elapsed days, truncated — the partial day
+    in progress is not charged, so rounding favours the borrower.
+  - The accrual base is **frozen** at principal + yield and does not shrink
+    as repayments land. This is deliberate: a base tracking the outstanding
+    balance would let a large late partial payment retroactively erase
+    penalty already accrued, since a read-time recomputation would apply the
+    reduced principal across the entire elapsed window.
+  - Total accrued penalty is capped at `penalty_cap_bps` of that base, so
+    worst-case liability is a fixed multiple of the original obligation
+    rather than a function of how long the invoice went unattended.
+  - New admin entrypoint `set_penalty(admin, penalty_bps, cap_bps)`
+    (pause-guarded, admin-only, `penalty_bps` ≤ 500 = 5%/day, `cap_bps` ≤
+    10 000), with getters `get_penalty_bps` / `get_penalty_cap_bps`. **Both
+    parameters default to 0, which disables accrual entirely** — this change
+    is behaviourally inert until an admin enables it per network.
+  - New read-only `calculate_penalty(offer_id)` exposes the penalty
+    component on its own, for UIs that show it separately from the combined
+    figure.
+  - The insurance pool does **not** cover accrued penalty: the claim in
+    `reclaim_invoice` remains principal + yield − repaid, per ADR-0003.
+    Penalty is a punitive charge owed by the originator, not an insured
+    credit loss, and covering it would make staker losses grow with the time
+    a defaulted invoice went unreclaimed.
+  - 16 new tests cover per-day accrual, the truncation boundary, the cap
+    boundary (days 299/300/400/5 000), the frozen base across a 95% partial
+    repayment, penalty-must-be-settled-for-full-repayment, accrual continuing
+    across the Overdue transition, exclusion from the insurance payout, and
+    the admin/range/pause guards on `set_penalty`.
+
+### Changed
+- **`calculate_total_due` now reads the registry.** It previously read only
+  the offer from financing; it needs `invoice.due_date` to compute accrued
+  penalty, so this query now also depends on the registry being reachable.
+- **The `off_def` event gained a fourth element** (accrued penalty, `i128`),
+  emitted by `reclaim_invoice` so indexers can track the portion of the
+  lender's claim the pool did not cover. Consumers that destructure the
+  payload positionally need updating.
 
 ### Docs
 - **Migration runbook**: add `docs/migration-runbook.md` with the snapshot

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -240,7 +240,7 @@ pub fn resolve_token(env: &Env, currency: &Symbol) -> Address {
 ///   - exceptions: pause, unpause, contract_is_paused, getters.
 /// - Repayment:
 ///   - state-changing: repay_invoice, mark_overdue, reclaim_invoice, set_insurance,
-///     set_reputation, transfer_admin.
+///     set_reputation, set_penalty, transfer_admin.
 ///   - exceptions: pause, unpause, contract_is_paused, getters.
 /// - Insurance:
 ///   - state-changing: stake, unstake, pay_out, set_staking_token, set_payout_caller,

--- a/docs/adr/0007-overdue-penalty-interest.md
+++ b/docs/adr/0007-overdue-penalty-interest.md
@@ -1,0 +1,164 @@
+# ADR-0007 — Overdue penalty interest
+
+**Status:** Proposed (2026-08-17)
+
+## Context
+
+Repayment charges a flat rate: the borrower owes `principal + principal *
+interest_rate / 10_000`, and that figure is identical whether they repay on
+the due date or a year later. An invoice that blows past its due date costs
+the borrower nothing extra, so there is no on-chain pressure to pay, and the
+lender's only recourse is to wait out `GRACE_PERIOD_SECS` and reclaim — which
+pushes the loss onto the insurance pool rather than onto the party that caused
+it (issue #49).
+
+Three facts about the existing code shape this design.
+
+**The Overdue status is a dead end for repayment.** `mark_overdue` is
+permissionless and moves an invoice Financed -> Overdue. But `repay_invoice`
+requires `status == Financed`, and the registry's authorized transition
+`repayment_marks_invoice_repaid` enforces the same precondition. The only
+transition out of Overdue is `repayment_marks_defaulted` (Overdue ->
+Defaulted). So once *anyone* calls `mark_overdue`, the originator can never
+repay; default becomes the only reachable terminal state. A penalty that
+accrued only in the Overdue status would therefore be uncollectible by
+construction — the borrower has no entrypoint through which to pay it.
+
+**Accrual anchored on a status transition is gameable.** `mark_overdue` is
+permissionless and nothing schedules it. If accrual started at the timestamp
+of that call, a borrower who kept a keeper from firing would accrue nothing,
+and a third party could inflate another user's liability by choosing when to
+call it.
+
+**Lazy accrual on the *outstanding* balance is exploitable.** Deriving the
+penalty at read time as `rate x outstanding_principal x elapsed` charges the
+*current* principal across the *whole* elapsed window. A borrower who sits at
+300 days overdue and then repays 99% of principal collapses the accrued
+penalty by ~99% in the same transaction, because the next read multiplies the
+full 300 days by the now-tiny balance. Any scheme that both (a) recomputes
+from scratch at read time and (b) uses a base that repayments shrink has this
+retroactive-erasure hole.
+
+## Decision
+
+1. **Accrual is anchored on `invoice.due_date`, not on the Overdue status.**
+   Penalty accrues whenever `now > invoice.due_date`, regardless of whether
+   the invoice is still labelled Financed or has been flipped to Overdue.
+   `due_date` is immutable, set at registration, and is already the anchor for
+   both `mark_overdue` and the `due_date + GRACE_PERIOD_SECS` reclaim gate, so
+   this keeps one clock for the whole overdue lifecycle. It also makes the
+   penalty collectible: the past-due-but-still-Financed window is exactly
+   where `repay_invoice` still works.
+
+2. **The accrual base is frozen at `total_due` (principal + yield).** The base
+   is fixed at the value the obligation had on its due date and does not
+   shrink as repayments land. This is what closes the retroactive-erasure hole
+   in the Context: the base is not a function of `amount_repaid`, so no
+   payment can rewrite penalty that has already accrued. Accrued penalty is
+   therefore monotonically non-decreasing in time, which is the invariant the
+   tests assert.
+
+   The cost is that a borrower who pays down 90% of the balance still accrues
+   penalty on the original base. That is punitive, and deliberately so — it is
+   bounded by the cap in (4), and the alternative (checkpointing accrued
+   penalty and a `last_accrual_ts` on every payment) requires new fields on the
+   shared `FinancingOffer` struct, a storage migration, and a new authorized
+   financing entrypoint. Not worth it for a bounded, capped charge.
+
+3. **Granularity is whole elapsed days, truncated.** `elapsed_days = (now -
+   due_date) / 86_400` in integer arithmetic. Per-second accrual produces
+   stroop-level dust on realistic invoice sizes and widens the overflow
+   surface for no economic gain on an instrument whose terms are quoted in
+   days. Truncation means the partial day in progress is not charged, so
+   rounding runs in the **borrower's** favour. That direction is chosen so the
+   protocol never overcharges on a boundary; it is a deliberate choice, not an
+   artifact of integer division, and it is asserted in the tests.
+
+4. **A hard cap bounds total accrued penalty.** `penalty = min(raw, total_due *
+   penalty_cap_bps / 10_000)`. Without a ceiling, a long-abandoned invoice
+   accrues without bound, which would make the lender's nominal claim — and,
+   if the pool ever covered it, staker losses — grow purely as a function of
+   how long nobody acted. The cap makes worst-case liability a fixed multiple
+   of the original obligation, known at origination.
+
+5. **Arithmetic is `i128` throughout with saturating multiplication.** Every
+   intermediate (`total_due * penalty_bps * elapsed_days`) is computed in
+   `i128` with `saturating_mul`, so a pathological `elapsed_days` saturates
+   rather than wrapping. Division by `10_000` happens last, after the
+   multiplications, to avoid compounding truncation error.
+
+6. **Configuration lives on the repayment contract and defaults to disabled.**
+   `set_penalty(admin, penalty_bps, cap_bps)` mirrors the registry's
+   `set_rate` / `set_fee` pattern: pause-guarded, admin-only, range-validated.
+   Both values default to **0**, which makes `accrued_penalty` return 0 on
+   every path. Deploying this change is therefore a no-op until an admin
+   explicitly enables it — the feature gate the issue asks for, in addition to
+   the existing pause guard that already covers `repay_invoice`,
+   `reclaim_invoice`, and `set_penalty` itself. `penalty_bps` is capped at
+   `MAX_PENALTY_BPS` (500 = 5%/day) so a mis-keyed admin call cannot set an
+   absurd rate; `cap_bps` is capped at 10_000 (100% of the obligation).
+
+   Storage lives on repayment rather than registry or financing because all
+   three consumers (`repay_invoice`, `reclaim_invoice`, `calculate_total_due`)
+   are repayment entrypoints — this keeps config reads local instead of adding
+   a cross-contract hop to the hot path.
+
+7. **Repayments settle against one combined figure; there is no
+   penalty-vs-principal ordering.** The amount owed at time `t` is `total_owed
+   = total_due + penalty(t)`, and `amount_repaid` accumulates against it;
+   `fully_repaid` is `amount_repaid >= total_owed(t)` evaluated at payment
+   time. Because every repayment routes to the same place — the lender, less
+   the existing protocol fee — splitting a payment into a "penalty part" and a
+   "principal part" would change no transfer and no balance. The ordering
+   question that a two-bucket design would force (does a partial clear penalty
+   first or principal first?) simply does not arise. The protocol fee applies
+   to the whole payment, penalty included, consistent with how it already
+   treats yield.
+
+8. **The insurance pool does not cover accrued penalty.** `reclaim_invoice`
+   computes the penalty and reports it, but the amount claimed from the pool
+   stays `principal + yield - amount_repaid`, exactly as ADR-0003 defines it.
+   Penalty is a punitive charge owed by the originator, not an insured credit
+   loss; folding it into the claim would make staker losses a function of how
+   long a defaulted invoice went unreclaimed, which is precisely the unbounded
+   exposure the cap in (4) exists to prevent. The accrued figure is emitted on
+   the `off_def` event so indexers can track the lender's uncovered claim.
+
+## Relationship to ADR-0006 (fixed installment repayment schedules)
+
+ADR-0006 landed while this was in review. The two do not interact, and that is
+deliberate: penalty accrual is anchored on `invoice.due_date`, whereas an
+installment schedule carries its own `first_due` and per-installment
+timestamps. A missed *installment* therefore accrues no penalty — only the
+invoice due date does.
+
+That is the right split for now, because ADR-0006 states the schedule is
+**advisory**: `offer.amount_repaid` remains the authoritative record, ad-hoc
+repayments never invalidate a schedule, and `get_installment_due` is a keeper
+signal rather than an enforcement gate. Charging a penalty off an advisory
+structure would make it enforcing through the back door, without the design
+review that change deserves. Per-installment penalties are a coherent future
+feature, but they belong in their own ADR that first decides whether schedules
+become binding.
+
+## Consequences
+
+- Borrowers face a real, compounding-by-the-day cost for running past due,
+  bounded by the cap — the lender-protection gap in #49 closes for the
+  past-due-but-Financed window.
+- Deployments that never call `set_penalty` are bit-for-bit unchanged in
+  behaviour, so this can ship dark and be enabled per-network after review.
+- `calculate_total_due` now performs a cross-contract read of the invoice (it
+  previously read only the offer) because it needs `due_date`. This makes a
+  previously offer-only query depend on the registry being reachable.
+- The `off_def` event gains a fourth element (accrued penalty). Indexers that
+  destructure it positionally need updating; this is noted in the CHANGELOG.
+- **The Overdue repayment dead end is not fixed here.** Once `mark_overdue`
+  fires, the borrower still cannot repay and still cannot pay the penalty,
+  and since `mark_overdue` is permissionless a third party can force that
+  state at will. Penalty accrual makes the consequence sharper — the meter
+  keeps running on an obligation the borrower is locked out of settling. A
+  cure path (accepting Overdue in `repay_invoice`, plus an Overdue ->
+  Financed/Repaid registry transition) is the natural follow-up and is filed
+  separately rather than smuggled into this change, because it alters the
+  invoice state machine and needs its own review.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0004 | [Reputation scoring](./0004-reputation.md) | Accepted |
 | 0005 | [Deployer-bound initialization (constructors)](./0005-deployer-bound-initialization.md) | Accepted |
 | 0006 | [Fixed installment repayment schedules](./0006-repayment-schedules.md) | Accepted |
+| 0007 | [Overdue penalty interest](./0007-overdue-penalty-interest.md) | Proposed |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -8,6 +8,91 @@ use invofi_common::{
     MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
 };
 
+// ─── Overdue penalty (ADR-0007) ──────────────────────────────────────────────
+
+/// Seconds in a day. Penalty accrues in whole elapsed days.
+const SECS_PER_DAY: u64 = 86_400;
+
+/// Upper bound on the configurable per-day penalty rate: 500 bps = 5%/day.
+/// Guards against a mis-keyed admin call setting an absurd rate.
+pub const MAX_PENALTY_BPS: u32 = 500;
+
+/// Accrued overdue penalty on an obligation, in the offer's currency.
+///
+/// Per ADR-0007:
+/// - accrual is anchored on `due_date`, not on the Overdue status transition
+///   (which is permissionless and therefore gameable);
+/// - the base is **frozen** at `total_due` (principal + yield) and does not
+///   shrink as repayments land, so a late partial payment cannot retroactively
+///   erase penalty that has already accrued;
+/// - elapsed time truncates to whole days, so the partial day in progress is
+///   not charged — rounding runs in the borrower's favour;
+/// - the result is capped at `total_due * cap_bps / 10_000`.
+///
+/// Returns 0 when the feature is disabled (`penalty_bps == 0`), which is the
+/// default for a freshly deployed contract.
+fn accrued_penalty(
+    env: &Env,
+    total_due: i128,
+    due_date: u64,
+    penalty_bps: u32,
+    cap_bps: u32,
+) -> i128 {
+    if penalty_bps == 0 || cap_bps == 0 || total_due <= 0 {
+        return 0;
+    }
+    let now = env.ledger().timestamp();
+    if now <= due_date {
+        return 0;
+    }
+    let elapsed_days = ((now - due_date) / SECS_PER_DAY) as i128;
+    if elapsed_days == 0 {
+        return 0;
+    }
+
+    // Multiply in i128 with saturation, divide by 10_000 last so the two
+    // multiplications do not compound truncation error.
+    let raw = total_due
+        .saturating_mul(penalty_bps as i128)
+        .saturating_mul(elapsed_days)
+        / 10_000;
+    let cap = total_due.saturating_mul(cap_bps as i128) / 10_000;
+    raw.min(cap)
+}
+
+/// Accrued penalty for an already-loaded offer. Reads the invoice (for
+/// `due_date`) and the penalty config. Shared by `calculate_total_due` and
+/// `calculate_penalty` so neither has to re-fetch the offer.
+fn penalty_for_offer(env: &Env, offer: &FinancingOffer) -> i128 {
+    let registry_addr: Address = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("registry"))
+        .unwrap_or_else(|| panic!("Not initialized"));
+    let registry_client = RegistryClient::new(env, &registry_addr);
+    let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
+
+    let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
+    let total_due = offer.amount + yield_amount;
+    let (penalty_bps, cap_bps) = load_penalty_config(env);
+    accrued_penalty(env, total_due, invoice.due_date, penalty_bps, cap_bps)
+}
+
+/// Read the configured penalty parameters, defaulting to disabled.
+fn load_penalty_config(env: &Env) -> (u32, u32) {
+    let penalty_bps: u32 = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("penbps"))
+        .unwrap_or(0);
+    let cap_bps: u32 = env
+        .storage()
+        .instance()
+        .get(&symbol_short!("pencap"))
+        .unwrap_or(0);
+    (penalty_bps, cap_bps)
+}
+
 // ─── Contract ────────────────────────────────────────────────────────────────
 
 #[contract]
@@ -98,6 +183,48 @@ impl RepaymentContract {
 
     pub fn get_reputation(env: Env) -> Option<Address> {
         env.storage().instance().get(&symbol_short!("repadd"))
+    }
+
+    /// Configure overdue penalty accrual (ADR-0007). Admin only.
+    ///
+    /// `penalty_bps` is the **per-day** rate applied to the frozen base
+    /// (principal + yield); `cap_bps` bounds total accrued penalty as a
+    /// fraction of that same base. Both default to 0, which disables accrual
+    /// entirely — a freshly deployed contract behaves exactly as before until
+    /// an admin calls this.
+    pub fn set_penalty(env: Env, admin: Address, penalty_bps: u32, cap_bps: u32) {
+        assert_not_paused(&env);
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            panic!("Only the current admin can set penalty parameters");
+        }
+        if penalty_bps > MAX_PENALTY_BPS {
+            panic!("penalty_bps must be at most 500 (5% per day)");
+        }
+        if cap_bps > 10_000 {
+            panic!("cap_bps must be between 0 and 10000");
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("penbps"), &penalty_bps);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("pencap"), &cap_bps);
+    }
+
+    /// The configured per-day penalty rate in basis points (0 = disabled).
+    pub fn get_penalty_bps(env: Env) -> u32 {
+        load_penalty_config(&env).0
+    }
+
+    /// The configured penalty ceiling in basis points of the frozen base.
+    pub fn get_penalty_cap_bps(env: Env) -> u32 {
+        load_penalty_config(&env).1
     }
 
     /// Transfers admin rights. Only current admin.
@@ -210,7 +337,15 @@ impl RepaymentContract {
         let token_client = token::TokenClient::new(&env, &token_id);
         let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
         let total_due = offer.amount + yield_amount;
-        let remaining_balance = total_due - offer.amount_repaid;
+
+        // Overdue penalty (ADR-0007). Accrues from the invoice due date, on a
+        // base frozen at principal + yield. Zero unless an admin has enabled
+        // it, and zero while the invoice is not yet past due.
+        let (penalty_bps, cap_bps) = load_penalty_config(&env);
+        let penalty = accrued_penalty(&env, total_due, invoice.due_date, penalty_bps, cap_bps);
+        let total_owed = total_due + penalty;
+
+        let remaining_balance = total_owed - offer.amount_repaid;
         assert!(
             amount <= remaining_balance,
             "Repayment amount exceeds remaining balance"
@@ -233,7 +368,7 @@ impl RepaymentContract {
         }
 
         offer.amount_repaid += amount;
-        let fully_repaid = offer.amount_repaid >= total_due;
+        let fully_repaid = offer.amount_repaid >= total_owed;
         let new_status = if fully_repaid {
             OfferStatus::Repaid
         } else {
@@ -357,7 +492,18 @@ impl RepaymentContract {
         // the pool is empty). Skipped entirely when no insurance contract is
         // configured.
         let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
-        let remaining_due = (offer.amount + yield_amount - offer.amount_repaid).max(0);
+        let total_due = offer.amount + yield_amount;
+        let remaining_due = (total_due - offer.amount_repaid).max(0);
+
+        // Overdue penalty (ADR-0007). Deliberately **excluded** from the
+        // insured amount: the pool covers realized credit loss (principal +
+        // yield, per ADR-0003), not the punitive charge owed by the
+        // originator. Including it would make staker losses grow with how
+        // long a defaulted invoice went unreclaimed. It is reported on the
+        // event so indexers can track the lender's uncovered claim.
+        let (penalty_bps, cap_bps) = load_penalty_config(&env);
+        let penalty = accrued_penalty(&env, total_due, invoice.due_date, penalty_bps, cap_bps);
+
         let mut payout: i128 = 0;
         let insurance_opt: Option<Address> = env.storage().instance().get(&symbol_short!("insadd"));
         if let Some(insurance_addr) = insurance_opt {
@@ -377,15 +523,24 @@ impl RepaymentContract {
 
         env.events().publish(
             (symbol_short!("off_def"), offer.id.clone()),
-            (offer.invoice_id.clone(), offer.lender.clone(), payout),
+            (
+                offer.invoice_id.clone(),
+                offer.lender.clone(),
+                payout,
+                penalty,
+            ),
         );
         offer
     }
 
     // ── Query helpers ────────────────────────────────────────────────────────
 
-    /// Calculate the remaining total due on an offer (principal + yield - repaid).
-    /// Cross-contract: reads offer from financing.
+    /// Calculate the remaining total due on an offer
+    /// (principal + yield + accrued overdue penalty - repaid).
+    ///
+    /// Cross-contract: reads the offer from financing and — since ADR-0007 —
+    /// the invoice from the registry, because penalty accrual is anchored on
+    /// `invoice.due_date`.
     pub fn calculate_total_due(env: Env, offer_id: Symbol) -> i128 {
         let financing_addr: Address = env
             .storage()
@@ -401,7 +556,30 @@ impl RepaymentContract {
         }
         let yield_amount = offer.amount * (offer.interest_rate as i128) / 10_000;
         let total_due = offer.amount + yield_amount;
-        (total_due - offer.amount_repaid).max(0)
+        let penalty = penalty_for_offer(&env, &offer);
+        (total_due + penalty - offer.amount_repaid).max(0)
+    }
+
+    /// The overdue penalty accrued on an offer so far (ADR-0007), before
+    /// subtracting anything already repaid. Returns 0 when accrual is
+    /// disabled, when the invoice is not yet past due, or when the offer has
+    /// reached a terminal status.
+    ///
+    /// Exposed separately so a UI can show the penalty component rather than
+    /// only the combined figure from `calculate_total_due`.
+    pub fn calculate_penalty(env: Env, offer_id: Symbol) -> i128 {
+        let financing_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("financing"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let financing_client = FinancingClient::new(&env, &financing_addr);
+        let offer: FinancingOffer = financing_client.get_offer(&offer_id);
+
+        if offer.status == OfferStatus::Repaid || offer.status == OfferStatus::Defaulted {
+            return 0;
+        }
+        penalty_for_offer(&env, &offer)
     }
 
     pub fn version(env: Env) -> soroban_sdk::String {

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -1157,3 +1157,478 @@ fn test_repayment_get_installment_due_zero_after_full_repay() {
     env.ledger().set_timestamp(first_due + 12 * 604_800 + 1);
     assert_eq!(rep.get_installment_due(&symbol_short!("off_fd")), 0);
 }
+
+// ─── Overdue penalty interest (ADR-0007, issue #49) ─────────────────────────
+
+/// Principal for the penalty fixtures.
+const PEN_AMOUNT: i128 = 1_000_000_000;
+/// 5.00% flat yield → 50_000_000.
+const PEN_RATE: u32 = 500;
+/// The **frozen** accrual base: principal + yield. Per ADR-0007 decision 2
+/// this does not shrink as repayments land.
+const PEN_TOTAL_DUE: i128 = 1_050_000_000;
+/// Invoice due date used by every penalty fixture.
+const PEN_DUE_DATE: u64 = 1_735_689_600;
+/// 0.10% per day of the frozen base → 1_050_000 per elapsed day.
+const PEN_BPS: u32 = 10;
+/// Ceiling at 30% of the frozen base → 315_000_000, reached at day 300.
+const PEN_CAP_BPS: u32 = 3_000;
+const PEN_PER_DAY: i128 = 1_050_000;
+const PEN_CAP: i128 = 315_000_000;
+
+struct PenCase<'a> {
+    reg: invofi_registry::RegistryContractClient<'a>,
+    fin: invofi_financing::FinancingContractClient<'a>,
+    rep: super::RepaymentContractClient<'a>,
+    token_id: Address,
+    registry_id: Address,
+    repayment_id: Address,
+    admin: Address,
+    originator: Address,
+    lender: Address,
+}
+
+/// A Financed invoice of `PEN_AMOUNT` at `PEN_RATE`, due at `PEN_DUE_DATE`,
+/// with the originator funded well past `PEN_TOTAL_DUE` so tests can settle
+/// principal, yield and penalty. Penalty accrual is left **disabled** — each
+/// test opts in via `set_penalty`, which is the deployed default per ADR-0007
+/// decision 6.
+fn setup_penalty_case<'a>(env: &'a Env) -> PenCase<'a> {
+    let admin = Address::generate(env);
+    let originator = Address::generate(env);
+    let lender = Address::generate(env);
+
+    let token_id = create_token(env);
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(env, &registry_id);
+
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), registry_id.clone(), token_id.clone()),
+    );
+    let fin = invofi_financing::FinancingContractClient::new(env, &financing_id);
+
+    let repayment_id = env.register(
+        RepaymentContract,
+        (
+            admin.clone(),
+            registry_id.clone(),
+            financing_id.clone(),
+            token_id.clone(),
+        ),
+    );
+    let rep = super::RepaymentContractClient::new(env, &repayment_id);
+
+    mint_and_approve(env, &token_id, &financing_id, &lender, PEN_AMOUNT);
+    fin.set_repayment_contract(&admin, &repayment_id);
+    reg.set_repayment_contract(&admin, &repayment_id);
+    reg.set_financing_contract(&admin, &financing_id);
+
+    reg.register_invoice(
+        &symbol_short!("inv_pen"),
+        &originator,
+        &PEN_AMOUNT,
+        &symbol_short!("USDC"),
+        &PEN_DUE_DATE,
+    );
+    fin.create_offer(
+        &symbol_short!("off_pen"),
+        &symbol_short!("inv_pen"),
+        &lender,
+        &PEN_AMOUNT,
+        &symbol_short!("USDC"),
+        &PEN_RATE,
+        &(2_592_000u64),
+    );
+    fin.accept_offer(&symbol_short!("off_pen"), &originator);
+
+    // Fund the originator beyond the capped worst case.
+    token::StellarAssetClient::new(env, &token_id).mint(&originator, &2_000_000_000);
+
+    PenCase {
+        reg,
+        fin,
+        rep,
+        token_id,
+        registry_id,
+        repayment_id,
+        admin,
+        originator,
+        lender,
+    }
+}
+
+/// Advance the ledger to exactly `days` whole days past the due date.
+fn at_days_overdue(env: &Env, days: u64) {
+    env.ledger().set_timestamp(PEN_DUE_DATE + days * 86_400);
+}
+
+#[test]
+fn test_penalty_disabled_by_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+
+    // Deployed default: both parameters zero, accrual inert.
+    assert_eq!(c.rep.get_penalty_bps(), 0);
+    assert_eq!(c.rep.get_penalty_cap_bps(), 0);
+
+    // Ten days past due and still no penalty — a deployment that never calls
+    // set_penalty behaves exactly as it did before ADR-0007.
+    at_days_overdue(&env, 10);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
+    assert_eq!(
+        c.rep.calculate_total_due(&symbol_short!("off_pen")),
+        PEN_TOTAL_DUE
+    );
+}
+
+#[test]
+fn test_penalty_zero_cap_disables_accrual() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+
+    // A rate with a zero ceiling accrues nothing — the cap is a hard bound,
+    // so a zero cap is a hard zero.
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &0u32);
+    at_days_overdue(&env, 10);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
+}
+
+#[test]
+fn test_penalty_accrues_in_whole_days() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    at_days_overdue(&env, 1);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        PEN_PER_DAY
+    );
+
+    at_days_overdue(&env, 5);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        5 * PEN_PER_DAY
+    );
+
+    // calculate_total_due reports principal + yield + penalty - repaid.
+    assert_eq!(
+        c.rep.calculate_total_due(&symbol_short!("off_pen")),
+        PEN_TOTAL_DUE + 5 * PEN_PER_DAY
+    );
+}
+
+#[test]
+fn test_penalty_truncates_partial_day_toward_borrower() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    // One second short of day 5: the day in progress is not charged, so the
+    // borrower is billed for 4 days. ADR-0007 decision 3 — rounding runs in
+    // the borrower's favour, deliberately.
+    env.ledger().set_timestamp(PEN_DUE_DATE + 5 * 86_400 - 1);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        4 * PEN_PER_DAY
+    );
+
+    // The boundary second itself tips it to 5.
+    env.ledger().set_timestamp(PEN_DUE_DATE + 5 * 86_400);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        5 * PEN_PER_DAY
+    );
+}
+
+#[test]
+fn test_penalty_not_accrued_before_or_at_due_date() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    env.ledger().set_timestamp(PEN_DUE_DATE - 1);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
+
+    // Exactly on the due date is not yet late.
+    env.ledger().set_timestamp(PEN_DUE_DATE);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
+
+    // And the first second past it has not completed a day.
+    env.ledger().set_timestamp(PEN_DUE_DATE + 1);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
+}
+
+#[test]
+fn test_penalty_stops_at_hard_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    // Day 299: still below the ceiling, accruing linearly.
+    at_days_overdue(&env, 299);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        299 * PEN_PER_DAY
+    );
+
+    // Day 300: raw accrual meets the ceiling exactly.
+    at_days_overdue(&env, 300);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), PEN_CAP);
+
+    // Day 400 and day 5_000: pinned at the ceiling. Without this bound a
+    // long-abandoned invoice would accrue purely as a function of neglect.
+    at_days_overdue(&env, 400);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), PEN_CAP);
+    at_days_overdue(&env, 5_000);
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), PEN_CAP);
+}
+
+#[test]
+fn test_penalty_base_frozen_across_partial_repayment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    at_days_overdue(&env, 5);
+    let before = c.rep.calculate_penalty(&symbol_short!("off_pen"));
+    assert_eq!(before, 5 * PEN_PER_DAY);
+
+    // Pay down almost the entire obligation at day 5.
+    c.rep.repay_invoice(
+        &symbol_short!("inv_pen"),
+        &symbol_short!("off_pen"),
+        &c.originator,
+        &1_000_000_000i128,
+    );
+
+    // The accrued penalty is unchanged. This is the retroactive-erasure hole
+    // ADR-0007 decision 2 closes: if the base tracked the *outstanding*
+    // balance, this 95% paydown would have collapsed the 5 days of accrued
+    // penalty to a fraction of its value.
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), before);
+
+    // Accrual continues on the frozen base, not on the reduced outstanding.
+    at_days_overdue(&env, 10);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        10 * PEN_PER_DAY
+    );
+
+    // Monotonically non-decreasing across the whole window, repayment or not.
+    let mut last = 0i128;
+    for day in [6u64, 7, 20, 100, 299, 300, 900] {
+        at_days_overdue(&env, day);
+        let p = c.rep.calculate_penalty(&symbol_short!("off_pen"));
+        assert!(p >= last, "penalty must never decrease over time");
+        last = p;
+    }
+}
+
+#[test]
+fn test_penalty_must_be_settled_for_full_repayment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    at_days_overdue(&env, 5);
+    let penalty = 5 * PEN_PER_DAY;
+
+    // Paying the pre-penalty figure in full is no longer a full settlement.
+    let inv = c.rep.repay_invoice(
+        &symbol_short!("inv_pen"),
+        &symbol_short!("off_pen"),
+        &c.originator,
+        &PEN_TOTAL_DUE,
+    );
+    assert_eq!(inv.status, InvoiceStatus::Financed);
+    assert_eq!(
+        c.fin.get_offer(&symbol_short!("off_pen")).status,
+        OfferStatus::Financed
+    );
+    assert_eq!(
+        c.rep.calculate_total_due(&symbol_short!("off_pen")),
+        penalty
+    );
+
+    // Clearing the penalty in the same ledger closes it out.
+    let inv = c.rep.repay_invoice(
+        &symbol_short!("inv_pen"),
+        &symbol_short!("off_pen"),
+        &c.originator,
+        &penalty,
+    );
+    assert_eq!(inv.status, InvoiceStatus::Repaid);
+    let offer = c.fin.get_offer(&symbol_short!("off_pen"));
+    assert_eq!(offer.status, OfferStatus::Repaid);
+    assert_eq!(offer.amount_repaid, PEN_TOTAL_DUE + penalty);
+    assert_eq!(c.rep.calculate_total_due(&symbol_short!("off_pen")), 0);
+
+    // The lender received principal + yield + penalty (no protocol fee is
+    // configured in this fixture, so the full amount lands with them).
+    assert_eq!(
+        token::TokenClient::new(&env, &c.token_id).balance(&c.lender),
+        PEN_TOTAL_DUE + penalty
+    );
+}
+
+#[test]
+#[should_panic(expected = "Repayment amount exceeds remaining balance")]
+fn test_penalty_overpayment_beyond_accrued_total_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    at_days_overdue(&env, 5);
+    // One stroop past principal + yield + accrued penalty.
+    c.rep.repay_invoice(
+        &symbol_short!("inv_pen"),
+        &symbol_short!("off_pen"),
+        &c.originator,
+        &(PEN_TOTAL_DUE + 5 * PEN_PER_DAY + 1),
+    );
+}
+
+#[test]
+fn test_penalty_accrues_while_invoice_marked_overdue() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    // Accrual is anchored on due_date, not on the status transition, so
+    // flipping the invoice to Overdue neither starts nor resets the meter.
+    at_days_overdue(&env, 5);
+    let before = c.rep.calculate_penalty(&symbol_short!("off_pen"));
+    c.rep.mark_overdue(&symbol_short!("inv_pen"));
+    assert_eq!(
+        c.reg.get_invoice(&symbol_short!("inv_pen")).status,
+        InvoiceStatus::Overdue
+    );
+    assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), before);
+
+    at_days_overdue(&env, 9);
+    assert_eq!(
+        c.rep.calculate_penalty(&symbol_short!("off_pen")),
+        9 * PEN_PER_DAY
+    );
+}
+
+#[test]
+fn test_penalty_excluded_from_insurance_payout() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+
+    // A pool deliberately deep enough to cover the full claim, so the
+    // assertion below distinguishes "penalty excluded" from "pool exhausted".
+    let staker = Address::generate(&env);
+    let insurance_id = env.register(InsuranceContract, (c.admin.clone(), c.token_id.clone()));
+    let ins = invofi_insurance::InsuranceContractClient::new(&env, &insurance_id);
+    let asset = token::StellarAssetClient::new(&env, &c.token_id);
+    asset.mint(&staker, &3_000_000_000);
+    let tok = token::TokenClient::new(&env, &c.token_id);
+    tok.approve(
+        &staker,
+        &insurance_id,
+        &3_000_000_000,
+        &(env.ledger().sequence() + 1000),
+    );
+    ins.stake(&staker, &3_000_000_000);
+    ins.set_payout_caller(&c.admin, &c.repayment_id);
+    // pay_out verifies on-chain that the invoice is Defaulted before moving
+    // staked funds, so the pool needs the registry wired or it fails closed.
+    ins.set_registry(&c.admin, &c.registry_id);
+    c.rep.set_insurance(&c.admin, &insurance_id);
+
+    // Past due plus the grace period, then default.
+    env.ledger()
+        .set_timestamp(PEN_DUE_DATE + invofi_common::GRACE_PERIOD_SECS + 1);
+    c.rep.mark_overdue(&symbol_short!("inv_pen"));
+
+    // Seven whole days elapsed, so a non-trivial penalty has accrued — the
+    // test would be vacuous if this were zero.
+    let accrued = c.rep.calculate_penalty(&symbol_short!("off_pen"));
+    assert_eq!(accrued, 7 * PEN_PER_DAY);
+    assert_eq!(tok.balance(&c.lender), 0);
+
+    c.rep.reclaim_invoice(
+        &symbol_short!("inv_pen"),
+        &symbol_short!("off_pen"),
+        &c.lender,
+    );
+
+    // The pool paid principal + yield only. ADR-0007 decision 8: penalty is a
+    // punitive charge owed by the originator, not an insured credit loss, so
+    // stakers do not fund it.
+    assert_eq!(tok.balance(&c.lender), PEN_TOTAL_DUE);
+    assert_eq!(ins.get_pool_total(), 3_000_000_000 - PEN_TOTAL_DUE);
+}
+
+#[test]
+#[should_panic(expected = "Only the current admin can set penalty parameters")]
+fn test_set_penalty_admin_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+
+    let stranger = Address::generate(&env);
+    c.rep.set_penalty(&stranger, &PEN_BPS, &PEN_CAP_BPS);
+}
+
+#[test]
+#[should_panic(expected = "penalty_bps must be at most 500")]
+fn test_set_penalty_rejects_excessive_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+
+    c.rep.set_penalty(&c.admin, &501u32, &PEN_CAP_BPS);
+}
+
+#[test]
+#[should_panic(expected = "cap_bps must be between 0 and 10000")]
+fn test_set_penalty_rejects_excessive_cap() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &10_001u32);
+}
+
+#[test]
+#[should_panic(expected = "Contract is paused")]
+fn test_set_penalty_blocked_while_paused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let c = setup_penalty_case(&env);
+
+    c.rep.pause(&c.admin);
+    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+}


### PR DESCRIPTION
Closes #49.

ADR first, as discussed on the issue: **[`docs/adr/0007-overdue-penalty-interest.md`](https://github.com/Stellar-VaultLink/invofi-contracts/blob/feat/49-overdue-penalty-interest/docs/adr/0007-overdue-penalty-interest.md)**. It is marked **Proposed**, not Accepted — it is a contributor proposal and the numbered decisions are meant to be argued with. Each one is a small, isolated change if you disagree.

## Summary

Repayment charged a flat rate, so an invoice cost the borrower the same whether they paid on the due date or a year late. Penalty now accrues past the invoice due date and is threaded through `calculate_total_due`, `repay_invoice`, and the `reclaim_invoice` payout math.

**This ships dark.** `penalty_bps` and `cap_bps` both default to 0, and `accrued_penalty` returns 0 on every path when either is 0. A deployment that never calls `set_penalty` is behaviourally identical to today. That is the feature gate the issue asked for, on top of the existing pause guard.

### The three decisions worth your attention

**Accrual is anchored on `invoice.due_date`, not on the Overdue status transition.** `mark_overdue` is permissionless and nothing schedules it. Anchoring accrual on that call would let a borrower accrue nothing by keeping a keeper from firing, and would let a third party inflate someone's liability by choosing when to call it. `due_date` is immutable and already anchors both `mark_overdue` and the reclaim grace gate, so this keeps one clock for the whole overdue lifecycle.

**The accrual base is frozen at principal + yield, not the outstanding balance.** I originally planned to accrue on the reducing principal, and it does not work. Deriving penalty at read time as `rate × outstanding × elapsed` charges the *current* principal across the *whole* elapsed window, so a borrower sitting at 300 days overdue who then repays 99% of principal collapses the accrued penalty by ~99% in the same transaction. Any scheme that both recomputes from scratch at read time and uses a base that repayments shrink has this hole. Freezing the base closes it and keeps accrued penalty monotonically non-decreasing, which is asserted directly in the tests.

The cost is real: a borrower who pays down 90% still accrues on the original base. It is bounded by the cap, and the alternative — checkpointing accrued penalty plus a `last_accrual_ts` — needs new fields on the shared `FinancingOffer` struct, a storage migration, and a new authorized financing entrypoint. That did not seem worth it for a bounded, capped charge, but it is a judgement call and I will change it if you disagree.

**The insurance pool does not cover accrued penalty.** The claim in `reclaim_invoice` stays `principal + yield − repaid`, exactly as ADR-0003 defines it. Penalty is a punitive charge owed by the originator, not an insured credit loss; folding it in would make staker losses grow with how long a defaulted invoice went unreclaimed — the same unbounded exposure the cap exists to prevent. The accrued figure is emitted on `off_def` so indexers can track the lender's uncovered claim.

### Also

- Elapsed time truncates to whole days, so the partial day in progress is not charged. Rounding runs in the **borrower's** favour — a deliberate choice, not an artifact of integer division, and asserted at the boundary second in the tests.
- `i128` with `saturating_mul` throughout; division by `10_000` happens last so the two multiplications do not compound truncation error.
- `set_penalty(admin, penalty_bps, cap_bps)` mirrors the registry's `set_rate`/`set_fee` pattern: pause-guarded, admin-only, `penalty_bps` ≤ 500 (5%/day), `cap_bps` ≤ 10 000. Added to the pause coverage matrix in `common`.
- New read-only `calculate_penalty(offer_id)` exposes the penalty component alone, for UIs that show it separately.

## Known limitation, deliberately not fixed here

**The Overdue status is a dead end for repayment, and this PR does not change that.** `repay_invoice` requires `status == Financed`, the registry's `repayment_marks_invoice_repaid` enforces the same, and the only transition out of Overdue is to Defaulted. So once anyone calls the permissionless `mark_overdue`, the originator can never repay — and now the penalty meter keeps running on an obligation they are locked out of settling.

Penalty is still collectible in the past-due-but-still-Financed window, which is where `repay_invoice` works, so the feature is not vacuous. But a cure path (accepting Overdue in `repay_invoice`, plus an Overdue → Financed/Repaid registry transition) alters the invoice state machine and deserves its own review rather than being smuggled in here. Happy to open a separate issue for it, or fold it in if you would rather have it in one change.

## Type of change

- [ ] Bug fix
- [x] New contract function
- [ ] Data type change
- [x] Test addition
- [x] Chore / docs

## Checklist

- [x] `cargo test` passes — 163 workspace tests, 33 in repayment (16 new)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] Soroban Scout security analysis passes (CI)
- [x] `stellar contract build` succeeds — the `stellar` CLI is not available in my environment, so I verified `cargo build --target wasm32-unknown-unknown --release` instead; CI owns the real check
- [x] New functions have corresponding tests
- [x] Breaking changes are documented

### Test coverage

Per-day accrual; the truncation boundary at `due_date + 5 days − 1s`; the cap boundary at days 299 / 300 / 400 / 5 000; the frozen base across a 95% partial repayment plus a monotonicity sweep; penalty-must-be-settled-for-full-repayment; accrual continuing unchanged across the Overdue transition; exclusion from the insurance payout (with a pool deliberately deep enough that the assertion distinguishes "penalty excluded" from "pool exhausted"); disabled-by-default; zero-cap-disables; and the admin / range / pause guards on `set_penalty`.

## Breaking changes

- **`calculate_total_due` now reads the registry.** It previously read only the offer; it needs `invoice.due_date`, so this query now also depends on the registry being reachable.
- **The `off_def` event gained a fourth element** (accrued penalty, `i128`). Consumers that destructure the payload positionally need updating. Noted in the CHANGELOG.

---

## Rebased onto master (2026-08-17)

`master` advanced 22 commits while this was open, which left the PR conflicting. A conflicting PR has no computable `refs/pull/.../merge` commit, and `pull_request` workflows run against that commit — which is why no CI ran on the first push. Rebased and resolved:

- **Renumbered ADR-0006 → ADR-0007.** `0006-repayment-schedules.md` (#133) claimed 0006 while this was in flight.
- **Wired the registry into the insurance payout test.** #157 landed, so `pay_out` now verifies Defaulted status on-chain and fails closed without a registry; the payout test needed `ins.set_registry(...)`.
- Resolved conflicts in `CHANGELOG.md`, `docs/adr/README.md`, and `repayment/src/test.rs`, keeping both sides in each.

Also added an ADR section on **why penalty does not accrue on missed installments**: ADR-0006 states the schedule is advisory (`amount_repaid` is authoritative, `get_installment_due` is a keeper signal, ad-hoc repayments never invalidate it). Charging a penalty off an advisory structure would make it enforcing through the back door. Per-installment penalties belong in their own ADR that first decides whether schedules become binding.

Re-verified after the rebase: **163 workspace tests pass**, `cargo clippy --workspace --all-targets -- -D warnings` clean.
