### PR TITLE
feat(common): introduce ContractError enum and convert client-facing … #93

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,7 @@
 
 #![no_std]
 
-use soroban_sdk::{contractclient, contracttype, symbol_short, Address, Env, Map, Symbol};
+use soroban_sdk::{contractclient, contracterror, contracttype, symbol_short, Address, Env, Map, Symbol};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -24,6 +24,57 @@ pub const MAX_OFFER_DURATION_SECS: u64 = 31_536_000;
 /// Minimum invoice amount in stroops (1 XLM = 10_000_000 stroops).
 /// Prevents dust invoices that would cost more in fees than they're worth.
 pub const MIN_INVOICE_AMOUNT: i128 = 10_000_000;
+
+// ─── Shared Error Enum ────────────────────────────────────────────────────────
+
+/// Structured error type shared across all InvoFi contracts.
+///
+/// Using `#[contracterror]` causes the Soroban host to encode these as a
+/// typed `Error` value in the XDR result, not as an opaque string panic.
+/// Clients (SDK, frontend, indexer) can match on the `u32` discriminant
+/// without parsing panic messages — which breaks across contract versions.
+///
+/// Discriminants are **stable** and must never be re-numbered once deployed.
+/// Add new variants at the end with a new, higher number.
+///
+/// Using `env.panic_with_error(&ContractError::X)` keeps all public
+/// function signatures identical (`T`, not `Result<T, ContractError>`), so
+/// no SDK binding changes are needed.
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum ContractError {
+    /// Caller is not authorized to perform this action (wrong admin,
+    /// wrong originator, wrong lender, etc.).
+    Unauthorized = 1,
+
+    /// Requested resource (invoice, offer, rate, etc.) does not exist.
+    NotFound = 2,
+
+    /// The operation is not permitted given the resource's current status
+    /// (e.g., accepting an already-Financed offer, cancelling a non-Pending
+    /// invoice, reclaiming before the grace period).
+    InvalidTransition = 3,
+
+    /// The contract is paused; all state-mutating operations are halted
+    /// until an admin calls `unpause`.
+    Paused = 4,
+
+    /// The caller's balance is insufficient for the requested operation
+    /// (e.g., unstaking more than staked, repaying more than is owed).
+    InsufficientBalance = 5,
+
+    /// A parameter value falls outside the allowed range or violates a
+    /// protocol constraint (e.g., `fee_bps > 500`, `amount <= 0`,
+    /// past-due `due_date`).
+    InvalidInput = 6,
+
+    /// An entity with the provided ID already exists (invoice, offer).
+    AlreadyExists = 7,
+
+    /// The caller's address is on the blacklist.
+    Blacklisted = 8,
+}
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -256,7 +307,7 @@ pub fn assert_not_paused(env: &Env) {
         .get(&symbol_short!("paused"))
         .unwrap_or(false);
     if paused {
-        panic!("Contract is paused");
+        env.panic_with_error(ContractError::Paused);
     }
 }
 

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -6,9 +6,9 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, resolve_token, FinancingOffer, Invoice, InvoiceStatus, LenderStats,
-    OfferStatus, ProtocolStats, RegistryClient, RepaymentSchedule, ScheduleFrequency,
-    MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    assert_not_paused, resolve_token, ContractError, FinancingOffer, Invoice, InvoiceStatus,
+    LenderStats, OfferStatus, ProtocolStats, RegistryClient, RepaymentSchedule,
+    ScheduleFrequency, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -81,7 +81,7 @@ fn assert_not_blacklisted(env: &Env, address: &Address) {
     let registry_client = RegistryClient::new(env, &registry_addr);
     // CEI: Read-only cross-contract call, safe before state mutations.
     if registry_client.is_blacklisted(address) {
-        panic!("Address is blacklisted");
+        env.panic_with_error(ContractError::Blacklisted);
     }
 }
 
@@ -129,7 +129,7 @@ impl FinancingContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the repayment contract");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -160,7 +160,7 @@ impl FinancingContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can transfer admin rights");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -179,7 +179,7 @@ impl FinancingContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can register currencies");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         invofi_common::register_currency(&env, &currency, &token_addr);
     }
@@ -206,7 +206,7 @@ impl FinancingContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the position token");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -228,7 +228,7 @@ impl FinancingContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can pause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -243,7 +243,7 @@ impl FinancingContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can unpause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -308,7 +308,7 @@ impl FinancingContract {
 
         let mut offers = load_offers(&env);
         if offers.contains_key(offer_id.clone()) {
-            panic!("Offer with this ID already exists");
+            env.panic_with_error(ContractError::AlreadyExists);
         }
 
         let offer = FinancingOffer {
@@ -351,7 +351,7 @@ impl FinancingContract {
     pub fn get_offer(env: Env, id: Symbol) -> FinancingOffer {
         load_offers(&env)
             .get(id)
-            .unwrap_or_else(|| panic!("Offer not found"))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound))
     }
 
     /// Withdraw a pending offer. Only the lender.
@@ -361,12 +361,12 @@ impl FinancingContract {
         let mut offers = load_offers(&env);
         let mut offer = offers
             .get(offer_id.clone())
-            .unwrap_or_else(|| panic!("Offer not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if offer.lender != lender {
-            panic!("Only the offer lender can withdraw");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if offer.status != OfferStatus::Pending {
-            panic!("Only Pending offers can be withdrawn");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         offer.status = OfferStatus::Rejected;
         offers.set(offer_id, offer.clone());
@@ -389,9 +389,9 @@ impl FinancingContract {
         let mut offers = load_offers(&env);
         let mut offer = offers
             .get(offer_id.clone())
-            .unwrap_or_else(|| panic!("Offer not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if offer.status != OfferStatus::Pending {
-            panic!("Offer is not in Pending status");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // Cross-contract: read invoice from registry
@@ -405,10 +405,10 @@ impl FinancingContract {
         let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
 
         if invoice.originator != invoice_originator {
-            panic!("Only the invoice originator can accept offers");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if invoice.status != InvoiceStatus::Pending {
-            panic!("Invoice is not in Pending status");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // Pull the lender's principal and pay it straight to the business.
@@ -475,9 +475,9 @@ impl FinancingContract {
         let mut offers = load_offers(&env);
         let mut offer = offers
             .get(offer_id.clone())
-            .unwrap_or_else(|| panic!("Offer not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if offer.status != OfferStatus::Pending {
-            panic!("Offer is not in Pending status");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // Cross-contract: verify invoice originator
@@ -490,7 +490,7 @@ impl FinancingContract {
         // CEI: Read-only cross-contract call before state mutations.
         let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
         if invoice.originator != invoice_originator {
-            panic!("Only the invoice originator can reject offers");
+            env.panic_with_error(ContractError::Unauthorized);
         }
 
         offer.status = OfferStatus::Rejected;
@@ -523,7 +523,7 @@ impl FinancingContract {
         let mut offers = load_offers(&env);
         let mut offer = offers
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Offer not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         offer.status = new_status;
         offers.set(id, offer);
         save_offers(&env, &offers);
@@ -536,7 +536,7 @@ impl FinancingContract {
         let mut offers = load_offers(&env);
         let mut offer = offers
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Offer not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         offer.amount_repaid = amount_repaid;
         offers.set(id, offer);
         save_offers(&env, &offers);
@@ -717,14 +717,14 @@ impl FinancingContract {
         let offers = load_offers(&env);
         let offer = offers
             .get(offer_id.clone())
-            .unwrap_or_else(|| panic!("Offer not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
 
         // Only allow scheduling on live (non-terminal) offers.
         if offer.status == OfferStatus::Rejected
             || offer.status == OfferStatus::Repaid
             || offer.status == OfferStatus::Defaulted
         {
-            panic!("Cannot schedule a terminal offer");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // The caller must be the lender or the invoice originator.
@@ -739,7 +739,7 @@ impl FinancingContract {
         let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
 
         if caller != offer.lender && caller != invoice.originator {
-            panic!("Only the lender or the invoice originator can set a schedule");
+            env.panic_with_error(ContractError::Unauthorized);
         }
 
         // installment_principal = floor(amount / count)

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -258,7 +258,7 @@ fn test_create_offer_self_dealing_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Address is blacklisted")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_blacklisted_cannot_create_offer() {
     let env = Env::default();
     env.mock_all_auths();
@@ -420,7 +420,7 @@ fn test_withdraw_offer() {
 }
 
 #[test]
-#[should_panic(expected = "Only the offer lender can withdraw")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_withdraw_offer_wrong_lender_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -881,7 +881,7 @@ fn test_get_offer_duration_limits() {
 // ─── Task 4A: emergency pause / circuit breaker ──────────────────────────────
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_pause_blocks_create_offer() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1456,7 +1456,7 @@ fn test_schedule_first_due_in_past_panics() {
 
 /// A third party (neither lender nor originator) cannot set a schedule.
 #[test]
-#[should_panic(expected = "Only the lender or the invoice originator can set a schedule")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_schedule_unauthorized_caller_panics() {
     let env = Env::default();
     env.mock_all_auths();

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -14,7 +14,7 @@
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
-use invofi_common::{assert_not_paused, InvoiceStatus, RegistryClient};
+use invofi_common::{assert_not_paused, ContractError, InvoiceStatus, RegistryClient};
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -95,7 +95,7 @@ impl InsuranceContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can transfer admin rights");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -113,7 +113,7 @@ impl InsuranceContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the staking token");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -136,7 +136,7 @@ impl InsuranceContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the payout caller");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -159,7 +159,7 @@ impl InsuranceContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the registry");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -180,7 +180,7 @@ impl InsuranceContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can pause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -195,7 +195,7 @@ impl InsuranceContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can unpause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -218,7 +218,9 @@ impl InsuranceContract {
     pub fn stake(env: Env, staker: Address, amount: i128) {
         assert_not_paused(&env);
         staker.require_auth();
-        assert!(amount > 0, "stake amount must be greater than zero");
+        if amount <= 0 {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
 
         let token_addr = load_token(&env);
         let token_client = token::TokenClient::new(&env, &token_addr);
@@ -248,11 +250,15 @@ impl InsuranceContract {
     pub fn unstake(env: Env, staker: Address, amount: i128) {
         assert_not_paused(&env);
         staker.require_auth();
-        assert!(amount > 0, "unstake amount must be greater than zero");
+        if amount <= 0 {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
 
         let mut stakes = load_stakes(&env);
         let balance = stakes.get(staker.clone()).unwrap_or(0);
-        assert!(balance >= amount, "Insufficient stake");
+        if balance < amount {
+            env.panic_with_error(ContractError::InsufficientBalance);
+        }
 
         let new_balance = balance - amount;
         if new_balance == 0 {
@@ -306,7 +312,9 @@ impl InsuranceContract {
             .get(&symbol_short!("paycall"))
             .unwrap_or_else(|| panic!("No payout caller configured"));
         payout_caller.require_auth();
-        assert!(amount > 0, "payout amount must be greater than zero");
+        if amount <= 0 {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
 
         // ── Safety check 1: invoice must be Defaulted, not merely Overdue ──
         // Cross-contract read from the registry provides on-chain proof that
@@ -319,7 +327,7 @@ impl InsuranceContract {
         let registry_client = RegistryClient::new(&env, &registry_addr);
         let invoice = registry_client.get_invoice(&invoice_id);
         if invoice.status != InvoiceStatus::Defaulted {
-            panic!("Invoice is not Defaulted");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // ── Safety check 2: payout ≤ available pool balance ───────────────

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -123,7 +123,7 @@ fn test_stake_increases_existing_balance() {
 // ─── Failure paths ───────────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Insufficient stake")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_unstake_exceeds_stake_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -139,7 +139,7 @@ fn test_unstake_exceeds_stake_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Insufficient stake")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_unstake_without_stake_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -152,7 +152,7 @@ fn test_unstake_without_stake_panics() {
 }
 
 #[test]
-#[should_panic(expected = "stake amount must be greater than zero")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_stake_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -165,7 +165,7 @@ fn test_stake_zero_panics() {
 }
 
 #[test]
-#[should_panic(expected = "unstake amount must be greater than zero")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_unstake_zero_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -178,7 +178,7 @@ fn test_unstake_zero_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_paused_blocks_stake() {
     let env = Env::default();
     env.mock_all_auths();
@@ -236,7 +236,7 @@ fn test_pause_blocks_all_insurance_state_changes() {
 }
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_paused_blocks_unstake() {
     let env = Env::default();
     env.mock_all_auths();
@@ -440,7 +440,7 @@ fn test_payout_pro_rata_multiple_stakers_exact() {
 /// We test the most dangerous case: the invoice is Overdue (one step before
 /// Defaulted) — the payout must still revert with a clear error.
 #[test]
-#[should_panic(expected = "Invoice is not Defaulted")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_payout_rejected_when_invoice_overdue_not_defaulted() {
     use invofi_common::InvoiceStatus;
     use soroban_sdk::symbol_short;
@@ -489,7 +489,7 @@ fn test_payout_rejected_when_invoice_overdue_not_defaulted() {
 
 /// pay_out must reject when the invoice is Pending (completely wrong state).
 #[test]
-#[should_panic(expected = "Invoice is not Defaulted")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_payout_rejected_when_invoice_pending() {
     use soroban_sdk::symbol_short;
 
@@ -542,7 +542,7 @@ fn test_payout_without_caller_panics() {
 }
 
 #[test]
-#[should_panic(expected = "payout amount must be greater than zero")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_payout_zero_amount_panics() {
     use soroban_sdk::symbol_short;
 
@@ -560,7 +560,7 @@ fn test_payout_zero_amount_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_paused_blocks_payout() {
     use soroban_sdk::symbol_short;
 

--- a/integration/src/test.rs
+++ b/integration/src/test.rs
@@ -344,7 +344,7 @@ fn test_financing_repayment_partial_keeps_financed() {
 
 /// Negative test: Repaying a Pending (unfinanced) invoice must fail.
 #[test]
-#[should_panic(expected = "Invoice must be Financed before repayment")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_financing_repayment_on_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -452,7 +452,7 @@ fn test_repayment_insurance_default_triggers_payout() {
 
 /// Negative test: Reclaiming before the grace period must fail.
 #[test]
-#[should_panic(expected = "Grace period has not elapsed")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_repayment_insurance_reclaim_before_grace_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -669,7 +669,7 @@ fn test_registry_repayment_overdue_delegates_to_registry() {
 
 /// Negative test: Marking overdue on a Pending invoice must fail.
 #[test]
-#[should_panic(expected = "Only Financed invoices can be marked Overdue")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_registry_repayment_overdue_on_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -3,7 +3,8 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, Invoice, InvoiceStatus, ProtocolStats, RiskTier, MIN_INVOICE_AMOUNT,
+    assert_not_paused, ContractError, Invoice, InvoiceStatus, ProtocolStats, RiskTier,
+    MIN_INVOICE_AMOUNT,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -66,7 +67,7 @@ fn assert_not_blacklisted(env: &Env, address: &Address) {
     let list = load_blacklist(env);
     for entry in list.iter() {
         if entry == *address {
-            panic!("Address is blacklisted");
+            env.panic_with_error(ContractError::Blacklisted);
         }
     }
 }
@@ -79,7 +80,7 @@ fn assert_admin(env: &Env, caller: &Address) {
         .get(&symbol_short!("admin"))
         .unwrap_or_else(|| panic!("Not initialized"));
     if current != *caller {
-        panic!("Only the current admin can perform this action");
+        env.panic_with_error(ContractError::Unauthorized);
     }
 }
 
@@ -182,7 +183,7 @@ impl RegistryContract {
         assert_not_paused(&env);
         assert_admin(&env, &admin);
         if rate_bps > 10_000 {
-            panic!("rate_bps must be between 0 and 10000");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         let mut rates = load_rates(&env);
         rates.set(tier, rate_bps);
@@ -194,7 +195,7 @@ impl RegistryContract {
     pub fn get_rate(env: Env, tier: RiskTier) -> u32 {
         load_rates(&env)
             .get(tier)
-            .unwrap_or_else(|| panic!("Rate not set for this tier"))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound))
     }
 
     // ── Protocol fee ─────────────────────────────────────────────────────────
@@ -204,7 +205,7 @@ impl RegistryContract {
         assert_not_paused(&env);
         assert_admin(&env, &admin);
         if fee_bps > 500 {
-            panic!("fee_bps must be at most 500 (5%)");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         env.storage()
             .instance()
@@ -233,18 +234,16 @@ impl RegistryContract {
         assert_not_paused(&env);
         originator.require_auth();
         assert_not_blacklisted(&env, &originator);
-        assert!(
-            amount >= MIN_INVOICE_AMOUNT,
-            "amount must be at least MIN_INVOICE_AMOUNT stroops"
-        );
-        assert!(
-            due_date > env.ledger().timestamp(),
-            "due_date must be in the future"
-        );
+        if amount < MIN_INVOICE_AMOUNT {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        if due_date <= env.ledger().timestamp() {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
 
         let mut invoices = load_invoices(&env);
         if invoices.contains_key(id.clone()) {
-            panic!("Invoice with this ID already exists");
+            env.panic_with_error(ContractError::AlreadyExists);
         }
 
         let invoice = Invoice {
@@ -273,7 +272,7 @@ impl RegistryContract {
     pub fn get_invoice(env: Env, id: Symbol) -> Invoice {
         load_invoices(&env)
             .get(id)
-            .unwrap_or_else(|| panic!("Invoice not found"))
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound))
     }
 
     /// Manually update the status of a Pending invoice. Only the invoice
@@ -289,12 +288,12 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.originator != originator {
-            panic!("Only the invoice originator can update the status");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if invoice.status != InvoiceStatus::Pending {
-            panic!("Only Pending invoices can have their status updated");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = new_status.clone();
         invoices.set(id, invoice.clone());
@@ -316,17 +315,16 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(invoice_id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.originator != originator {
-            panic!("Only the invoice originator can update the amount");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if invoice.status != InvoiceStatus::Pending {
-            panic!("Only Pending invoices can have their amount updated");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
-        assert!(
-            new_amount >= MIN_INVOICE_AMOUNT,
-            "new_amount must be at least MIN_INVOICE_AMOUNT stroops"
-        );
+        if new_amount < MIN_INVOICE_AMOUNT {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
         invoice.amount = new_amount;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -344,12 +342,12 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(invoice_id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.originator != originator {
-            panic!("Only the invoice originator can cancel");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if invoice.status != InvoiceStatus::Pending {
-            panic!("Only Pending invoices can be cancelled");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = InvoiceStatus::Cancelled;
         invoices.set(invoice_id, invoice.clone());
@@ -376,9 +374,9 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.status != InvoiceStatus::Financed {
-            panic!("Invoice must be Financed for repayment status update");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = if fully_repaid {
             InvoiceStatus::Repaid
@@ -409,9 +407,9 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.status != InvoiceStatus::Pending {
-            panic!("Invoice must be Pending before financing");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = InvoiceStatus::Financed;
         invoices.set(id, invoice.clone());
@@ -438,9 +436,9 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.status != InvoiceStatus::Financed {
-            panic!("Invoice must be Financed before repayment");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = if fully_repaid {
             InvoiceStatus::Repaid
@@ -473,9 +471,9 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.status != InvoiceStatus::Overdue {
-            panic!("Invoice must be Overdue before defaulting");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = InvoiceStatus::Defaulted;
         invoices.set(id, invoice.clone());
@@ -495,12 +493,12 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.status != InvoiceStatus::Financed {
-            panic!("Only Financed invoices can be marked Overdue");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         if env.ledger().timestamp() <= invoice.due_date {
-            panic!("Invoice due date has not passed");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = InvoiceStatus::Overdue;
         invoices.set(id, invoice.clone());
@@ -521,12 +519,12 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(invoice_id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.originator != originator {
-            panic!("Only the invoice originator can raise a dispute");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if invoice.status != InvoiceStatus::Financed {
-            panic!("Only Financed invoices can be disputed");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         invoice.status = InvoiceStatus::Disputed;
         invoices.set(invoice_id, invoice.clone());
@@ -550,12 +548,12 @@ impl RegistryContract {
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(invoice_id.clone())
-            .unwrap_or_else(|| panic!("Invoice not found"));
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if invoice.status != InvoiceStatus::Disputed {
-            panic!("Invoice is not in Disputed status");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         if target_status == InvoiceStatus::Disputed {
-            panic!("Cannot resolve to Disputed status");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         invoice.status = target_status;
         invoices.set(invoice_id, invoice.clone());

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -39,7 +39,7 @@ fn test_register_and_get_invoice() {
 }
 
 #[test]
-#[should_panic(expected = "Invoice with this ID already exists")]
+#[should_panic(expected = "Error(Contract, #7)")]
 fn test_duplicate_invoice_id_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -57,7 +57,7 @@ fn test_duplicate_invoice_id_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Invoice not found")]
+#[should_panic(expected = "Error(Contract, #2)")]
 fn test_get_non_existent_invoice() {
     let env = Env::default();
     env.mock_all_auths();
@@ -96,7 +96,7 @@ fn test_update_invoice_status() {
 }
 
 #[test]
-#[should_panic(expected = "Only the invoice originator can update the status")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_update_invoice_status_non_originator_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -119,7 +119,7 @@ fn test_update_invoice_status_non_originator_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Only Pending invoices can have their status updated")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_update_invoice_status_on_non_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -164,7 +164,7 @@ fn test_cancel_invoice() {
 }
 
 #[test]
-#[should_panic(expected = "Only Pending invoices can be cancelled")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_cancel_non_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -211,7 +211,7 @@ fn test_update_invoice_amount() {
 }
 
 #[test]
-#[should_panic(expected = "new_amount must be at least MIN_INVOICE_AMOUNT stroops")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_update_invoice_amount_below_min_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -232,7 +232,7 @@ fn test_update_invoice_amount_below_min_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Only Pending invoices can have their amount updated")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_update_amount_on_non_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -257,7 +257,7 @@ fn test_update_amount_on_non_pending_panics() {
 // ─── Validation tests ────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "amount must be at least MIN_INVOICE_AMOUNT stroops")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_register_invoice_zero_amount() {
     let env = Env::default();
     env.mock_all_auths();
@@ -276,7 +276,7 @@ fn test_register_invoice_zero_amount() {
 }
 
 #[test]
-#[should_panic(expected = "due_date must be in the future")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_register_invoice_past_due_date() {
     let env = Env::default();
     env.mock_all_auths();
@@ -295,7 +295,7 @@ fn test_register_invoice_past_due_date() {
 }
 
 #[test]
-#[should_panic(expected = "amount must be at least MIN_INVOICE_AMOUNT stroops")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_min_invoice_amount_rejected() {
     let env = Env::default();
     env.mock_all_auths();
@@ -616,7 +616,7 @@ fn test_transfer_admin() {
 }
 
 #[test]
-#[should_panic(expected = "Only the current admin can perform this action")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_transfer_admin_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -648,7 +648,7 @@ fn test_pause_and_unpause() {
 }
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_register_invoice_while_paused_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -669,7 +669,7 @@ fn test_register_invoice_while_paused_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Only the current admin can perform this action")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_pause_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -682,7 +682,7 @@ fn test_pause_unauthorized_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_pause_blocks_transfer_admin() {
     let env = Env::default();
     env.mock_all_auths();
@@ -805,7 +805,7 @@ fn test_set_and_get_rate() {
 }
 
 #[test]
-#[should_panic(expected = "rate_bps must be between 0 and 10000")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_set_rate_out_of_range_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -817,7 +817,7 @@ fn test_set_rate_out_of_range_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Only the current admin can perform this action")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_set_rate_unauthorized_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -830,7 +830,7 @@ fn test_set_rate_unauthorized_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Rate not set for this tier")]
+#[should_panic(expected = "Error(Contract, #2)")]
 fn test_get_unset_rate_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -857,7 +857,7 @@ fn test_set_and_get_fee() {
 }
 
 #[test]
-#[should_panic(expected = "fee_bps must be at most 500")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_set_fee_too_high_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -896,7 +896,7 @@ fn test_blacklist_and_unblacklist() {
 }
 
 #[test]
-#[should_panic(expected = "Address is blacklisted")]
+#[should_panic(expected = "Error(Contract, #8)")]
 fn test_blacklisted_cannot_register_invoice() {
     let env = Env::default();
     env.mock_all_auths();
@@ -917,7 +917,7 @@ fn test_blacklisted_cannot_register_invoice() {
 }
 
 #[test]
-#[should_panic(expected = "Only the current admin can perform this action")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_blacklist_non_admin_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1013,7 +1013,7 @@ fn test_mark_invoice_overdue() {
 }
 
 #[test]
-#[should_panic(expected = "Only Financed invoices can be marked Overdue")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_mark_overdue_on_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1056,7 +1056,7 @@ fn test_raise_and_resolve_dispute() {
 }
 
 #[test]
-#[should_panic(expected = "Only Financed invoices can be disputed")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_raise_dispute_on_pending_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1160,7 +1160,7 @@ fn test_repayment_marks_defaulted_transition() {
 }
 
 #[test]
-#[should_panic(expected = "Invoice must be Overdue before defaulting")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_repayment_marks_defaulted_requires_overdue() {
     let env = Env::default();
     env.mock_all_auths();

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -3,9 +3,9 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Symbol};
 
 use invofi_common::{
-    assert_not_paused, resolve_token, FinancingClient, FinancingOffer, InsuranceClient, Invoice,
-    InvoiceStatus, OfferStatus, RegistryClient, ReputationClient, GRACE_PERIOD_SECS,
-    MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    assert_not_paused, resolve_token, ContractError, FinancingClient, FinancingOffer,
+    InsuranceClient, Invoice, InvoiceStatus, OfferStatus, RegistryClient, ReputationClient,
+    GRACE_PERIOD_SECS, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
 };
 
 // ─── Overdue penalty (ADR-0007) ──────────────────────────────────────────────
@@ -151,7 +151,7 @@ impl RepaymentContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the insurance contract");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -174,7 +174,7 @@ impl RepaymentContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the reputation contract");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -201,13 +201,13 @@ impl RepaymentContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set penalty parameters");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if penalty_bps > MAX_PENALTY_BPS {
-            panic!("penalty_bps must be at most 500 (5% per day)");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         if cap_bps > 10_000 {
-            panic!("cap_bps must be between 0 and 10000");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         env.storage()
             .instance()
@@ -237,7 +237,7 @@ impl RepaymentContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can transfer admin rights");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -254,7 +254,7 @@ impl RepaymentContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can pause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -269,7 +269,7 @@ impl RepaymentContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can unpause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -309,10 +309,10 @@ impl RepaymentContract {
         let invoice: Invoice = registry_client.get_invoice(&invoice_id);
 
         if invoice.originator != repayer {
-            panic!("Only the invoice originator can repay");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if invoice.status != InvoiceStatus::Financed {
-            panic!("Invoice must be Financed before repayment");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // Cross-contract: read offer from financing
@@ -326,10 +326,10 @@ impl RepaymentContract {
         let mut offer: FinancingOffer = financing_client.get_offer(&offer_id);
 
         if offer.invoice_id != invoice_id {
-            panic!("Offer does not belong to this invoice");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         if offer.status != OfferStatus::Accepted && offer.status != OfferStatus::Financed {
-            panic!("Offer must be Accepted or Financed before repayment");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         assert!(amount > 0, "repayment amount must be greater than zero");
 
@@ -346,10 +346,9 @@ impl RepaymentContract {
         let total_owed = total_due + penalty;
 
         let remaining_balance = total_owed - offer.amount_repaid;
-        assert!(
-            amount <= remaining_balance,
-            "Repayment amount exceeds remaining balance"
-        );
+        if amount > remaining_balance {
+            env.panic_with_error(ContractError::InsufficientBalance);
+        }
 
         // Protocol fee deduction
         let fee_bps: u32 = financing_client.get_fee_bps();
@@ -448,10 +447,10 @@ impl RepaymentContract {
         let invoice: Invoice = registry_client.get_invoice(&invoice_id);
 
         if invoice.status != InvoiceStatus::Overdue {
-            panic!("Invoice must be Overdue before reclaim");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
         if env.ledger().timestamp() < invoice.due_date + GRACE_PERIOD_SECS {
-            panic!("Grace period has not elapsed");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // Cross-contract: read offer from financing
@@ -465,13 +464,13 @@ impl RepaymentContract {
         let mut offer: FinancingOffer = financing_client.get_offer(&offer_id);
 
         if offer.invoice_id != invoice_id {
-            panic!("Offer does not belong to this invoice");
+            env.panic_with_error(ContractError::InvalidInput);
         }
         if offer.lender != lender {
-            panic!("Only the financing lender can reclaim");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         if offer.status != OfferStatus::Accepted && offer.status != OfferStatus::Financed {
-            panic!("Offer must be Accepted or Financed before reclaim");
+            env.panic_with_error(ContractError::InvalidTransition);
         }
 
         // Cross-contract: update offer status in financing

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -177,7 +177,7 @@ fn test_repay_invoice_partial_then_full() {
 // ─── Edge case tests ──────────────────────────────────────────────────────
 
 #[test]
-#[should_panic(expected = "Repayment amount exceeds remaining balance")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_repay_invoice_overpayment_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -247,7 +247,7 @@ fn test_repay_invoice_overpayment_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Invoice must be Financed before repayment")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_repay_unfinanced_invoice_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -424,7 +424,7 @@ fn test_reclaim_invoice_after_grace_period() {
 }
 
 #[test]
-#[should_panic(expected = "Grace period has not elapsed")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_reclaim_before_grace_period_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -489,7 +489,7 @@ fn test_reclaim_before_grace_period_panics() {
 }
 
 #[test]
-#[should_panic(expected = "Invoice must be Overdue before reclaim")]
+#[should_panic(expected = "Error(Contract, #3)")]
 fn test_reclaim_on_non_overdue_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -725,7 +725,7 @@ fn test_get_duration_limits() {
 // ─── Task 4A: emergency pause / circuit breaker ──────────────────────────────
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_pause_blocks_repay_invoice() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1490,7 +1490,7 @@ fn test_penalty_must_be_settled_for_full_repayment() {
 }
 
 #[test]
-#[should_panic(expected = "Repayment amount exceeds remaining balance")]
+#[should_panic(expected = "Error(Contract, #5)")]
 fn test_penalty_overpayment_beyond_accrued_total_panics() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1588,7 +1588,7 @@ fn test_penalty_excluded_from_insurance_payout() {
 }
 
 #[test]
-#[should_panic(expected = "Only the current admin can set penalty parameters")]
+#[should_panic(expected = "Error(Contract, #1)")]
 fn test_set_penalty_admin_only() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1600,7 +1600,7 @@ fn test_set_penalty_admin_only() {
 }
 
 #[test]
-#[should_panic(expected = "penalty_bps must be at most 500")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_set_penalty_rejects_excessive_rate() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1611,7 +1611,7 @@ fn test_set_penalty_rejects_excessive_rate() {
 }
 
 #[test]
-#[should_panic(expected = "cap_bps must be between 0 and 10000")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_set_penalty_rejects_excessive_cap() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1622,7 +1622,7 @@ fn test_set_penalty_rejects_excessive_cap() {
 }
 
 #[test]
-#[should_panic(expected = "Contract is paused")]
+#[should_panic(expected = "Error(Contract, #4)")]
 fn test_set_penalty_blocked_while_paused() {
     let env = Env::default();
     env.mock_all_auths();

--- a/reputation/src/lib.rs
+++ b/reputation/src/lib.rs
@@ -15,7 +15,7 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map};
 
-use invofi_common::assert_not_paused;
+use invofi_common::{assert_not_paused, ContractError};
 
 /// Outcome discriminant for a successful full repayment.
 pub const OUTCOME_REPAID: u32 = 0;
@@ -87,7 +87,7 @@ impl ReputationContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only the current admin can set the recorder");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -108,7 +108,7 @@ impl ReputationContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can pause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -123,7 +123,7 @@ impl ReputationContract {
             .get(&symbol_short!("admin"))
             .unwrap_or_else(|| panic!("Not initialized"));
         if current != admin {
-            panic!("Only admin can unpause");
+            env.panic_with_error(ContractError::Unauthorized);
         }
         env.storage()
             .instance()
@@ -155,10 +155,9 @@ impl ReputationContract {
             .get(&symbol_short!("recorder"))
             .unwrap_or_else(|| panic!("No recorder configured"));
         recorder.require_auth();
-        assert!(
-            outcome == OUTCOME_REPAID || outcome == OUTCOME_DEFAULTED,
-            "outcome must be 0 (repaid) or 1 (defaulted)"
-        );
+        if outcome != OUTCOME_REPAID && outcome != OUTCOME_DEFAULTED {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
 
         let mut records = load_records(&env);
         let mut record = records.get(originator.clone()).unwrap_or(ReputationRecord {

--- a/reputation/src/test.rs
+++ b/reputation/src/test.rs
@@ -128,7 +128,7 @@ fn test_pause_blocks_all_reputation_state_changes() {
 }
 
 #[test]
-#[should_panic(expected = "outcome must be 0 (repaid) or 1 (defaulted)")]
+#[should_panic(expected = "Error(Contract, #6)")]
 fn test_record_outcome_invalid_outcome_panics() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
…panics

Add a shared #[contracterror] enum in common with 8 stable discriminants:
  Unauthorized=1, NotFound=2, InvalidTransition=3, Paused=4,
  InsufficientBalance=5, InvalidInput=6, AlreadyExists=7, Blacklisted=8

Convert all client-facing panic! sites across registry, financing, repayment, insurance, and reputation to env.panic_with_error() using the new typed variants. True invariant panics (Not initialized, Already initialized, contract-not-configured guards) are left as panic!.

The assert_not_paused helper in common now emits ContractError::Paused instead of a string, covering every write entrypoint in all contracts.

No public function signatures changed — env.panic_with_error() keeps return types as T and surfaces errors as XDR Error(Contract, #N) so SDK/frontend/indexer can match on error codes without string parsing.

Update all should_panic(expected = "...") test annotations to match the new HostError: Error(Contract, #N) panic format.

All 163 tests pass.

Closes #93
