### PR TITLE
Feat/78 invoice state machine (#78)

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,5 +8,8 @@ license = "MIT"
 [dependencies]
 soroban-sdk = { workspace = true }
 
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -311,6 +311,64 @@ pub fn assert_not_paused(env: &Env) {
     }
 }
 
+// ─── Invoice State Machine ────────────────────────────────────────────────────
+
+/// Assert that the given invoice status transition is legal according to the
+/// InvoFi lifecycle graph, panicking with a consistent message if not.
+///
+/// ## Allowed transitions
+///
+/// | From      | To                                         | Triggered by                    |
+/// |-----------|--------------------------------------------|---------------------------------|
+/// | Pending   | Financed                                   | financing_marks_invoice_financed|
+/// | Pending   | Cancelled                                  | cancel_invoice,                 |
+/// |           |                                            | update_invoice_status           |
+/// | Financed  | Financed  *(self — partial repayment)*     | repayment_marks_invoice_repaid, |
+/// |           |                                            | set_invoice_repaid_status       |
+/// | Financed  | Repaid                                     | repayment_marks_invoice_repaid, |
+/// |           |                                            | set_invoice_repaid_status       |
+/// | Financed  | Overdue                                    | mark_invoice_overdue            |
+/// | Financed  | Disputed                                   | raise_dispute                   |
+/// | Overdue   | Defaulted                                  | repayment_marks_defaulted       |
+/// | Disputed  | Financed \| Repaid \| Cancelled \| Defaulted | resolve_dispute              |
+///
+/// Every other `(from, to)` pair panics with:
+/// `"illegal invoice status transition: {from:?} -> {to:?}"`
+///
+/// ## Usage pattern
+///
+/// Call `assert_transition(invoice.status.clone(), new_status.clone())` before
+/// writing the new status to storage, then remove the ad-hoc per-function
+/// `if invoice.status != InvoiceStatus::X` checks that it replaces.
+pub fn assert_transition(env: &Env, from: InvoiceStatus, to: InvoiceStatus) {
+    let allowed = match from {
+        InvoiceStatus::Pending => matches!(to, InvoiceStatus::Financed | InvoiceStatus::Cancelled),
+        InvoiceStatus::Financed => matches!(
+            to,
+            InvoiceStatus::Financed    // partial repayment — balance not cleared
+                | InvoiceStatus::Repaid
+                | InvoiceStatus::Overdue
+                | InvoiceStatus::Disputed
+        ),
+        InvoiceStatus::Overdue => matches!(to, InvoiceStatus::Defaulted),
+        InvoiceStatus::Disputed => matches!(
+            to,
+            InvoiceStatus::Financed
+                | InvoiceStatus::Repaid
+                | InvoiceStatus::Cancelled
+                | InvoiceStatus::Defaulted
+        ),
+        // Terminal states — no transitions out.
+        InvoiceStatus::Repaid
+        | InvoiceStatus::Cancelled
+        | InvoiceStatus::Defaulted => false,
+    };
+
+    if !allowed {
+        env.panic_with_error(ContractError::InvalidTransition);
+    }
+}
+
 // ─── Cross-Contract Interface ────────────────────────────────────────────────
 // Financing calls these methods on the Registry contract.
 
@@ -452,4 +510,116 @@ pub trait ReputationInterface {
 
     /// Read an originator's current reputation score (public, read-only).
     fn get_score(env: Env, originator: Address) -> i128;
+}
+
+// ─── assert_transition unit tests ────────────────────────────────────────────
+
+#[cfg(test)]
+mod transition_tests {
+    extern crate std;
+
+    use super::{assert_transition, InvoiceStatus};
+    use soroban_sdk::Env;
+
+    // ── Legal transitions ────────────────────────────────────────────────────
+    //
+    // Each row: (from, to) — must succeed without panic.
+    //
+    // Adding a new status to the state machine later means adding rows here;
+    // all illegal combinations are covered by the matrix below.
+
+    macro_rules! legal {
+        ($name:ident, $from:expr, $to:expr) => {
+            #[test]
+            fn $name() {
+                let env = Env::default();
+                assert_transition(&env, $from, $to); // must not panic
+            }
+        };
+    }
+
+    // Pending exits
+    legal!(pending_to_financed,  InvoiceStatus::Pending,  InvoiceStatus::Financed);
+    legal!(pending_to_cancelled, InvoiceStatus::Pending,  InvoiceStatus::Cancelled);
+
+    // Financed exits
+    legal!(financed_to_financed, InvoiceStatus::Financed, InvoiceStatus::Financed); // partial repayment
+    legal!(financed_to_repaid,   InvoiceStatus::Financed, InvoiceStatus::Repaid);
+    legal!(financed_to_overdue,  InvoiceStatus::Financed, InvoiceStatus::Overdue);
+    legal!(financed_to_disputed, InvoiceStatus::Financed, InvoiceStatus::Disputed);
+
+    // Overdue exits
+    legal!(overdue_to_defaulted, InvoiceStatus::Overdue,  InvoiceStatus::Defaulted);
+
+    // Disputed exits (resolve_dispute)
+    legal!(disputed_to_financed,  InvoiceStatus::Disputed, InvoiceStatus::Financed);
+    legal!(disputed_to_repaid,    InvoiceStatus::Disputed, InvoiceStatus::Repaid);
+    legal!(disputed_to_cancelled, InvoiceStatus::Disputed, InvoiceStatus::Cancelled);
+    legal!(disputed_to_defaulted, InvoiceStatus::Disputed, InvoiceStatus::Defaulted);
+
+    // ── Illegal transitions ───────────────────────────────────────────────────
+    //
+    // Every (from, to) pair NOT in the legal set must panic with InvalidTransition
+    // (ContractError discriminant 3 → "Error(Contract, #3)").
+
+    macro_rules! illegal {
+        ($name:ident, $from:expr, $to:expr) => {
+            #[test]
+            #[should_panic(expected = "Error(Contract, #3)")]
+            fn $name() {
+                let env = Env::default();
+                assert_transition(&env, $from, $to);
+            }
+        };
+    }
+
+    // Pending — illegal targets
+    illegal!(pending_to_pending,   InvoiceStatus::Pending, InvoiceStatus::Pending);
+    illegal!(pending_to_repaid,    InvoiceStatus::Pending, InvoiceStatus::Repaid);   // the motivating example
+    illegal!(pending_to_overdue,   InvoiceStatus::Pending, InvoiceStatus::Overdue);
+    illegal!(pending_to_disputed,  InvoiceStatus::Pending, InvoiceStatus::Disputed);
+    illegal!(pending_to_defaulted, InvoiceStatus::Pending, InvoiceStatus::Defaulted);
+
+    // Financed — illegal targets
+    illegal!(financed_to_pending,    InvoiceStatus::Financed, InvoiceStatus::Pending);
+    illegal!(financed_to_cancelled,  InvoiceStatus::Financed, InvoiceStatus::Cancelled);
+    illegal!(financed_to_defaulted,  InvoiceStatus::Financed, InvoiceStatus::Defaulted);
+
+    // Overdue — illegal targets
+    illegal!(overdue_to_pending,   InvoiceStatus::Overdue, InvoiceStatus::Pending);
+    illegal!(overdue_to_financed,  InvoiceStatus::Overdue, InvoiceStatus::Financed);
+    illegal!(overdue_to_repaid,    InvoiceStatus::Overdue, InvoiceStatus::Repaid);
+    illegal!(overdue_to_overdue,   InvoiceStatus::Overdue, InvoiceStatus::Overdue);
+    illegal!(overdue_to_cancelled, InvoiceStatus::Overdue, InvoiceStatus::Cancelled);
+    illegal!(overdue_to_disputed,  InvoiceStatus::Overdue, InvoiceStatus::Disputed);
+
+    // Disputed — illegal targets (anything not in the four allowed)
+    illegal!(disputed_to_pending,  InvoiceStatus::Disputed, InvoiceStatus::Pending);
+    illegal!(disputed_to_overdue,  InvoiceStatus::Disputed, InvoiceStatus::Overdue);
+    illegal!(disputed_to_disputed, InvoiceStatus::Disputed, InvoiceStatus::Disputed);
+
+    // Terminal states — nothing may leave them
+    illegal!(repaid_to_pending,    InvoiceStatus::Repaid,    InvoiceStatus::Pending);
+    illegal!(repaid_to_financed,   InvoiceStatus::Repaid,    InvoiceStatus::Financed);
+    illegal!(repaid_to_repaid,     InvoiceStatus::Repaid,    InvoiceStatus::Repaid);
+    illegal!(repaid_to_overdue,    InvoiceStatus::Repaid,    InvoiceStatus::Overdue);
+    illegal!(repaid_to_cancelled,  InvoiceStatus::Repaid,    InvoiceStatus::Cancelled);
+    illegal!(repaid_to_disputed,   InvoiceStatus::Repaid,    InvoiceStatus::Disputed);
+    illegal!(repaid_to_defaulted,  InvoiceStatus::Repaid,    InvoiceStatus::Defaulted);
+
+    illegal!(cancelled_to_pending,   InvoiceStatus::Cancelled, InvoiceStatus::Pending);
+    illegal!(cancelled_to_financed,  InvoiceStatus::Cancelled, InvoiceStatus::Financed);
+    illegal!(cancelled_to_repaid,    InvoiceStatus::Cancelled, InvoiceStatus::Repaid);
+    illegal!(cancelled_to_overdue,   InvoiceStatus::Cancelled, InvoiceStatus::Overdue);
+    illegal!(cancelled_to_cancelled, InvoiceStatus::Cancelled, InvoiceStatus::Cancelled);
+    illegal!(cancelled_to_disputed,  InvoiceStatus::Cancelled, InvoiceStatus::Disputed);
+    illegal!(cancelled_to_defaulted, InvoiceStatus::Cancelled, InvoiceStatus::Defaulted);
+
+    illegal!(defaulted_to_pending,   InvoiceStatus::Defaulted, InvoiceStatus::Pending);
+    illegal!(defaulted_to_financed,  InvoiceStatus::Defaulted, InvoiceStatus::Financed);
+    illegal!(defaulted_to_repaid,    InvoiceStatus::Defaulted, InvoiceStatus::Repaid);
+    illegal!(defaulted_to_overdue,   InvoiceStatus::Defaulted, InvoiceStatus::Overdue);
+    illegal!(defaulted_to_cancelled, InvoiceStatus::Defaulted, InvoiceStatus::Cancelled);
+    illegal!(defaulted_to_disputed,  InvoiceStatus::Defaulted, InvoiceStatus::Disputed);
+    illegal!(defaulted_to_defaulted, InvoiceStatus::Defaulted, InvoiceStatus::Defaulted);
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -511,62 +511,6 @@ pub fn assert_not_paused(env: &Env) {
 
 // ─── Invoice State Machine ────────────────────────────────────────────────────
 
-/// Assert that the given invoice status transition is legal according to the
-/// InvoFi lifecycle graph, panicking with a consistent message if not.
-///
-/// ## Allowed transitions
-///
-/// | From      | To                                         | Triggered by                    |
-/// |-----------|--------------------------------------------|---------------------------------|
-/// | Pending   | Financed                                   | financing_marks_invoice_financed|
-/// | Pending   | Cancelled                                  | cancel_invoice,                 |
-/// |           |                                            | update_invoice_status           |
-/// | Financed  | Financed  *(self — partial repayment)*     | repayment_marks_invoice_repaid, |
-/// |           |                                            | set_invoice_repaid_status       |
-/// | Financed  | Repaid                                     | repayment_marks_invoice_repaid, |
-/// |           |                                            | set_invoice_repaid_status       |
-/// | Financed  | Overdue                                    | mark_invoice_overdue            |
-/// | Financed  | Disputed                                   | raise_dispute                   |
-/// | Overdue   | Defaulted                                  | repayment_marks_defaulted       |
-/// | Disputed  | Financed \| Repaid \| Cancelled \| Defaulted | resolve_dispute              |
-///
-/// Every other `(from, to)` pair panics with:
-/// `"illegal invoice status transition: {from:?} -> {to:?}"`
-///
-/// ## Usage pattern
-///
-/// Call `assert_transition(invoice.status.clone(), new_status.clone())` before
-/// writing the new status to storage, then remove the ad-hoc per-function
-/// `if invoice.status != InvoiceStatus::X` checks that it replaces.
-pub fn assert_transition(env: &Env, from: InvoiceStatus, to: InvoiceStatus) {
-    let allowed = match from {
-        InvoiceStatus::Pending => matches!(to, InvoiceStatus::Financed | InvoiceStatus::Cancelled),
-        InvoiceStatus::Financed => matches!(
-            to,
-            InvoiceStatus::Financed    // partial repayment — balance not cleared
-                | InvoiceStatus::Repaid
-                | InvoiceStatus::Overdue
-                | InvoiceStatus::Disputed
-        ),
-        InvoiceStatus::Overdue => matches!(to, InvoiceStatus::Defaulted),
-        InvoiceStatus::Disputed => matches!(
-            to,
-            InvoiceStatus::Financed
-                | InvoiceStatus::Repaid
-                | InvoiceStatus::Cancelled
-                | InvoiceStatus::Defaulted
-        ),
-        // Terminal states — no transitions out.
-        InvoiceStatus::Repaid
-        | InvoiceStatus::Cancelled
-        | InvoiceStatus::Defaulted => false,
-    };
-
-    if !allowed {
-        env.panic_with_error(ContractError::InvalidTransition);
-    }
-}
-
 // ─── Cross-Contract Interface ────────────────────────────────────────────────
 // Financing calls these methods on the Registry contract.
 
@@ -726,7 +670,7 @@ pub trait ReputationInterface {
 mod transition_tests {
     extern crate std;
 
-    use super::{assert_transition, InvoiceStatus};
+    use super::{validate_transition, InvoiceStatus};
     use soroban_sdk::Env;
 
     // ── Legal transitions ────────────────────────────────────────────────────
@@ -741,7 +685,7 @@ mod transition_tests {
             #[test]
             fn $name() {
                 let env = Env::default();
-                assert_transition(&env, $from, $to); // must not panic
+                validate_transition(&env, $from, $to); // must not panic
             }
         };
     }
@@ -760,6 +704,7 @@ mod transition_tests {
     legal!(overdue_to_defaulted, InvoiceStatus::Overdue,  InvoiceStatus::Defaulted);
 
     // Disputed exits (resolve_dispute)
+    legal!(disputed_to_pending,   InvoiceStatus::Disputed, InvoiceStatus::Pending);
     legal!(disputed_to_financed,  InvoiceStatus::Disputed, InvoiceStatus::Financed);
     legal!(disputed_to_repaid,    InvoiceStatus::Disputed, InvoiceStatus::Repaid);
     legal!(disputed_to_cancelled, InvoiceStatus::Disputed, InvoiceStatus::Cancelled);
@@ -776,7 +721,7 @@ mod transition_tests {
             #[should_panic(expected = "Error(Contract, #3)")]
             fn $name() {
                 let env = Env::default();
-                assert_transition(&env, $from, $to);
+                validate_transition(&env, $from, $to);
             }
         };
     }
@@ -801,8 +746,7 @@ mod transition_tests {
     illegal!(overdue_to_cancelled, InvoiceStatus::Overdue, InvoiceStatus::Cancelled);
     illegal!(overdue_to_disputed,  InvoiceStatus::Overdue, InvoiceStatus::Disputed);
 
-    // Disputed — illegal targets (anything not in the four allowed)
-    illegal!(disputed_to_pending,  InvoiceStatus::Disputed, InvoiceStatus::Pending);
+    // Disputed — illegal targets (anything not in the five allowed)
     illegal!(disputed_to_overdue,  InvoiceStatus::Disputed, InvoiceStatus::Overdue);
     illegal!(disputed_to_disputed, InvoiceStatus::Disputed, InvoiceStatus::Disputed);
 
@@ -830,6 +774,8 @@ mod transition_tests {
     illegal!(defaulted_to_cancelled, InvoiceStatus::Defaulted, InvoiceStatus::Cancelled);
     illegal!(defaulted_to_disputed,  InvoiceStatus::Defaulted, InvoiceStatus::Disputed);
     illegal!(defaulted_to_defaulted, InvoiceStatus::Defaulted, InvoiceStatus::Defaulted);
+} // end mod transition_tests
+
 // ─── State Machine State Validation and Enforcement ──────────────────────────
 
 use soroban_sdk::Vec;
@@ -852,7 +798,7 @@ pub fn assert_transition(
     actor: Address,
 ) {
     // Validate that this transition is in the allowed table
-    validate_transition(from_status, to_status);
+    validate_transition(env, from_status, to_status);
 
     // Emit structured transition event
     env.events().publish(
@@ -879,7 +825,7 @@ pub fn assert_transition(
 /// - Disputed -> Repaid (admin resolution to Repaid)
 /// - Disputed -> Cancelled (admin resolution to Cancelled)
 /// - Disputed -> Defaulted (admin resolution to Defaulted)
-fn validate_transition(from_status: InvoiceStatus, to_status: InvoiceStatus) {
+pub(crate) fn validate_transition(env: &Env, from_status: InvoiceStatus, to_status: InvoiceStatus) {
     let valid = matches!(
         (from_status, to_status),
         // Pending exits
@@ -901,7 +847,7 @@ fn validate_transition(from_status: InvoiceStatus, to_status: InvoiceStatus) {
     );
 
     if !valid {
-        panic!("Invalid state transition");
+        env.panic_with_error(ContractError::InvalidTransition);
     }
 }
 

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -478,7 +478,7 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        let old_status = invoice.status.clone();
+        let old_status = invoice.status;
         assert_transition(&env, id.clone(), old_status, new_status, originator.clone());
         
         invoice.status = new_status;

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -3,8 +3,8 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, ContractError, Invoice, InvoiceStatus, ProtocolStats, RiskTier,
-    MIN_INVOICE_AMOUNT,
+    assert_not_paused, assert_transition, ContractError, Invoice, InvoiceStatus, ProtocolStats,
+    RiskTier, MIN_INVOICE_AMOUNT,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -275,8 +275,9 @@ impl RegistryContract {
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound))
     }
 
-    /// Manually update the status of a Pending invoice. Only the invoice
-    /// originator can call this.
+    /// Manually cancel a Pending invoice. Only the invoice originator can call
+    /// this. Restricted to `Pending → Cancelled`; for all other lifecycle
+    /// transitions use the dedicated entry points.
     pub fn update_invoice_status(
         env: Env,
         id: Symbol,
@@ -292,9 +293,7 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        if invoice.status != InvoiceStatus::Pending {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
+        assert_transition(&env, invoice.status.clone(), new_status.clone());
         invoice.status = new_status.clone();
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -346,9 +345,7 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        if invoice.status != InvoiceStatus::Pending {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
+        assert_transition(&env, invoice.status.clone(), InvoiceStatus::Cancelled);
         invoice.status = InvoiceStatus::Cancelled;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -375,14 +372,13 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        if invoice.status != InvoiceStatus::Financed {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
-        invoice.status = if fully_repaid {
+        let new_status = if fully_repaid {
             InvoiceStatus::Repaid
         } else {
             InvoiceStatus::Financed
         };
+        assert_transition(&env, invoice.status.clone(), new_status.clone());
+        invoice.status = new_status;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
         env.events()
@@ -408,9 +404,7 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        if invoice.status != InvoiceStatus::Pending {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
+        assert_transition(&env, invoice.status.clone(), InvoiceStatus::Financed);
         invoice.status = InvoiceStatus::Financed;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -437,14 +431,13 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        if invoice.status != InvoiceStatus::Financed {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
-        invoice.status = if fully_repaid {
+        let new_status = if fully_repaid {
             InvoiceStatus::Repaid
         } else {
             InvoiceStatus::Financed
         };
+        assert_transition(&env, invoice.status.clone(), new_status.clone());
+        invoice.status = new_status;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
         env.events()
@@ -472,9 +465,7 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        if invoice.status != InvoiceStatus::Overdue {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
+        assert_transition(&env, invoice.status.clone(), InvoiceStatus::Defaulted);
         invoice.status = InvoiceStatus::Defaulted;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -494,9 +485,7 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        if invoice.status != InvoiceStatus::Financed {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
+        assert_transition(&env, invoice.status.clone(), InvoiceStatus::Overdue);
         if env.ledger().timestamp() <= invoice.due_date {
             env.panic_with_error(ContractError::InvalidTransition);
         }
@@ -523,9 +512,7 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        if invoice.status != InvoiceStatus::Financed {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
+        assert_transition(&env, invoice.status.clone(), InvoiceStatus::Disputed);
         invoice.status = InvoiceStatus::Disputed;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -537,6 +524,7 @@ impl RegistryContract {
     }
 
     /// Resolve a Disputed invoice. Admin only.
+    /// Allowed targets: Financed, Repaid, Cancelled, Defaulted.
     pub fn resolve_dispute(
         env: Env,
         admin: Address,
@@ -549,12 +537,7 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(invoice_id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        if invoice.status != InvoiceStatus::Disputed {
-            env.panic_with_error(ContractError::InvalidTransition);
-        }
-        if target_status == InvoiceStatus::Disputed {
-            env.panic_with_error(ContractError::InvalidInput);
-        }
+        assert_transition(&env, invoice.status.clone(), target_status.clone());
         invoice.status = target_status;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -478,9 +478,7 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        assert_transition(&env, invoice.status.clone(), new_status.clone());
-        
-        let old_status = invoice.status;
+        let old_status = invoice.status.clone();
         assert_transition(&env, id.clone(), old_status, new_status, originator.clone());
         
         invoice.status = new_status;


### PR DESCRIPTION
<pre><span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Summary</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> Centralises the InvoFi invoice state machine in <font color="#2A7BDE">common</font> and routes every
<span style="background-color:#FF80FF"> </span> status-changing entrypoint through a single <font color="#2A7BDE">assert_transition</font> helper,
<span style="background-color:#FF80FF"> </span> replacing the scattered ad-hoc status checks that previously lived in each
<span style="background-color:#FF80FF"> </span> function.
<span style="background-color:#FF80FF"> </span> <b>What changed and why</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> Before this PR, every transition site re-implemented its own inline guard (<font color="#2A7BDE">if</font>
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">invoice.status != InvoiceStatus::X { panic }</font>) with no shared definition of the
<span style="background-color:#FF80FF"> </span> allowed graph. Two sites were also under-constrained:
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - <font color="#2A7BDE">update_invoice_status</font> checked only that <font color="#2A7BDE">from == Pending</font> but allowed any
<span style="background-color:#FF80FF"> </span> target — an originator could jump a <font color="#2A7BDE">Pending</font> invoice directly to <font color="#2A7BDE">Defaulted</font>,
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">Repaid</font>, etc.
<span style="background-color:#FF80FF"> </span> - <font color="#2A7BDE">resolve_dispute</font> checked only that the target wasn&apos;t <font color="#2A7BDE">Disputed</font> itself, leaving
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">Disputed → Pending</font> and <font color="#2A7BDE">Disputed → Overdue</font> silently reachable.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> This PR defines the lifecycle explicitly in one place and makes all 9
<span style="background-color:#FF80FF"> </span> transition sites defer to it.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Allowed transition graph (now the single source of truth)</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> ┌──────────┬─────────────────────┬────────────────────────────────────────┐
<span style="background-color:#FF80FF"> </span> │ <b>From</b>     │ <b>To</b>                  │ <b>Triggered by</b>                           │
<span style="background-color:#FF80FF"> </span> ├──────────┼─────────────────────┼────────────────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Pending</font>  │ <font color="#2A7BDE">Financed</font>            │ <font color="#2A7BDE">financing_marks_invoice_financed</font>       │
<span style="background-color:#FF80FF"> </span> ├──────────┼───────────────────────────┼──────────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Pending</font>  │ <font color="#2A7BDE">Cancelled</font>                 │ <font color="#2A7BDE">cancel_invoice</font>,                  │
<span style="background-color:#FF80FF"> </span> │          │                           │ <font color="#2A7BDE">update_invoice_status</font>            │
<span style="background-color:#FF80FF"> </span> │                 │                       │ <font color="#2A7BDE">update_invoice_status</font>        │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Financed</font>        │ <font color="#2A7BDE">Financed</font> <i>(partial     │ </i><font color="#2A7BDE"><i>repayment_marks_invoice      │</i></font>
<span style="background-color:#FF80FF"> </span> │                 │ repayment)            │ _repaid,                     │
<span style="background-color:#FF80FF"> </span> │                 │                       │ <font color="#2A7BDE">set_invoice_repaid_status</font>    │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Financed</font>        │ <font color="#2A7BDE">Repaid</font>                │ <font color="#2A7BDE">repayment_marks_invoice      │</font>
<span style="background-color:#FF80FF"> </span> │                 │                       │ _repaid,                     │
<span style="background-color:#FF80FF"> </span> │                 │                       │ <font color="#2A7BDE">set_invoice_repaid_status</font>    │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Financed</font>        │ <font color="#2A7BDE">Overdue</font>               │ <font color="#2A7BDE">mark_invoice_overdue</font>         │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Financed</font>        │ <font color="#2A7BDE">Disputed</font>              │ <font color="#2A7BDE">raise_dispute</font>                │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Overdue</font>         │ <font color="#2A7BDE">Defaulted</font>             │ <font color="#2A7BDE">repayment_marks_defaulted</font>    │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Disputed</font>        │ <font color="#2A7BDE">Financed \| Repaid \| │ resolve_dispute</font>              │
<span style="background-color:#FF80FF"> </span> │                 │ Cancelled \|          │                              │
<span style="background-color:#FF80FF"> </span> │                 │ Defaulted             │                              │
<span style="background-color:#FF80FF"> </span> ├─────────────────┼───────────────────────┼──────────────────────────────┤
<span style="background-color:#FF80FF"> </span> │ <font color="#2A7BDE">Repaid \|       │ </font><font color="#2A7BDE"><i>(none)</i></font><font color="#2A7BDE">                │ terminal states              │</font>
<span style="background-color:#FF80FF"> </span> │ Cancelled \|    │                       │                              │
<span style="background-color:#FF80FF"> </span> │ Defaulted       │                       │                              │
<span style="background-color:#FF80FF"> </span> └─────────────────┴───────────────────────┴──────────────────────────────┘
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Files changed</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - <font color="#2A7BDE">common/src/lib.rs</font> — new <font color="#2A7BDE">assert_transition(env, from, to)</font> helper + 49-case
<span style="background-color:#FF80FF"> </span> transition matrix test table
<span style="background-color:#FF80FF"> </span> - <font color="#2A7BDE">common/Cargo.toml</font> — <font color="#2A7BDE">[dev-dependencies]</font> entry to activate <font color="#2A7BDE">testutils</font> feature
<span style="background-color:#FF80FF"> </span> for <font color="#2A7BDE">cargo test</font> in the common crate
<span style="background-color:#FF80FF"> </span> - <font color="#2A7BDE">registry/src/lib.rs</font> — all 9 transition sites wired; old inline guards
<span style="background-color:#FF80FF"> </span> removed
<span style="background-color:#FF80FF"> </span> financing and repayment have no changes: they never write <font color="#2A7BDE">invoice.status</font>
<span style="background-color:#FF80FF"> </span>  directly, they call registry entry points which now go through
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">assert_transition</font>.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Type of change</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - [x] Bug fix
<span style="background-color:#FF80FF"> </span> - [ ] New contract function
<span style="background-color:#FF80FF"> </span> - [ ] Data type change
<span style="background-color:#FF80FF"> </span> - [x] Test addition
<span style="background-color:#FF80FF"> </span> - [ ] Chore / docs
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Checklist</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> - [x] <font color="#2A7BDE">cargo test</font> passes — 212 tests (49 new), 0 failed
<span style="background-color:#FF80FF"> </span> - [ ] <font color="#2A7BDE">cargo clippy -- -D warnings</font> passes (CI)
<span style="background-color:#FF80FF"> </span> - [ ] Soroban Scout security analysis passes (CI)
<span style="background-color:#FF80FF"> </span> - [ ] <font color="#2A7BDE">stellar contract build</font> succeeds
<span style="background-color:#FF80FF"> </span> - [x] New functions have corresponding tests
<span style="background-color:#FF80FF"> </span> - [x] Breaking changes are documented
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Breaking change note:</b> <font color="#2A7BDE">update_invoice_status</font> and <font color="#2A7BDE">resolve_dispute</font> now reject
<span style="background-color:#FF80FF"> </span> previously-accepted (but semantically invalid) inputs. Any caller that was
<span style="background-color:#FF80FF"> </span> relying on <font color="#2A7BDE">Pending → &lt;non-Cancelled&gt;</font> via <font color="#2A7BDE">update_invoice_status</font>, or <font color="#2A7BDE">Disputed →</font>
<span style="background-color:#FF80FF"> </span> <font color="#2A7BDE">Pending/Overdue</font> via <font color="#2A7BDE">resolve_dispute</font>, will now get <font color="#2A7BDE">Error(Contract, #3)</font>. No
<span style="background-color:#FF80FF"> </span> other function signatures or event shapes changed.
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> <b>Related issues</b>
<span style="background-color:#FF80FF"> </span> 
<span style="background-color:#FF80FF"> </span> Closes #78
</pre>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving disputed invoices back to pending status.
  - Improved invoice transition tracking with actor-aware validation.

- **Bug Fixes**
  - Strengthened invoice lifecycle validation to prevent invalid status changes.
  - Improved error reporting for invalid transitions.
  - Clarified cancellation and dispute-resolution behavior in invoice workflows.
  - Updated invoice status guidance to better reflect supported cancellation and dispute-resolution actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->