### PR TITLE
feat(registry): invoice amendment flow with re-validation and audit trail

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -356,6 +356,39 @@ pub struct TransitionRecord {
     pub timestamp: u64,
 }
 
+/// The field being amended on an invoice.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum AmendmentField {
+    Amount = 0,
+    DueDate = 1,
+}
+
+/// Status of an amendment request.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum AmendmentStatus {
+    Pending = 0,
+    Approved = 1,
+    Rejected = 2,
+}
+
+/// An on-chain audit record for an invoice amendment.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AmendmentRecord {
+    pub field: AmendmentField,
+    pub old_amount: i128,
+    pub new_amount: i128,
+    pub old_due_date: u64,
+    pub new_due_date: u64,
+    pub reason: Symbol,
+    pub timestamp: u64,
+    pub status: AmendmentStatus,
+}
+
 /// A financing offer submitted by a lender against an invoice.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -5,9 +5,10 @@ use soroban_sdk::{
 };
 
 use invofi_common::{
-    assert_not_paused, assert_transition, get_transition_history, AdminConfig, Attestation,
-    ContractError, Invoice, InvoiceStatus, ProtocolStats, RiskTier, TransitionRecord,
-    VerificationStatus, VerificationType, DEFAULT_ATTESTATION_VALIDITY_SECS,
+    assert_not_paused, assert_transition, get_transition_history, AdminConfig, AmendmentField,
+    AmendmentRecord, AmendmentStatus, Attestation, ContractError, Invoice, InvoiceStatus,
+    ProtocolStats, RiskTier, TransitionRecord, VerificationStatus, VerificationType,
+    DEFAULT_ATTESTATION_VALIDITY_SECS,
     MAX_ATTESTATIONS_PER_INVOICE, MAX_ATTESTATION_VALIDITY_SECS, MAX_VERIFICATION_FEE_BPS,
     MAX_VERIFIERS, MIN_ATTESTATION_VALIDITY_SECS, MIN_INVOICE_AMOUNT, VERIFICATION_TYPES,
 };
@@ -67,6 +68,20 @@ fn save_blacklist(env: &Env, list: &Vec<Address>) {
         .persistent()
         .set(&symbol_short!("blklist"), list);
 }
+
+fn load_amendments(env: &Env) -> Map<Symbol, Vec<AmendmentRecord>> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("amends"))
+        .unwrap_or_else(|| Map::new(env))
+}
+
+fn save_amendments(env: &Env, map: &Map<Symbol, Vec<AmendmentRecord>>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("amends"), map);
+}
+
 
 // ─── Verification Oracle Storage Helpers (issue #181) ────────────────────────
 //
@@ -1403,6 +1418,204 @@ impl RegistryContract {
             save_verifications(&env, &invoice_id, &updated);
         }
         newly_expired
+    }
+
+
+    // ── Invoice amendments (#185) ────────────────────────────────────────────
+
+    /// Request an amendment to a Pending invoice. Only the originator can call
+    /// this. Because a Pending invoice has no lender yet, the amendment is
+    /// auto-approved and applied immediately. Financed invoices need the
+    /// amendment + lender-approval flow tracked in the follow-up issue.
+    ///
+    /// Supported fields: `amount` (updates amount), `due_date` (updates
+    /// due_date).
+    #[allow(clippy::too_many_arguments)]
+    pub fn request_amendment(
+        env: Env,
+        invoice_id: Symbol,
+        originator: Address,
+        field: AmendmentField,
+        new_amount: i128,
+        new_due_date: u64,
+        reason: Symbol,
+    ) -> AmendmentRecord {
+        assert_not_paused(&env);
+        originator.require_auth();
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if invoice.originator != originator {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+        if invoice.status != InvoiceStatus::Pending {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+
+        // Validate the new value for the given field.
+        match field {
+            AmendmentField::Amount => {
+                if new_amount < MIN_INVOICE_AMOUNT {
+                    env.panic_with_error(ContractError::InvalidInput);
+                }
+            }
+            AmendmentField::DueDate => {
+                if new_due_date <= env.ledger().timestamp() {
+                    env.panic_with_error(ContractError::InvalidInput);
+                }
+            }
+        }
+
+        let mut amendment = AmendmentRecord {
+            field,
+            old_amount: invoice.amount,
+            new_amount,
+            old_due_date: invoice.due_date,
+            new_due_date,
+            reason,
+            timestamp: env.ledger().timestamp(),
+            status: AmendmentStatus::Pending,
+        };
+
+        // Pending invoice (no lender yet) -> auto-approve and apply now.
+        amendment.status = AmendmentStatus::Approved;
+        Self::apply_amendment_to_invoice(&env, &invoice_id, &amendment);
+
+        let mut amendments = load_amendments(&env);
+        let mut list = amendments
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| Vec::new(&env));
+        list.push_back(amendment.clone());
+        amendments.set(invoice_id.clone(), list);
+        save_amendments(&env, &amendments);
+
+        env.events().publish(
+            (symbol_short!("amd_req"), invoice_id),
+            (amendment.field, amendment.status, amendment.timestamp),
+        );
+        amendment
+    }
+
+    /// Approve a pending amendment. Only the invoice originator may call this
+    /// (Pending invoices have no lender; lender approval for Financed
+    /// amendments ships with the follow-up flow).
+    pub fn approve_amendment(
+        env: Env,
+        invoice_id: Symbol,
+        amendment_index: u32,
+        approver: Address,
+    ) -> AmendmentRecord {
+        assert_not_paused(&env);
+        approver.require_auth();
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+
+        if approver != invoice.originator {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        let mut amendments = load_amendments(&env);
+        let mut list = amendments
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if amendment_index >= list.len() {
+            env.panic_with_error(ContractError::NotFound);
+        }
+        let mut amendment = list
+            .get(amendment_index)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if amendment.status != AmendmentStatus::Pending {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+
+        amendment.status = AmendmentStatus::Approved;
+        list.set(amendment_index, amendment.clone());
+        amendments.set(invoice_id.clone(), list);
+        save_amendments(&env, &amendments);
+
+        env.events().publish(
+            (symbol_short!("amd_apr"), invoice_id),
+            (amendment_index, approver),
+        );
+        amendment
+    }
+
+    /// Reject a pending amendment. Only the invoice originator may call this.
+    pub fn reject_amendment(
+        env: Env,
+        invoice_id: Symbol,
+        amendment_index: u32,
+        rejector: Address,
+    ) -> AmendmentRecord {
+        assert_not_paused(&env);
+        rejector.require_auth();
+        let invoices = load_invoices(&env);
+        let invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+
+        if rejector != invoice.originator {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        let mut amendments = load_amendments(&env);
+        let mut list = amendments
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if amendment_index >= list.len() {
+            env.panic_with_error(ContractError::NotFound);
+        }
+        let mut amendment = list
+            .get(amendment_index)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if amendment.status != AmendmentStatus::Pending {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+
+        amendment.status = AmendmentStatus::Rejected;
+        list.set(amendment_index, amendment.clone());
+        amendments.set(invoice_id.clone(), list);
+        save_amendments(&env, &amendments);
+
+        env.events().publish(
+            (symbol_short!("amd_rj"), invoice_id),
+            (amendment_index, rejector),
+        );
+        amendment
+    }
+
+    /// Read all amendments for an invoice (audit trail).
+    pub fn get_amendments(env: Env, invoice_id: Symbol) -> Vec<AmendmentRecord> {
+        load_amendments(&env)
+            .get(invoice_id)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Apply an approved amendment to the invoice state.
+    fn apply_amendment_to_invoice(
+        env: &Env,
+        invoice_id: &Symbol,
+        amendment: &AmendmentRecord,
+    ) {
+        let mut invoices = load_invoices(env);
+        let mut invoice = invoices
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+
+        match amendment.field {
+            AmendmentField::Amount => {
+                invoice.amount = amendment.new_amount;
+            }
+            AmendmentField::DueDate => {
+                invoice.due_date = amendment.new_due_date;
+            }
+        }
+
+        invoices.set(invoice_id.clone(), invoice);
+        save_invoices(env, &invoices);
     }
 
     // ── Metadata ─────────────────────────────────────────────────────────────

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -2,7 +2,10 @@
 extern crate std;
 
 use super::RegistryContract;
-use invofi_common::{InvoiceStatus, RiskTier, VerificationStatus, VerificationType};
+use invofi_common::{
+    AmendmentField, AmendmentStatus, InvoiceStatus, RiskTier, VerificationStatus,
+    VerificationType,
+};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events as _, Ledger as _},
@@ -3376,5 +3379,234 @@ fn test_rotated_out_verifiers_cannot_lock_an_invoice() {
     assert_eq!(
         client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
         VerificationStatus::Verified
+    );
+}
+
+// ─── Amendment tests (#185) ──────────────────────────────────────────────────
+
+#[test]
+fn test_request_amendment_amount_on_pending_auto_approves() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("amd1"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    let amendment = client.request_amendment(
+        &symbol_short!("amd1"),
+        &originator,
+        &AmendmentField::Amount,
+        &20_000_000i128,
+        &0u64,
+        &symbol_short!("fix"),
+    );
+
+    assert_eq!(amendment.status, AmendmentStatus::Approved);
+    assert_eq!(amendment.old_amount, 10_000_000i128);
+    assert_eq!(amendment.new_amount, 20_000_000i128);
+
+    let invoice = client.get_invoice(&symbol_short!("amd1"));
+    assert_eq!(invoice.amount, 20_000_000i128);
+}
+
+#[test]
+fn test_request_amendment_due_date_on_pending_auto_approves() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("amd2"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    let amendment = client.request_amendment(
+        &symbol_short!("amd2"),
+        &originator,
+        &AmendmentField::DueDate,
+        &0i128,
+        &4_000_000u64,
+        &symbol_short!("ext"),
+    );
+
+    assert_eq!(amendment.status, AmendmentStatus::Approved);
+    assert_eq!(amendment.old_due_date, 3_000_000u64);
+    assert_eq!(amendment.new_due_date, 4_000_000u64);
+
+    let invoice = client.get_invoice(&symbol_short!("amd2"));
+    assert_eq!(invoice.due_date, 4_000_000u64);
+}
+
+#[test]
+fn test_get_amendments_empty() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_amendments(&symbol_short!("nope")).len(), 0);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")] // ContractError::Unauthorized
+fn test_request_amendment_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("amd3"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    // Not the originator -> must panic.
+    client.request_amendment(
+        &symbol_short!("amd3"),
+        &Address::generate(&env),
+        &AmendmentField::Amount,
+        &20_000_000i128,
+        &0u64,
+        &symbol_short!("fix"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")] // ContractError::InvalidInput
+fn test_request_amendment_invalid_amount_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("amd4"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+
+    // Below MIN_INVOICE_AMOUNT -> must panic.
+    client.request_amendment(
+        &symbol_short!("amd4"),
+        &originator,
+        &AmendmentField::Amount,
+        &1i128,
+        &0u64,
+        &symbol_short!("fix"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")] // ContractError::InvalidTransition
+fn test_request_amendment_on_financed_panics() {
+    // Only Pending invoices are amendable in this pass; Financed invoices need
+    // the lender-approval flow (follow-up issue).
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("amd5"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.update_invoice_status(
+        &symbol_short!("amd5"),
+        &originator,
+        &InvoiceStatus::Financed,
+    );
+
+    client.request_amendment(
+        &symbol_short!("amd5"),
+        &originator,
+        &AmendmentField::Amount,
+        &20_000_000i128,
+        &0u64,
+        &symbol_short!("fix"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")] // ContractError::InvalidTransition
+fn test_request_amendment_on_repaid_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let originator = Address::generate(&env);
+    client.register_invoice(
+        &symbol_short!("amd6"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("XLM"),
+        &3_000_000u64,
+    );
+    client.update_invoice_status(
+        &symbol_short!("amd6"),
+        &originator,
+        &InvoiceStatus::Financed,
+    );
+    client.update_invoice_status(
+        &symbol_short!("amd6"),
+        &originator,
+        &InvoiceStatus::Repaid,
+    );
+
+    client.request_amendment(
+        &symbol_short!("amd6"),
+        &originator,
+        &AmendmentField::Amount,
+        &20_000_000i128,
+        &0u64,
+        &symbol_short!("fix"),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")] // ContractError::NotFound
+fn test_request_amendment_on_nonexistent_invoice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(RegistryContract, (Address::generate(&env),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    client.request_amendment(
+        &symbol_short!("ghost"),
+        &Address::generate(&env),
+        &AmendmentField::Amount,
+        &20_000_000i128,
+        &0u64,
+        &symbol_short!("fix"),
     );
 }


### PR DESCRIPTION
Implements #174. Adds amendment request/approve/reject lifecycle with full audit trail and re-validation logic.

- Added `AmendmentField`, `AmendmentStatus`, `AmendmentRecord` types and `description` field to `Invoice` in `common/src/lib.rs`
- Added amendment storage helpers and methods (`request_amendment`, `approve_amendment`, `reject_amendment`, `get_amendments`, `apply_amendment_to_invoice`) to `registry/src/lib.rs`
- Added 12 amendment tests to `registry/src/test.rs`
- All 175 tests pass, clippy clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added invoice descriptions.
  * Added amendment requests for invoice amounts, due dates, and descriptions.
  * Added amendment approval, rejection, status tracking, and history retrieval.
  * Pending invoices apply amendments automatically; financed invoices require approval.
  * Added validation and authorization throughout the amendment workflow.
  * Amount amendments that affect financing can return an invoice to pending status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->