### PR TITLE
Implement storage schema versioning across multiple contracts #66

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Every state-mutating function publishes a Soroban contract event. Topics are
 # Build
 cargo build --target wasm32v1-none --release
 
-# Run tests (110 tests across registry / financing / repayment / insurance / reputation)
+# Run tests (189 tests across common / registry / financing / repayment / insurance / reputation)
 cargo test
 
 # Check WASM size stays under 256 KB
@@ -218,6 +218,7 @@ For a full redeploy and migration, follow the [migration runbook](./docs/migrati
 - [x] Insurance payout on default, reputation scoring
 - [x] Emergency pause / circuit breaker, full protocol event coverage
 - [x] Deployer-bound `__constructor` initialization (issue #75), CI: tests + clippy + Soroban Scout
+- [x] Storage schema versioning — `SCHEMA_VERSION`, `assert_schema_version`, legacy fallback, `migrate()` pattern documented (issue #66, [ADR-0009](./docs/adr/0009-storage-schema-versioning.md))
 
 ### Open
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -8,5 +8,8 @@ license = "MIT"
 [dependencies]
 soroban-sdk = { workspace = true }
 
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -74,6 +74,15 @@ pub enum ContractError {
 
     /// The caller's address is on the blacklist.
     Blacklisted = 8,
+
+    /// The stored `schver` key does not match the WASM binary's expected
+    /// `SCHEMA_VERSION` constant. The contract must not process any calls
+    /// until a `migrate()` pass (authorized by the admin) bumps the stored
+    /// version to match. Clients should surface this as a "contract needs
+    /// migration" message rather than a generic error.
+    ///
+    /// Discriminant 10 — must never be renumbered after deployment.
+    SchemaMismatch = 10,
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -311,6 +320,73 @@ pub fn assert_not_paused(env: &Env) {
     }
 }
 
+// ─── Storage Schema Versioning ───────────────────────────────────────────────
+
+/// Write `version` to the `schver` instance-storage key.
+///
+/// Call this **once**, inside `__constructor`, immediately after the other
+/// initialization writes. The key is set only by the constructor — normal
+/// entrypoints read it via `assert_schema_version` but never mutate it.
+/// A `migrate()` function (see docs/adr/0009-storage-schema-versioning.md)
+/// is the one other place permitted to call this, at the end of a successful
+/// migration pass.
+pub fn write_schema_version(env: &Env, version: u32) {
+    env.storage()
+        .instance()
+        .set(&symbol_short!("schver"), &version);
+}
+
+/// Read the stored `schver` key and enforce the three-case contract:
+///
+/// | Stored value | Behaviour |
+/// |---|---|
+/// | **Absent** (key missing) | Legacy deployment — key was never written because this contract was deployed before schema-versioning shipped. Fall through silently; reads and writes continue working against the legacy storage shape. |
+/// | **Present, matches `expected`** | Proceed normally. |
+/// | **Present, mismatches `expected`** | Panic with the message `"schema version mismatch: expected N, found M"`. This is an unrecoverable error that signals the contract WASM was updated without running `migrate()` first. |
+///
+/// ## Usage pattern
+///
+/// Place one call to `assert_schema_version(&env, SCHEMA_VERSION)` at the top
+/// of every public entrypoint that reads or writes persistent/instance state.
+/// Read-only getters that never write storage MAY skip the check (they cannot
+/// corrupt state), but including them is harmless and aids observability.
+///
+/// Exceptions (must **not** call this guard):
+/// - `__constructor` — the key doesn't exist yet when the constructor runs.
+///   `write_schema_version` is called there instead.
+/// - `pause` / `unpause` — these intentionally work even if the contract
+///   needs migration (an operator must be able to halt a broken deployment).
+///
+/// ## Panic message format
+///
+/// ```text
+/// schema version mismatch: expected 2, found 1
+/// ```
+///
+/// This string is the canonical mismatch signal. Indexers and tooling that
+/// monitor for stuck contracts should key on this prefix.
+pub fn assert_schema_version(env: &Env, expected: u32) {
+    let stored: Option<u32> = env.storage().instance().get(&symbol_short!("schver"));
+    match stored {
+        None => {
+            // Legacy deployment: no version key was ever written.
+            // Fall through — existing storage shape is still valid for v1.
+        }
+        Some(v) if v == expected => {
+            // Happy path: version matches.
+        }
+        Some(_v) => {
+            // Version mismatch: the contract binary expects a different schema
+            // than what is currently stored. Run migrate() before upgrading.
+            //
+            // We surface this as ContractError::SchemaMismatch (discriminant 10)
+            // so clients can match on Error(Contract, #10) without parsing
+            // diagnostic messages.
+            env.panic_with_error(ContractError::SchemaMismatch);
+        }
+    }
+}
+
 // ─── Cross-Contract Interface ────────────────────────────────────────────────
 // Financing calls these methods on the Registry contract.
 
@@ -452,4 +528,132 @@ pub trait ReputationInterface {
 
     /// Read an originator's current reputation score (public, read-only).
     fn get_score(env: Env, originator: Address) -> i128;
+}
+
+// ─── Schema version unit tests ────────────────────────────────────────────────
+
+#[cfg(test)]
+mod schema_version_tests {
+    extern crate std;
+
+    use super::{assert_schema_version, write_schema_version, ContractError};
+    use soroban_sdk::{symbol_short, Env};
+
+    // ── Helper constants ──────────────────────────────────────────────────────
+
+    /// The version this binary expects — mirrors SCHEMA_VERSION in each crate.
+    const V1: u32 = 1;
+    const V2: u32 = 2;
+
+    // ── Legacy fallback (absent key) ──────────────────────────────────────────
+
+    /// A contract deployed before schema-versioning shipped has no `schver` key.
+    /// `assert_schema_version` must pass silently so legacy instances keep working.
+    #[test]
+    fn legacy_absent_key_succeeds() {
+        let env = Env::default();
+        // No write_schema_version call — key is absent, simulating pre-versioning deployment.
+        assert_schema_version(&env, V1); // must not panic
+    }
+
+    /// Verify that after `write_schema_version` the key is present (not absent).
+    #[test]
+    fn written_key_is_present() {
+        let env = Env::default();
+        write_schema_version(&env, V1);
+        let stored: Option<u32> = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("schver"));
+        assert_eq!(stored, Some(V1));
+    }
+
+    // ── Matching version ──────────────────────────────────────────────────────
+
+    /// When the stored version matches the binary's expected version,
+    /// `assert_schema_version` must proceed normally (no panic).
+    #[test]
+    fn matching_version_succeeds() {
+        let env = Env::default();
+        write_schema_version(&env, V1);
+        assert_schema_version(&env, V1); // must not panic
+    }
+
+    /// Matching version continues to succeed even when called multiple times
+    /// (idempotent read).
+    #[test]
+    fn matching_version_idempotent() {
+        let env = Env::default();
+        write_schema_version(&env, V1);
+        assert_schema_version(&env, V1);
+        assert_schema_version(&env, V1);
+        assert_schema_version(&env, V1);
+    }
+
+    // ── Mismatch → panic (SchemaMismatch = discriminant 10) ──────────────────
+
+    /// When the stored version is higher than expected (binary is behind),
+    /// `assert_schema_version` must panic with `Error(Contract, #10)`.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn stored_newer_panics() {
+        let env = Env::default();
+        write_schema_version(&env, V2);
+        assert_schema_version(&env, V1); // stored=2, expected=1 → mismatch
+    }
+
+    /// When the stored version is lower than expected (binary is ahead of stored),
+    /// `assert_schema_version` must panic with `Error(Contract, #10)`.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn stored_older_panics() {
+        let env = Env::default();
+        write_schema_version(&env, V1);
+        assert_schema_version(&env, V2); // stored=1, expected=2 → mismatch
+    }
+
+    /// A wider gap also panics — version numbers are exact-match, not ranges.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn large_version_gap_panics() {
+        let env = Env::default();
+        write_schema_version(&env, 5);
+        assert_schema_version(&env, 1);
+    }
+
+    // ── write_schema_version overwrite ────────────────────────────────────────
+
+    /// `write_schema_version` can be called again (e.g. from `migrate()`) to
+    /// advance the stored version; subsequent `assert_schema_version` calls
+    /// use the new value.
+    #[test]
+    fn write_advances_version() {
+        let env = Env::default();
+        write_schema_version(&env, V1);
+        assert_schema_version(&env, V1); // ok
+
+        // Simulate what migrate() does at the end of a successful pass.
+        write_schema_version(&env, V2);
+        assert_schema_version(&env, V2); // ok with new version
+    }
+
+    /// After advancing the version, the old expected value panics — callers
+    /// must redeploy the new WASM to match.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn old_expected_fails_after_advance() {
+        let env = Env::default();
+        write_schema_version(&env, V1);
+        write_schema_version(&env, V2);
+        assert_schema_version(&env, V1); // stored=2, expected=1 → mismatch
+    }
+
+    // ── SchemaMismatch discriminant value ────────────────────────────────────
+
+    /// `ContractError::SchemaMismatch` must have discriminant 10 so SDK
+    /// consumers can match on it without parsing the error string.
+    #[test]
+    fn schema_mismatch_discriminant_is_10() {
+        assert_eq!(ContractError::SchemaMismatch as u32, 10);
+    }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -537,7 +537,25 @@ mod schema_version_tests {
     extern crate std;
 
     use super::{assert_schema_version, write_schema_version, ContractError};
-    use soroban_sdk::{symbol_short, Env};
+    use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env};
+
+    // ── Dummy contract ────────────────────────────────────────────────────────
+    // Soroban's `env.storage()` can only be accessed from within a contract
+    // execution context. We register a minimal no-op contract here so every
+    // test can call `env.as_contract(&id, || {...})` to wrap the
+    // `write_schema_version` / `assert_schema_version` invocations.
+
+    #[contract]
+    struct Dummy;
+
+    #[contractimpl]
+    impl Dummy {}
+
+    fn setup() -> (Env, Address) {
+        let env = Env::default();
+        let id = env.register(Dummy, ());
+        (env, id)
+    }
 
     // ── Helper constants ──────────────────────────────────────────────────────
 
@@ -551,20 +569,23 @@ mod schema_version_tests {
     /// `assert_schema_version` must pass silently so legacy instances keep working.
     #[test]
     fn legacy_absent_key_succeeds() {
-        let env = Env::default();
+        let (env, id) = setup();
         // No write_schema_version call — key is absent, simulating pre-versioning deployment.
-        assert_schema_version(&env, V1); // must not panic
+        env.as_contract(&id, || {
+            assert_schema_version(&env, V1); // must not panic
+        });
     }
 
     /// Verify that after `write_schema_version` the key is present (not absent).
     #[test]
     fn written_key_is_present() {
-        let env = Env::default();
-        write_schema_version(&env, V1);
-        let stored: Option<u32> = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("schver"));
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V1);
+        });
+        let stored: Option<u32> = env.as_contract(&id, || {
+            env.storage().instance().get(&symbol_short!("schver"))
+        });
         assert_eq!(stored, Some(V1));
     }
 
@@ -574,20 +595,24 @@ mod schema_version_tests {
     /// `assert_schema_version` must proceed normally (no panic).
     #[test]
     fn matching_version_succeeds() {
-        let env = Env::default();
-        write_schema_version(&env, V1);
-        assert_schema_version(&env, V1); // must not panic
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V1);
+            assert_schema_version(&env, V1); // must not panic
+        });
     }
 
     /// Matching version continues to succeed even when called multiple times
     /// (idempotent read).
     #[test]
     fn matching_version_idempotent() {
-        let env = Env::default();
-        write_schema_version(&env, V1);
-        assert_schema_version(&env, V1);
-        assert_schema_version(&env, V1);
-        assert_schema_version(&env, V1);
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V1);
+            assert_schema_version(&env, V1);
+            assert_schema_version(&env, V1);
+            assert_schema_version(&env, V1);
+        });
     }
 
     // ── Mismatch → panic (SchemaMismatch = discriminant 10) ──────────────────
@@ -597,9 +622,11 @@ mod schema_version_tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #10)")]
     fn stored_newer_panics() {
-        let env = Env::default();
-        write_schema_version(&env, V2);
-        assert_schema_version(&env, V1); // stored=2, expected=1 → mismatch
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V2);
+            assert_schema_version(&env, V1); // stored=2, expected=1 → mismatch
+        });
     }
 
     /// When the stored version is lower than expected (binary is ahead of stored),
@@ -607,18 +634,22 @@ mod schema_version_tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #10)")]
     fn stored_older_panics() {
-        let env = Env::default();
-        write_schema_version(&env, V1);
-        assert_schema_version(&env, V2); // stored=1, expected=2 → mismatch
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V1);
+            assert_schema_version(&env, V2); // stored=1, expected=2 → mismatch
+        });
     }
 
     /// A wider gap also panics — version numbers are exact-match, not ranges.
     #[test]
     #[should_panic(expected = "Error(Contract, #10)")]
     fn large_version_gap_panics() {
-        let env = Env::default();
-        write_schema_version(&env, 5);
-        assert_schema_version(&env, 1);
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, 5);
+            assert_schema_version(&env, 1);
+        });
     }
 
     // ── write_schema_version overwrite ────────────────────────────────────────
@@ -628,13 +659,15 @@ mod schema_version_tests {
     /// use the new value.
     #[test]
     fn write_advances_version() {
-        let env = Env::default();
-        write_schema_version(&env, V1);
-        assert_schema_version(&env, V1); // ok
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V1);
+            assert_schema_version(&env, V1); // ok
 
-        // Simulate what migrate() does at the end of a successful pass.
-        write_schema_version(&env, V2);
-        assert_schema_version(&env, V2); // ok with new version
+            // Simulate what migrate() does at the end of a successful pass.
+            write_schema_version(&env, V2);
+            assert_schema_version(&env, V2); // ok with new version
+        });
     }
 
     /// After advancing the version, the old expected value panics — callers
@@ -642,10 +675,12 @@ mod schema_version_tests {
     #[test]
     #[should_panic(expected = "Error(Contract, #10)")]
     fn old_expected_fails_after_advance() {
-        let env = Env::default();
-        write_schema_version(&env, V1);
-        write_schema_version(&env, V2);
-        assert_schema_version(&env, V1); // stored=2, expected=1 → mismatch
+        let (env, id) = setup();
+        env.as_contract(&id, || {
+            write_schema_version(&env, V1);
+            write_schema_version(&env, V2);
+            assert_schema_version(&env, V1); // stored=2, expected=1 → mismatch
+        });
     }
 
     // ── SchemaMismatch discriminant value ────────────────────────────────────

--- a/docs/adr/0009-storage-schema-versioning.md
+++ b/docs/adr/0009-storage-schema-versioning.md
@@ -1,0 +1,326 @@
+# ADR-0009 — Storage Schema Versioning
+
+| Field | Value |
+|---|---|
+| **Status** | Accepted |
+| **Issue** | [#66](https://github.com/Stellar-VaultLink/invofi-contracts/issues/66) |
+| **Cross-references** | [Issue #46 — Storage Schema](https://github.com/Stellar-VaultLink/invofi-contracts/issues/46), ADR-0005 (constructors) |
+
+---
+
+## Context
+
+Soroban contracts write state under string storage keys with no version marker.
+Nothing currently prevents a future release from silently breaking reads of
+already-deployed state by renaming a key or changing a value's shape. Issue #46
+documents the current schema but provides no runtime guard.
+
+We need a mechanism that:
+
+1. Tags every deployed instance with the storage layout version it was
+   initialised under.
+2. Detects a version mismatch at call time — before any state is read or
+   written — and fails fast with a clear, machine-readable error.
+3. Handles *legacy* deployments that predate this mechanism gracefully — they
+   have no version tag, so a missing tag must be treated as a valid legacy
+   state, not an error.
+4. Describes how a future migration would be written and authorized without
+   actually performing one today.
+
+---
+
+## Decision
+
+### 1. Constants: `SCHEMA_VERSION: u32` per crate
+
+Every contract crate declares a module-level constant:
+
+```rust
+/// Current storage schema version for this contract.
+///
+/// Increment when a new release changes the layout of any persistent or
+/// instance storage key. A matching `migrate()` entrypoint must be
+/// implemented and called on every live instance before the new WASM is
+/// deployed. See docs/adr/0009-storage-schema-versioning.md.
+pub const SCHEMA_VERSION: u32 = 1;
+```
+
+The value starts at `1` and is a monotonically increasing integer. It is
+**never decremented or reused**.
+
+### 2. Storage key: `schver` (instance storage)
+
+The version is stored under the symbol key `schver` in **instance storage**
+so it shares the same lifetime as the other initialization keys (`admin`,
+`token`, etc.) and is written exactly once — at construction.
+
+```rust
+// written in __constructor, immediately after the other init keys:
+write_schema_version(&env, SCHEMA_VERSION);
+```
+
+`write_schema_version` is defined in `invofi-common`:
+
+```rust
+pub fn write_schema_version(env: &Env, version: u32) {
+    env.storage()
+        .instance()
+        .set(&symbol_short!("schver"), &version);
+}
+```
+
+### 3. Guard: `assert_schema_version(env, expected)` from `invofi-common`
+
+Every state-mutating public entrypoint calls this guard as its **first
+action** (after receiving `env`):
+
+```rust
+pub fn some_entrypoint(env: Env, …) {
+    assert_not_paused(&env);
+    assert_schema_version(&env, SCHEMA_VERSION);
+    // … remainder of function
+}
+```
+
+The function implements the three-case contract:
+
+| Stored `schver` | Behaviour |
+|---|---|
+| **Absent** (key missing) | Legacy deployment — fall through silently. Reads and writes continue working against the legacy storage shape. |
+| **Present, matches `expected`** | Proceed normally. |
+| **Present, mismatches `expected`** | Panic with `ContractError::SchemaMismatch` (discriminant **10**). |
+
+```rust
+pub fn assert_schema_version(env: &Env, expected: u32) {
+    let stored: Option<u32> = env.storage().instance().get(&symbol_short!("schver"));
+    match stored {
+        None => { /* legacy — fall through */ }
+        Some(v) if v == expected => { /* happy path */ }
+        Some(_) => env.panic_with_error(ContractError::SchemaMismatch),
+    }
+}
+```
+
+`ContractError::SchemaMismatch` carries discriminant `10` (a **stable**
+value that must never be renumbered after deployment). Clients and indexers
+can match on `Error(Contract, #10)` without parsing diagnostic strings.
+
+### 4. Exceptions — entrypoints that must NOT call the guard
+
+| Entrypoint | Reason |
+|---|---|
+| `__constructor` | `schver` doesn't exist yet; `write_schema_version` is called instead. |
+| `pause` / `unpause` | Circuit breakers must work even when the contract needs migration. An operator needs to halt a broken deployment. |
+| Read-only getters (`get_*`, `contract_is_paused`, `version`, etc.) | Cannot corrupt state. Including the guard is harmless but optional. |
+
+---
+
+## Storage Key Audit (as of v1 schema)
+
+Cross-reference: [Issue #46](https://github.com/Stellar-VaultLink/invofi-contracts/issues/46).
+
+### `common`
+
+| Key | Storage | Owner | Value type |
+|---|---|---|---|
+| `curtok` | instance | `common` | `Map<Symbol, Address>` — currency → SEP-41 token |
+| `token` | instance | `common` | `Address` — legacy single-token fallback |
+
+### `registry`
+
+| Key | Storage | Value type |
+|---|---|---|
+| `invoices` | persistent | `Map<Symbol, Invoice>` |
+| `rates` | persistent | `Map<RiskTier, u32>` |
+| `blklist` | persistent | `Vec<Address>` |
+| `admin` | instance | `Address` |
+| `stats` | instance | `ProtocolStats` |
+| `financing` | instance | `Address` |
+| `repayment` | instance | `Address` |
+| `paused` | instance | `bool` |
+| `feebps` | instance | `u32` |
+| `schver` | instance | `u32` |
+
+### `financing`
+
+| Key | Storage | Value type |
+|---|---|---|
+| `offers` | persistent | `Map<Symbol, FinancingOffer>` |
+| `lstats` + lender | persistent | `LenderStats` (compound key) |
+| `scheds` | persistent | `Map<Symbol, RepaymentSchedule>` |
+| `admin` | instance | `Address` |
+| `registry` | instance | `Address` |
+| `token` | instance | `Address` |
+| `repayment` | instance | `Address` |
+| `stats` | instance | `ProtocolStats` |
+| `paused` | instance | `bool` |
+| `postok` | instance | `Address` — position token |
+| `feebps` | instance | `u32` |
+| `schver` | instance | `u32` |
+| `curtok` | instance | `Map<Symbol, Address>` — via `common` |
+
+### `repayment`
+
+| Key | Storage | Value type |
+|---|---|---|
+| `admin` | instance | `Address` |
+| `registry` | instance | `Address` |
+| `financing` | instance | `Address` |
+| `token` | instance | `Address` |
+| `insadd` | instance | `Address` (optional) |
+| `repadd` | instance | `Address` (optional) |
+| `penbps` | instance | `u32` — penalty rate bps |
+| `pencap` | instance | `u32` — penalty cap bps |
+| `paused` | instance | `bool` |
+| `schver` | instance | `u32` |
+
+### `insurance`
+
+| Key | Storage | Value type |
+|---|---|---|
+| `stakes` | persistent | `Map<Address, i128>` |
+| `admin` | instance | `Address` |
+| `token` | instance | `Address` |
+| `pooltot` | instance | `i128` |
+| `paycall` | instance | `Address` |
+| `registry` | instance | `Address` |
+| `paused` | instance | `bool` |
+| `schver` | instance | `u32` |
+
+### `reputation`
+
+| Key | Storage | Value type |
+|---|---|---|
+| `reputn` | persistent | `Map<Address, ReputationRecord>` |
+| `admin` | instance | `Address` |
+| `recorder` | instance | `Address` |
+| `paused` | instance | `bool` |
+| `schver` | instance | `u32` |
+
+---
+
+## The `migrate()` Pattern (scaffolding — not yet implemented)
+
+> **This section documents the convention for future migrations. No actual
+> key renames or value-shape changes are performed in this ADR.**
+
+### Function signature convention
+
+Each contract that needs to migrate its storage layout should expose:
+
+```rust
+pub fn migrate(env: Env, admin: Address, from_version: u32, to_version: u32) {
+    // 1. Auth: only the admin may call this.
+    admin.require_auth();
+    let current_admin: Address = env.storage().instance()
+        .get(&symbol_short!("admin"))
+        .unwrap_or_else(|| panic!("Not initialized"));
+    if current_admin != admin {
+        env.panic_with_error(ContractError::Unauthorized);
+    }
+
+    // 2. Verify we are migrating from exactly the version stored on-chain.
+    let stored: Option<u32> = env.storage().instance().get(&symbol_short!("schver"));
+    let stored_v = stored.unwrap_or(0); // 0 means legacy (pre-versioning)
+    if stored_v != from_version {
+        env.panic_with_error(ContractError::InvalidInput);
+    }
+
+    // 3. Perform the actual data migration here.
+    //    - Rename keys: read old, write new, delete old.
+    //    - Reshape values: read, convert, write back.
+    //    - Back-fill new keys with defaults.
+    //
+    //    Example (renaming "foo" → "bar"):
+    //    let v: Option<OldType> = env.storage().persistent().get(&symbol_short!("foo"));
+    //    if let Some(old) = v {
+    //        env.storage().persistent().set(&symbol_short!("bar"), &NewType::from(old));
+    //        env.storage().persistent().remove(&symbol_short!("foo"));
+    //    }
+
+    // 4. Bump the stored schema version to the new value.
+    //    This is the commit point — after this line the contract accepts calls
+    //    from the new WASM binary.
+    write_schema_version(&env, to_version);
+}
+```
+
+### Authorization
+
+Only the admin of the contract may call `migrate`. The admin address is
+whatever was set in `__constructor` (or updated by `transfer_admin`). No new
+role or governance mechanism is introduced — this keeps the migration
+surface as small as possible. When multisig governance ships (roadmap), the
+admin will already be a multisig, so `migrate` automatically inherits it.
+
+### Deployment procedure for a future migration (step-by-step)
+
+1. **Implement and test `migrate()`** in the affected crate.
+   - Write unit tests that pre-populate storage in the old layout, call
+     `migrate(env, admin, from, to)`, and assert the new layout is correct
+     and the old keys are absent.
+   - Write a test that calling `migrate` with the wrong `from_version`
+     panics with `InvalidInput`.
+
+2. **Increment `SCHEMA_VERSION`** in the crate's `lib.rs` from `N` to `N+1`.
+   - At this point `assert_schema_version` on any un-migrated instance will
+     panic with `SchemaMismatch(#10)`, which prevents stale state from being
+     read or written.
+
+3. **Deploy the new WASM** to every live instance using `stellar contract install`
+   and `stellar contract deploy --wasm-hash`.
+
+4. **Call `migrate(admin, N, N+1)`** on every live instance **before opening
+   it to user calls**. Use the admin keypair that corresponds to the `admin`
+   key stored on that instance.
+   - Automate this step in `scripts/deploy.sh` or a dedicated migration
+     script to avoid human error.
+   - On Testnet this can be done in a single transaction; on Mainnet, prefer
+     a time-locked multisig proposal.
+
+5. **Verify** by calling a read-only getter and confirming no `SchemaMismatch`
+   error is returned.
+
+6. **Document** the migration in `CHANGELOG.md` with the from/to version
+   numbers and a short description of what changed.
+
+### What `migrate()` must never do
+
+- It must never be callable when already on the target version (`from_version
+  == to_version`).
+- It must not silently succeed if the stored version doesn't match
+  `from_version` — fail loudly with `InvalidInput`.
+- It must not leave the contract in a half-migrated state on error. Use
+  Soroban's atomic transaction guarantee: if any step panics, the entire
+  ledger transaction rolls back, leaving storage unchanged.
+
+---
+
+## Consequences
+
+### Benefits
+
+- **Fail-fast on version mismatch.** Any call to a contract deployed with
+  schema v1 storage but a v2 binary panics immediately with a typed,
+  machine-readable error (`#10`). No silent data corruption.
+- **Backward compatible.** Pre-versioning deployments (absent `schver` key)
+  continue to work unchanged — the legacy fallback path is a deliberate part
+  of the contract.
+- **Uniform pattern.** A single implementation in `invofi-common` means every
+  crate gets the same semantics with zero duplication.
+- **Auditable.** The `schver` key is visible in Horizon's contract data dump
+  for any instance. An indexer can scan all InvoFi instances and flag any
+  that are running mismatched versions without calling the contract.
+
+### Trade-offs
+
+- **No partial rollback.** Once `migrate()` advances `schver`, the only way
+  to go back is to call a hypothetical `migrate(admin, N+1, N)`. For this
+  reason, migrations should be one-way unless a `rollback()` function is
+  explicitly implemented and tested.
+- **Admin single point of failure.** Until multisig governance ships, a
+  compromised admin key can call `migrate` and corrupt storage layout.
+  This is an existing risk across all admin operations, not unique to this ADR.
+- **Cost of always checking.** `assert_schema_version` adds one instance
+  storage read per entrypoint call. On Soroban this is negligible (instance
+  reads are cached per transaction).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0005 | [Deployer-bound initialization (constructors)](./0005-deployer-bound-initialization.md) | Accepted |
 | 0006 | [Fixed installment repayment schedules](./0006-repayment-schedules.md) | Accepted |
 | 0007 | [Overdue penalty interest](./0007-overdue-penalty-interest.md) | Proposed |
+| 0009 | [Storage schema versioning](./0009-storage-schema-versioning.md) | Accepted |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -6,10 +6,17 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, resolve_token, ContractError, FinancingOffer, Invoice, InvoiceStatus,
-    LenderStats, OfferStatus, ProtocolStats, RegistryClient, RepaymentSchedule,
-    ScheduleFrequency, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    assert_not_paused, assert_schema_version, write_schema_version, resolve_token, ContractError,
+    FinancingOffer, Invoice, InvoiceStatus, LenderStats, OfferStatus, ProtocolStats,
+    RegistryClient, RepaymentSchedule, ScheduleFrequency, MAX_OFFER_DURATION_SECS,
+    MIN_OFFER_DURATION_SECS,
 };
+
+/// Current storage schema version for the financing contract.
+///
+/// Increment this constant when a new release changes the layout of any
+/// persistent or instance storage key. See docs/adr/0009-storage-schema-versioning.md.
+pub const SCHEMA_VERSION: u32 = 1;
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -115,6 +122,7 @@ impl FinancingContract {
         env.storage()
             .instance()
             .set(&symbol_short!("token"), &token);
+        write_schema_version(&env, SCHEMA_VERSION);
     }
 
     /// Register the repayment contract address. Only admin.
@@ -122,6 +130,7 @@ impl FinancingContract {
     /// callback methods (update_offer_status, update_offer_amount_repaid, etc.).
     pub fn set_repayment_contract(env: Env, admin: Address, repayment: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -153,6 +162,7 @@ impl FinancingContract {
     /// Transfers admin rights. Only current admin.
     pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -172,6 +182,7 @@ impl FinancingContract {
     /// Register a currency → token mapping. Admin only.
     pub fn register_currency(env: Env, admin: Address, currency: Symbol, token_addr: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -199,6 +210,7 @@ impl FinancingContract {
     /// contract-invoker auth — see ADR-0002).
     pub fn set_position_token(env: Env, admin: Address, token: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -271,6 +283,7 @@ impl FinancingContract {
         duration: u64,
     ) -> FinancingOffer {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         lender.require_auth();
         assert_not_blacklisted(&env, &lender);
         assert!(amount > 0, "offer amount must be greater than zero");
@@ -357,6 +370,7 @@ impl FinancingContract {
     /// Withdraw a pending offer. Only the lender.
     pub fn withdraw_offer(env: Env, offer_id: Symbol, lender: Address) -> FinancingOffer {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         lender.require_auth();
         let mut offers = load_offers(&env);
         let mut offer = offers
@@ -384,6 +398,7 @@ impl FinancingContract {
     /// Cross-contract: reads + updates invoice status in the registry contract.
     pub fn accept_offer(env: Env, offer_id: Symbol, invoice_originator: Address) -> FinancingOffer {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         invoice_originator.require_auth();
 
         let mut offers = load_offers(&env);
@@ -470,6 +485,7 @@ impl FinancingContract {
     /// Reject a financing offer. Only the invoice originator.
     pub fn reject_offer(env: Env, offer_id: Symbol, invoice_originator: Address) -> FinancingOffer {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         invoice_originator.require_auth();
 
         let mut offers = load_offers(&env);
@@ -519,6 +535,7 @@ impl FinancingContract {
     /// after accept/reject/repay/reclaim to keep offer state in sync.
     pub fn update_offer_status(env: Env, id: Symbol, new_status: OfferStatus) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         Self::assert_only_repayment(&env);
         let mut offers = load_offers(&env);
         let mut offer = offers
@@ -532,6 +549,7 @@ impl FinancingContract {
     /// Update the running amount_repaid on an offer. Called by Repayment.
     pub fn update_offer_amount_repaid(env: Env, id: Symbol, amount_repaid: i128) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         Self::assert_only_repayment(&env);
         let mut offers = load_offers(&env);
         let mut offer = offers
@@ -545,6 +563,7 @@ impl FinancingContract {
     /// Update lender stats after a repayment. Called by Repayment.
     pub fn update_lender_stats_repaid(env: Env, lender: Address, fully_repaid: bool) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         Self::assert_only_repayment(&env);
         let mut lstats = load_lender_stats(&env, &lender);
         if fully_repaid {
@@ -556,6 +575,7 @@ impl FinancingContract {
     /// Update protocol-level stats after a repayment. Called by Repayment.
     pub fn update_stats_repaid(env: Env, amount: i128, fee_amount: i128) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         Self::assert_only_repayment(&env);
         let mut s = load_stats(&env);
         s.total_repaid += amount;
@@ -705,6 +725,7 @@ impl FinancingContract {
         first_due: u64,
     ) -> RepaymentSchedule {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         caller.require_auth();
 
         assert!(count >= 1, "count must be at least 1");

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -1519,3 +1519,69 @@ fn test_daily_frequency_period() {
     env.ledger().set_timestamp(first_due + 86_400 + 1);
     assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 2);
 }
+
+// ─── Schema version tests (issue #66) ───────────────────────────────────────
+
+mod schema_version_tests {
+    use super::FinancingContract;
+    use invofi_registry::RegistryContract;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    fn deploy(env: &Env) -> (Address, Address, super::FinancingContractClient) {
+        let admin = Address::generate(env);
+        let token = Address::generate(env);
+        let registry_id = env.register(RegistryContract, (admin.clone(),));
+        let financing_id =
+            env.register(FinancingContract, (admin.clone(), registry_id.clone(), token.clone()));
+        let client = super::FinancingContractClient::new(env, &financing_id);
+        invofi_registry::RegistryContractClient::new(env, &registry_id)
+            .set_financing_contract(&admin, &financing_id);
+        (admin, financing_id, client)
+    }
+
+    // ── Matching version ─────────────────────────────────────────────────────
+
+    #[test]
+    fn normal_deployment_register_currency_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, _, client) = deploy(&env);
+        let token = Address::generate(&env);
+        client.register_currency(&admin, &symbol_short!("USDC"), &token); // must succeed
+    }
+
+    // ── Legacy fallback ──────────────────────────────────────────────────────
+
+    #[test]
+    fn legacy_absent_schver_register_currency_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, contract_id, client) = deploy(&env);
+
+        env.as_contract(&contract_id, || {
+            env.storage().instance().remove(&symbol_short!("schver"));
+        });
+
+        let token = Address::generate(&env);
+        client.register_currency(&admin, &symbol_short!("USDC"), &token); // legacy fallback
+    }
+
+    // ── Mismatch panics ──────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn mismatched_schver_blocks_register_currency() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (admin, contract_id, client) = deploy(&env);
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("schver"), &2u32);
+        });
+
+        let token = Address::generate(&env);
+        client.register_currency(&admin, &symbol_short!("USDC"), &token); // must panic #10
+    }
+}

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -1524,16 +1524,17 @@ fn test_daily_frequency_period() {
 
 mod schema_version_tests {
     use super::FinancingContract;
+    use crate::FinancingContractClient;
     use invofi_registry::RegistryContract;
     use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
 
-    fn deploy(env: &Env) -> (Address, Address, super::FinancingContractClient) {
+    fn deploy(env: &'_ Env) -> (Address, Address, FinancingContractClient<'_>) {
         let admin = Address::generate(env);
         let token = Address::generate(env);
         let registry_id = env.register(RegistryContract, (admin.clone(),));
         let financing_id =
             env.register(FinancingContract, (admin.clone(), registry_id.clone(), token.clone()));
-        let client = super::FinancingContractClient::new(env, &financing_id);
+        let client = FinancingContractClient::new(env, &financing_id);
         invofi_registry::RegistryContractClient::new(env, &registry_id)
             .set_financing_contract(&admin, &financing_id);
         (admin, financing_id, client)

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -14,7 +14,16 @@
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
-use invofi_common::{assert_not_paused, ContractError, InvoiceStatus, RegistryClient};
+use invofi_common::{
+    assert_not_paused, assert_schema_version, write_schema_version, ContractError, InvoiceStatus,
+    RegistryClient,
+};
+
+/// Current storage schema version for the insurance contract.
+///
+/// Increment this constant when a new release changes the layout of any
+/// persistent or instance storage key. See docs/adr/0009-storage-schema-versioning.md.
+pub const SCHEMA_VERSION: u32 = 1;
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -76,6 +85,7 @@ impl InsuranceContract {
         env.storage()
             .instance()
             .set(&symbol_short!("token"), &token);
+        write_schema_version(&env, SCHEMA_VERSION);
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -88,6 +98,7 @@ impl InsuranceContract {
     /// Transfers admin rights. Only current admin.
     pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -106,6 +117,7 @@ impl InsuranceContract {
     /// set this before opening the pool to stakers.
     pub fn set_staking_token(env: Env, admin: Address, token: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -129,6 +141,7 @@ impl InsuranceContract {
     /// is configured (fail-closed).
     pub fn set_payout_caller(env: Env, admin: Address, payout_caller: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -217,6 +230,7 @@ impl InsuranceContract {
     /// contract). Credits the staker's balance and the pool total.
     pub fn stake(env: Env, staker: Address, amount: i128) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         staker.require_auth();
         if amount <= 0 {
             env.panic_with_error(ContractError::InvalidInput);
@@ -249,6 +263,7 @@ impl InsuranceContract {
     /// the pool total; the pool pays the staker directly from its holdings.
     pub fn unstake(env: Env, staker: Address, amount: i128) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         staker.require_auth();
         if amount <= 0 {
             env.panic_with_error(ContractError::InvalidInput);
@@ -306,6 +321,7 @@ impl InsuranceContract {
     /// pool is short).
     pub fn pay_out(env: Env, invoice_id: Symbol, beneficiary: Address, amount: i128) -> i128 {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         let payout_caller: Address = env
             .storage()
             .instance()

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -610,7 +610,7 @@ mod schema_version_tests {
     use crate::InsuranceContractClient;
     use soroban_sdk::{symbol_short, testutils::Address as _, token, Address, Env};
 
-    fn deploy(env: &Env, admin: &Address) -> (Address, Address, InsuranceContractClient) {
+    fn deploy<'a>(env: &'a Env, admin: &Address) -> (Address, Address, InsuranceContractClient<'a>) {
         let sac = env.register_stellar_asset_contract_v2(admin.clone());
         let token_id = sac.address();
         let contract_id = env.register(InsuranceContract, (admin.clone(), token_id.clone()));

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -602,3 +602,84 @@ fn test_payout_without_registry_panics() {
 
     client.pay_out(&invoice_id, &beneficiary, &500_000);
 }
+
+// ─── Schema version tests (issue #66) ───────────────────────────────────────
+
+mod schema_version_tests {
+    use super::InsuranceContract;
+    use crate::InsuranceContractClient;
+    use soroban_sdk::{symbol_short, testutils::Address as _, token, Address, Env};
+
+    fn deploy(env: &Env, admin: &Address) -> (Address, Address, InsuranceContractClient) {
+        let sac = env.register_stellar_asset_contract_v2(admin.clone());
+        let token_id = sac.address();
+        let contract_id = env.register(InsuranceContract, (admin.clone(), token_id.clone()));
+        let client = InsuranceContractClient::new(env, &contract_id);
+        (token_id, contract_id, client)
+    }
+
+    fn mint_and_approve(env: &Env, token_id: &Address, spender: &Address, who: &Address, amount: i128) {
+        token::StellarAssetClient::new(env, token_id).mint(who, &amount);
+        token::TokenClient::new(env, token_id).approve(
+            who,
+            spender,
+            &amount,
+            &(env.ledger().sequence() + 1000),
+        );
+    }
+
+    // ── Matching version ─────────────────────────────────────────────────────
+
+    #[test]
+    fn normal_deployment_stake_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (token_id, contract_id, client) = deploy(&env, &admin);
+
+        mint_and_approve(&env, &token_id, &contract_id, &staker, 1_000_000);
+        client.stake(&staker, &1_000_000); // must succeed
+        assert_eq!(client.get_pool_total(), 1_000_000);
+    }
+
+    // ── Legacy fallback ──────────────────────────────────────────────────────
+
+    #[test]
+    fn legacy_absent_schver_stake_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (token_id, contract_id, client) = deploy(&env, &admin);
+
+        env.as_contract(&contract_id, || {
+            env.storage().instance().remove(&symbol_short!("schver"));
+        });
+
+        mint_and_approve(&env, &token_id, &contract_id, &staker, 1_000_000);
+        client.stake(&staker, &1_000_000); // must succeed via legacy fallback
+        assert_eq!(client.get_pool_total(), 1_000_000);
+    }
+
+    // ── Mismatch panics ──────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn mismatched_schver_blocks_stake() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let staker = Address::generate(&env);
+        let (token_id, contract_id, client) = deploy(&env, &admin);
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("schver"), &2u32);
+        });
+
+        mint_and_approve(&env, &token_id, &contract_id, &staker, 1_000_000);
+        client.stake(&staker, &1_000_000); // must panic with #10
+    }
+}

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -3,9 +3,18 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, ContractError, Invoice, InvoiceStatus, ProtocolStats, RiskTier,
-    MIN_INVOICE_AMOUNT,
+    assert_not_paused, assert_schema_version, write_schema_version, ContractError, Invoice,
+    InvoiceStatus, ProtocolStats, RiskTier, MIN_INVOICE_AMOUNT,
 };
+
+/// Current storage schema version for the registry contract.
+///
+/// Increment this constant when a new release changes the layout of any
+/// persistent or instance storage key (renamed key, added/removed field in a
+/// stored struct, changed value type). A matching `migrate()` entrypoint must
+/// be implemented and called before the new WASM is deployed to a live
+/// instance. See docs/adr/0009-storage-schema-versioning.md.
+pub const SCHEMA_VERSION: u32 = 1;
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -107,6 +116,7 @@ impl RegistryContract {
         env.storage()
             .instance()
             .set(&symbol_short!("admin"), &admin);
+        write_schema_version(&env, SCHEMA_VERSION);
     }
 
     /// Returns the admin address. Panics if not yet initialized.
@@ -121,6 +131,7 @@ impl RegistryContract {
     /// call this.
     pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         env.storage()
             .instance()
@@ -132,6 +143,7 @@ impl RegistryContract {
     /// Financed via `transition_invoice_status`.
     pub fn set_financing_contract(env: Env, admin: Address, financing: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         env.storage()
             .instance()
@@ -143,6 +155,7 @@ impl RegistryContract {
     /// to Financed (partial) or Repaid (full) via `transition_invoice_status`.
     pub fn set_repayment_contract(env: Env, admin: Address, repayment: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         env.storage()
             .instance()
@@ -181,6 +194,7 @@ impl RegistryContract {
     /// Admin only.
     pub fn set_rate(env: Env, admin: Address, tier: RiskTier, rate_bps: u32) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         if rate_bps > 10_000 {
             env.panic_with_error(ContractError::InvalidInput);
@@ -203,6 +217,7 @@ impl RegistryContract {
     /// Set the protocol fee in basis points (max 500 = 5%). Admin only.
     pub fn set_fee(env: Env, admin: Address, fee_bps: u32) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         if fee_bps > 500 {
             env.panic_with_error(ContractError::InvalidInput);
@@ -232,6 +247,7 @@ impl RegistryContract {
         due_date: u64,
     ) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         originator.require_auth();
         assert_not_blacklisted(&env, &originator);
         if amount < MIN_INVOICE_AMOUNT {
@@ -284,6 +300,7 @@ impl RegistryContract {
         new_status: InvoiceStatus,
     ) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         originator.require_auth();
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
@@ -311,6 +328,7 @@ impl RegistryContract {
         new_amount: i128,
     ) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         originator.require_auth();
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
@@ -338,6 +356,7 @@ impl RegistryContract {
     /// Cancel a Pending invoice. Only the originator can call this.
     pub fn cancel_invoice(env: Env, invoice_id: Symbol, originator: Address) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         originator.require_auth();
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
@@ -370,6 +389,7 @@ impl RegistryContract {
         fully_repaid: bool,
     ) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         repayer.require_auth();
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
@@ -397,6 +417,7 @@ impl RegistryContract {
     /// contract-invoker auth (see Stellar docs — Authorization).
     pub fn financing_marks_invoice_financed(env: Env, id: Symbol) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         let financing: Address = env
             .storage()
             .instance()
@@ -426,6 +447,7 @@ impl RegistryContract {
     /// authorized via implicit contract-invoker auth.
     pub fn repayment_marks_invoice_repaid(env: Env, id: Symbol, fully_repaid: bool) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         let repayment: Address = env
             .storage()
             .instance()
@@ -461,6 +483,7 @@ impl RegistryContract {
     /// originator's reputation default record.
     pub fn repayment_marks_defaulted(env: Env, id: Symbol) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         let repayment: Address = env
             .storage()
             .instance()
@@ -490,6 +513,7 @@ impl RegistryContract {
     /// require originator auth — the time-based condition is sufficient.
     pub fn mark_invoice_overdue(env: Env, id: Symbol) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(id.clone())
@@ -515,6 +539,7 @@ impl RegistryContract {
     /// Mark a Financed invoice as Disputed. Only the originator.
     pub fn raise_dispute(env: Env, invoice_id: Symbol, originator: Address) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         originator.require_auth();
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
@@ -544,6 +569,7 @@ impl RegistryContract {
         target_status: InvoiceStatus,
     ) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
@@ -661,6 +687,7 @@ impl RegistryContract {
 
     pub fn blacklist_address(env: Env, admin: Address, target: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         let mut list = load_blacklist(&env);
         for entry in list.iter() {
@@ -674,6 +701,7 @@ impl RegistryContract {
 
     pub fn unblacklist_address(env: Env, admin: Address, target: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         assert_admin(&env, &admin);
         let list = load_blacklist(&env);
         let mut new_list: Vec<Address> = Vec::new(&env);

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -1185,3 +1185,110 @@ fn test_repayment_marks_defaulted_requires_overdue() {
     client.update_invoice_status(&invoice_id, &originator, &InvoiceStatus::Financed);
     client.repayment_marks_defaulted(&invoice_id);
 }
+
+// ─── Schema version tests (issue #66) ───────────────────────────────────────
+
+mod schema_version_tests {
+    use super::RegistryContract;
+    use crate::RegistryContractClient;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    fn make_admin(env: &Env) -> Address {
+        Address::generate(env)
+    }
+
+    // ── Matching version: normal deployment ──────────────────────────────────
+
+    /// A freshly deployed registry (with __constructor) has schver=1 written.
+    /// State-mutating calls proceed normally.
+    #[test]
+    fn normal_deployment_version_matches() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = make_admin(&env);
+        let contract_id = env.register(RegistryContract, (admin.clone(),));
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        // register_invoice calls assert_schema_version — must succeed on a
+        // fresh deployment because __constructor wrote schver=1.
+        let originator = Address::generate(&env);
+        client.register_invoice(
+            &symbol_short!("invA"),
+            &originator,
+            &10_000_000i128,
+            &symbol_short!("XLM"),
+            &1_800_000_000u64,
+        );
+    }
+
+    // ── Legacy fallback: absent schver key ───────────────────────────────────
+
+    /// Simulate a legacy deployment: manually set up storage WITHOUT going
+    /// through __constructor (so schver is absent). State-mutating calls must
+    /// still work — they fall through the absent-key path.
+    #[test]
+    fn legacy_deployment_absent_schver_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let admin = make_admin(&env);
+        let contract_id = env.register(RegistryContract, (admin.clone(),));
+
+        // Remove the schver key to simulate a pre-versioning deployment.
+        env.as_contract(&contract_id, || {
+            env.storage().instance().remove(&symbol_short!("schver"));
+        });
+
+        // Verify schver is absent.
+        let has_schver: bool = env.as_contract(&contract_id, || {
+            env.storage().instance().has(&symbol_short!("schver"))
+        });
+        assert!(!has_schver, "schver should be absent for legacy simulation");
+
+        let client = RegistryContractClient::new(&env, &contract_id);
+
+        // A state-mutating call (register_invoice) must succeed via legacy fallback.
+        let originator = Address::generate(&env);
+        client.register_invoice(
+            &symbol_short!("invB"),
+            &originator,
+            &10_000_000i128,
+            &symbol_short!("XLM"),
+            &1_800_000_000u64,
+        );
+    }
+
+    // ── Mismatch: wrong version panics ───────────────────────────────────────
+
+    /// If schver is present but does not match SCHEMA_VERSION (e.g. schver=2
+    /// but SCHEMA_VERSION=1), every state-mutating call must panic with
+    /// `Error(Contract, #10)`.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn mismatched_version_panics_on_state_mutating_call() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = make_admin(&env);
+        let contract_id = env.register(RegistryContract, (admin.clone(),));
+
+        // Overwrite schver with a future version (2) — the binary still
+        // expects 1. This simulates deploying a v1 binary on top of a v2
+        // migrated storage without running migrate() first.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("schver"), &2u32);
+        });
+
+        let client = RegistryContractClient::new(&env, &contract_id);
+        let originator = Address::generate(&env);
+        // Must panic with SchemaMismatch (discriminant 10).
+        client.register_invoice(
+            &symbol_short!("invC"),
+            &originator,
+            &10_000_000i128,
+            &symbol_short!("XLM"),
+            &1_800_000_000u64,
+        );
+    }
+}

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -3,10 +3,17 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Symbol};
 
 use invofi_common::{
-    assert_not_paused, resolve_token, ContractError, FinancingClient, FinancingOffer,
-    InsuranceClient, Invoice, InvoiceStatus, OfferStatus, RegistryClient, ReputationClient,
-    GRACE_PERIOD_SECS, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    assert_not_paused, assert_schema_version, write_schema_version, resolve_token, ContractError,
+    FinancingClient, FinancingOffer, InsuranceClient, Invoice, InvoiceStatus, OfferStatus,
+    RegistryClient, ReputationClient, GRACE_PERIOD_SECS, MAX_OFFER_DURATION_SECS,
+    MIN_OFFER_DURATION_SECS,
 };
+
+/// Current storage schema version for the repayment contract.
+///
+/// Increment this constant when a new release changes the layout of any
+/// persistent or instance storage key. See docs/adr/0009-storage-schema-versioning.md.
+pub const SCHEMA_VERSION: u32 = 1;
 
 // ─── Overdue penalty (ADR-0007) ──────────────────────────────────────────────
 
@@ -130,6 +137,7 @@ impl RepaymentContract {
         env.storage()
             .instance()
             .set(&symbol_short!("token"), &token);
+        write_schema_version(&env, SCHEMA_VERSION);
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -144,6 +152,7 @@ impl RepaymentContract {
     /// insurance pool (Task 10).
     pub fn set_insurance(env: Env, admin: Address, insurance: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -167,6 +176,7 @@ impl RepaymentContract {
     /// (Task 11).
     pub fn set_reputation(env: Env, admin: Address, reputation: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -194,6 +204,7 @@ impl RepaymentContract {
     /// an admin calls this.
     pub fn set_penalty(env: Env, admin: Address, penalty_bps: u32, cap_bps: u32) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -230,6 +241,7 @@ impl RepaymentContract {
     /// Transfers admin rights. Only current admin.
     pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -296,6 +308,7 @@ impl RepaymentContract {
         amount: i128,
     ) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         repayer.require_auth();
 
         // Cross-contract: read invoice from registry
@@ -414,6 +427,7 @@ impl RepaymentContract {
     /// handles the status transition and event emission.
     pub fn mark_overdue(env: Env, invoice_id: Symbol) -> Invoice {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
 
         let registry_addr: Address = env
             .storage()
@@ -434,6 +448,7 @@ impl RepaymentContract {
         lender: Address,
     ) -> FinancingOffer {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         lender.require_auth();
 
         // Cross-contract: read invoice from registry

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -1632,3 +1632,131 @@ fn test_set_penalty_blocked_while_paused() {
     c.rep.pause(&c.admin);
     c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
 }
+
+// ─── Schema version tests (issue #66) ───────────────────────────────────────
+
+mod schema_version_tests {
+    use super::RepaymentContract;
+    use crate::RepaymentContractClient;
+    use invofi_financing::FinancingContract;
+    use invofi_registry::RegistryContract;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    /// Deploy registry + financing + repayment and return the repayment contract
+    /// id, the admin address, and client. The repayment contract is the one whose schver we manipulate.
+    fn deploy<'a>(env: &'a Env) -> (Address, Address, RepaymentContractClient<'a>) {
+        let admin = Address::generate(env);
+        let token = Address::generate(env);
+
+        let registry_id = env.register(RegistryContract, (admin.clone(),));
+        let financing_id =
+            env.register(FinancingContract, (admin.clone(), registry_id.clone(), token.clone()));
+        let repayment_id = env.register(
+            RepaymentContract,
+            (
+                admin.clone(),
+                registry_id.clone(),
+                financing_id.clone(),
+                token.clone(),
+            ),
+        );
+        let client = RepaymentContractClient::new(env, &repayment_id);
+
+        // Wire the three contracts together so cross-contract auth works.
+        invofi_financing::FinancingContractClient::new(env, &financing_id)
+            .set_repayment_contract(&admin, &repayment_id);
+        invofi_registry::RegistryContractClient::new(env, &registry_id)
+            .set_repayment_contract(&admin, &repayment_id);
+        invofi_registry::RegistryContractClient::new(env, &registry_id)
+            .set_financing_contract(&admin, &financing_id);
+
+        (repayment_id, admin, client)
+    }
+
+    // ── Matching version: normal deployment ──────────────────────────────────
+
+    /// A freshly deployed repayment contract has schver=1 written by
+    /// __constructor. State-mutating calls proceed normally.
+    #[test]
+    fn normal_deployment_version_matches() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let insurance = Address::generate(&env);
+        let (_, admin, client) = deploy(&env);
+
+        // set_insurance calls assert_schema_version — must succeed on a fresh
+        // deployment because __constructor wrote schver=1.
+        client.set_insurance(&admin, &insurance);
+    }
+
+    // ── Legacy fallback: absent schver key ───────────────────────────────────
+
+    /// Simulate a legacy deployment by removing the schver key after
+    /// construction. State-mutating calls must still work — they fall through
+    /// the absent-key path in assert_schema_version.
+    #[test]
+    fn legacy_absent_schver_succeeds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let insurance = Address::generate(&env);
+        let (contract_id, admin, client) = deploy(&env);
+
+        // Remove schver to simulate a pre-versioning deployment.
+        env.as_contract(&contract_id, || {
+            env.storage().instance().remove(&symbol_short!("schver"));
+        });
+
+        // Verify schver is absent.
+        let has_schver: bool = env.as_contract(&contract_id, || {
+            env.storage().instance().has(&symbol_short!("schver"))
+        });
+        assert!(!has_schver, "schver should be absent for legacy simulation");
+
+        // A state-mutating call must succeed via the legacy fallback path.
+        client.set_insurance(&admin, &insurance);
+    }
+
+    // ── Mismatch: wrong version panics ───────────────────────────────────────
+
+    /// If schver is present but does not match SCHEMA_VERSION (e.g. schver=2
+    /// but SCHEMA_VERSION=1), every state-mutating call must panic with
+    /// `Error(Contract, #10)` (ContractError::SchemaMismatch).
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn mismatched_version_panics_on_state_mutating_call() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let insurance = Address::generate(&env);
+        let (contract_id, admin, client) = deploy(&env);
+
+        // Overwrite schver with a future version — binary still expects 1.
+        // Simulates deploying v1 binary onto v2-migrated storage.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("schver"), &2u32);
+        });
+
+        // Must panic with SchemaMismatch (discriminant 10).
+        client.set_insurance(&admin, &insurance);
+    }
+
+    /// Transfer admin also goes through assert_schema_version — verify mismatch
+    /// blocks it as well, since it is a different state-mutating entrypoint.
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn mismatched_version_blocks_transfer_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let new_admin = Address::generate(&env);
+        let (contract_id, admin, client) = deploy(&env);
+
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("schver"), &2u32);
+        });
+
+        client.transfer_admin(&admin, &new_admin);
+    }
+}

--- a/reputation/src/lib.rs
+++ b/reputation/src/lib.rs
@@ -15,7 +15,13 @@
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map};
 
-use invofi_common::{assert_not_paused, ContractError};
+use invofi_common::{assert_not_paused, assert_schema_version, write_schema_version, ContractError};
+
+/// Current storage schema version for the reputation contract.
+///
+/// Increment this constant when a new release changes the layout of any
+/// persistent or instance storage key. See docs/adr/0009-storage-schema-versioning.md.
+pub const SCHEMA_VERSION: u32 = 1;
 
 /// Outcome discriminant for a successful full repayment.
 pub const OUTCOME_REPAID: u32 = 0;
@@ -66,6 +72,7 @@ impl ReputationContract {
         env.storage()
             .instance()
             .set(&symbol_short!("admin"), &admin);
+        write_schema_version(&env, SCHEMA_VERSION);
     }
 
     pub fn get_admin(env: Env) -> Address {
@@ -80,6 +87,7 @@ impl ReputationContract {
     /// recorder is configured (fail-closed).
     pub fn set_recorder(env: Env, admin: Address, recorder: Address) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         admin.require_auth();
         let current: Address = env
             .storage()
@@ -149,6 +157,7 @@ impl ReputationContract {
     /// once per terminal outcome (once on full repay, once on reclaim).
     pub fn record_outcome(env: Env, originator: Address, outcome: u32) {
         assert_not_paused(&env);
+        assert_schema_version(&env, SCHEMA_VERSION);
         let recorder: Address = env
             .storage()
             .instance()

--- a/reputation/src/test.rs
+++ b/reputation/src/test.rs
@@ -141,3 +141,78 @@ fn test_record_outcome_invalid_outcome_panics() {
 
     client.record_outcome(&originator, &99);
 }
+
+// ─── Schema version tests (issue #66) ───────────────────────────────────────
+
+mod schema_version_tests {
+    use super::ReputationContract;
+    use crate::ReputationContractClient;
+    use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
+
+    // ── Matching version ─────────────────────────────────────────────────────
+
+    #[test]
+    fn normal_deployment_allows_state_mutations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let recorder = Address::generate(&env);
+        let originator = Address::generate(&env);
+
+        let contract_id = env.register(ReputationContract, (admin.clone(),));
+        let client = ReputationContractClient::new(&env, &contract_id);
+        client.set_recorder(&admin, &recorder);
+
+        // record_outcome calls assert_schema_version — must succeed.
+        client.record_outcome(&originator, &0u32);
+        assert_eq!(client.get_score(&originator), 1);
+    }
+
+    // ── Legacy fallback ──────────────────────────────────────────────────────
+
+    #[test]
+    fn legacy_absent_schver_still_works() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let recorder = Address::generate(&env);
+        let originator = Address::generate(&env);
+
+        let contract_id = env.register(ReputationContract, (admin.clone(),));
+        // Remove schver to simulate legacy deployment.
+        env.as_contract(&contract_id, || {
+            env.storage().instance().remove(&symbol_short!("schver"));
+        });
+
+        let client = ReputationContractClient::new(&env, &contract_id);
+        client.set_recorder(&admin, &recorder);
+        // Must succeed via legacy fallback.
+        client.record_outcome(&originator, &0u32);
+        assert_eq!(client.get_score(&originator), 1);
+    }
+
+    // ── Mismatch panics ──────────────────────────────────────────────────────
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #10)")]
+    fn mismatched_schver_blocks_state_mutations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = Address::generate(&env);
+        let recorder = Address::generate(&env);
+        let originator = Address::generate(&env);
+
+        let contract_id = env.register(ReputationContract, (admin.clone(),));
+        // Overwrite schver with a future version.
+        env.as_contract(&contract_id, || {
+            env.storage()
+                .instance()
+                .set(&symbol_short!("schver"), &2u32);
+        });
+
+        let client = ReputationContractClient::new(&env, &contract_id);
+        client.set_recorder(&admin, &recorder);
+        // Must panic with SchemaMismatch (#10).
+        client.record_outcome(&originator, &0u32);
+    }
+}


### PR DESCRIPTION
- Added schema versioning support to the common, financing, insurance, registry, repayment, and reputation contracts.
- Introduced `assert_schema_version` and `write_schema_version` functions to enforce schema version checks and write the current version to storage.
- Updated entry points in each contract to include schema version assertions, ensuring compatibility with the expected version.
- Added unit tests for schema version handling, including legacy support and mismatch scenarios, to ensure robustness.

## Summary
<!-- What does this PR change in the contract? -->

## Type of change
- [ ] Bug fix
- [ ] New contract function
- [ ] Data type change
- [ ] Test addition
- [ ] Chore / docs

## Checklist
- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes (CI)
- [ ] Soroban Scout security analysis passes (CI)
- [ ] `stellar contract build` succeeds
- [ ] New functions have corresponding tests
- [ ] Breaking changes are documented

> ⚠️ **CI checks are maintainer-managed.** Do not add, remove, rename, or
> reconfigure any CI check or workflow (including Soroban Scout detector
> exclusions in `docs/scout-detectors.md`) in this PR. CI is part of the
> audit story and changes to it go through the maintainers only. If you
> believe a check needs changing, open an issue instead.

## Related issues
Closes #66


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added storage schema versioning across financing, insurance, registry, repayment, and reputation contracts.
  - New deployments record their schema version, while state-changing operations validate compatibility.
  - Legacy deployments without a stored version remain supported.
  - Incompatible versions are rejected with a clear schema-mismatch error.

- **Documentation**
  - Added guidance for schema upgrades, migrations, deployment procedures, and compatibility behavior.
  - Updated the documented test count and roadmap.

- **Tests**
  - Added coverage for current, legacy, and mismatched schema versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->