### PR TITLE
feat(insurance): allow unstake while paused (emergency withdrawal path)

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -690,9 +690,11 @@ pub fn resolve_token(env: &Env, currency: &Symbol) -> Address {
 ///     set_reputation, set_penalty, transfer_admin.
 ///   - exceptions: pause, unpause, contract_is_paused, getters.
 /// - Insurance:
-///   - state-changing: stake, unstake, pay_out, set_staking_token, set_payout_caller,
+///   - state-changing: stake, pay_out, set_staking_token, set_payout_caller,
 ///     transfer_admin.
-///   - exceptions: pause, unpause, contract_is_paused, getters.
+///   - exceptions: pause, unpause, contract_is_paused, getters, and `unstake`
+///     (an emergency withdrawal path that stays available while paused —
+///     see issue #67 and ADR-0008).
 /// - Reputation:
 ///   - state-changing: record_outcome, resolve_dispute, set_recorder.
 ///   - exceptions: pause, unpause, contract_is_paused, getters.

--- a/docs/adr/0011-emergency-unstake-while-paused.md
+++ b/docs/adr/0011-emergency-unstake-while-paused.md
@@ -1,0 +1,61 @@
+# ADR-0011 — Emergency withdrawal path while the insurance pool is paused
+
+**Status:** Accepted
+
+## Context
+
+ADR-0001 introduced a same-block emergency pause (circuit breaker) in which
+every state-changing function begins with `assert_not_paused`. The insurance
+pool's `stake` and `unstake` were both treated as paused operations like any
+other.
+
+That creates a liveness hazard specific to the insurance pool: the pause switch
+exists to stop *the wider protocol* (invoice financing, repayments, payouts) when
+something is wrong. It is not about the stakers themselves. If a pause is
+triggered for a prolonged incident, stakers have no path to withdraw their own
+funds — money stays locked indefinitely even though the incident may be entirely
+unrelated to them (see issue #67).
+
+## Decision
+
+`unstake` is **not** guarded by `assert_not_paused`. A staker may withdraw their
+own position at any time, including while the pool is paused. `stake` and
+`pay_out` remain pause-guarded.
+
+The rationale is the direction of the mutation:
+
+- **`stake`** moves new funds *into* the pool and grows the protocol's exposure.
+  During an incident it must stay locked so an attacker or confused user cannot
+  grow a position the protocol may need to unwind.
+- **`pay_out`** moves pooled funds *to a third party* (a lender) automatically.
+  This is the highest-risk operation and must never run during an incident.
+- **`unstake`** only unwinds the caller's *own* claim and moves the pool's own
+  holdings back to the staker. It is a safety valve, not a state mutation of the
+  wider protocol: it reduces the pool's exposure, cannot grow anyone else's
+  position, and cannot move funds the staker does not already own. Letting it
+  succeed while paused is strictly safer for stakers and does not interfere with
+  the incident response.
+
+The alternative — fully locked funds plus an admin-gated
+`emergency_withdraw` that refunds every staker pro-rata — was considered and
+rejected. It concentrates yet more power in the single pause/admin key (the very
+trust assumption ADR-0001 already flags as a single point of compromise),
+requires a new permissioned entry point with its own edge cases (rounding,
+iteration over unbounded staker sets, race with `pay_out`), and still does not
+let an individual staker exit on their own terms. A per-staker `unstake` is the
+smallest change that satisfies the requirement and keeps custody with the staker.
+
+## Consequences
+
+- Stakers can always recover their funds, so a prolonged pause no longer locks
+  them out. Withdrawals remain a safety valve.
+- Staking new funds and automatic payouts stay halted while paused, preserving
+  the circuit breaker's purpose.
+- The pause-guard coverage matrix in `invofi_common` is updated to list `unstake`
+  as an explicit exception alongside `pause`/`unpause`/getters.
+- The pool's accounting invariants are unaffected: `unstake` performs the same
+  balance/pool-total reduction and token transfer whether or not the pool is
+  paused, so `get_stake` sums continue to equal `get_pool_total`.
+- This amends ADR-0001's blanket statement that "every state-changing function
+  begins with `assert_not_paused`" for this one, narrowly-scoped insurance
+  function.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,6 +15,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0008 | [Offer amendment and counter-offer](./0008-offer-negotiation.md) | Proposed |
 | 0009 | [Invoice verification oracle](./0009-verification-oracle.md) | Proposed |
 | 0010 | [M-of-N admin governance (multisig)](./0010-multisig-admin-governance.md) | Accepted |
+| 0011 | [Emergency withdrawal path while the insurance pool is paused](./0011-emergency-unstake-while-paused.md) | Accepted |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -838,8 +838,13 @@ impl InsuranceContract {
     /// added to the banked amount, and transferred to the staker together with
     /// the requested principal. The `pool_yld` event is emitted for the yield
     /// component if non-zero.
+    ///
+    /// **Emergency withdrawal path (issue #67):** deliberately *not* guarded by
+    /// `assert_not_paused`. Withdrawing is a safety valve for stakers — it only
+    /// unwinds a staker's own position and cannot mutate the wider protocol —
+    /// so it stays available during an emergency pause. `stake` and `pay_out`
+    /// remain paused. See ADR-0011.
     pub fn unstake(env: Env, staker: Address, amount: i128) {
-        assert_not_paused(&env);
         staker.require_auth();
         if amount <= 0 {
             env.panic_with_error(ContractError::InvalidInput);

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -229,7 +229,7 @@ fn test_paused_blocks_stake() {
 }
 
 #[test]
-fn test_pause_blocks_all_insurance_state_changes() {
+fn test_pause_blocks_state_changes_except_unstake() {
     let env = Env::default();
     env.mock_all_auths();
     let admin = Address::generate(&env);
@@ -250,9 +250,6 @@ fn test_pause_blocks_all_insurance_state_changes() {
         client.stake(&staker, &1_000i128);
     });
     assert_paused(|| {
-        client.unstake(&staker, &1_000i128);
-    });
-    assert_paused(|| {
         client.pay_out(&soroban_sdk::symbol_short!("inv_x"), &beneficiary, &1_000i128);
     });
     assert_paused(|| {
@@ -270,8 +267,7 @@ fn test_pause_blocks_all_insurance_state_changes() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #4)")]
-fn test_paused_blocks_unstake() {
+fn test_paused_allows_unstake() {
     let env = Env::default();
     env.mock_all_auths();
 
@@ -283,7 +279,16 @@ fn test_paused_blocks_unstake() {
     client.stake(&staker, &1_000_000);
 
     client.pause(&one(&env, &admin));
+    assert!(client.contract_is_paused());
+
+    // Emergency withdrawal: unstake succeeds while paused (issue #67).
     client.unstake(&staker, &100_000);
+
+    assert_eq!(client.get_stake(&staker), 900_000);
+    assert_eq!(client.get_pool_total(), 900_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 100_000);
+    assert_eq!(client.get_contract_token_balance(), 900_000);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #67

Fixes the emergency withdrawal path for insurance stakers: `unstake` now succeeds while the pool is paused, so a prolonged emergency pause can no longer lock stakers out of their own funds. `stake` and `pay_out` remain pause-guarded.

## Problem

The pause switch (Task 4A) makes every state-changing function call `assert_not_paused`, and insurance `stake`/`unstake` were treated like any other paused operation. If a pause is triggered for a prolonged incident, stakers had no way to withdraw their own funds even though the incident is unrelated to them — money stayed locked with no path out.

## Change

- `insurance::unstake` no longer calls `assert_not_paused` (`insurance/src/lib.rs`).
- `stake` and `pay_out` are unchanged and stay pause-guarded.
- The pause-guard coverage matrix in `invofi_common` is updated to list `unstake` as an explicit exception.
- New **ADR-0008** documents the decision and the rejected alternative (admin-gated pro-rata `emergency_withdraw`).
- README (insurance function table + note) and `docs/adr/README.md` updated.

## Why unstake stays open

Withdrawing is a safety valve, not a state mutation of the wider protocol:

| Function | While paused | Why |
|---|---|---|
| `stake` | blocked | Grows the pool's exposure — must not run mid-incident |
| `pay_out` | blocked | Moves pooled funds to a third party automatically — highest-risk operation |
| `unstake` | allowed | Only unwinds the caller's own claim; reduces exposure and cannot move funds the staker does not own |

The alternative of fully-locked funds plus an admin `emergency_withdraw` that refunds every staker pro-rata was considered and rejected (see ADR-0008): it concentrates more power in the single pause/admin key and still does not let an individual staker exit on their own terms.

## Acceptance criteria

- [x] Paused pool → staker calls `unstake` → succeeds and balance decrements (`test_paused_allows_unstake`).
- [x] Paused pool → new `stake` → still reverts (`test_paused_blocks_stake`, `test_pause_blocks_state_changes_except_unstake`).
- [x] Behavior documented in the insurance ADR (`docs/adr/0008-emergency-unstake-while-paused.md`) and README.

## Testing

- `cargo test --target <host>` — full workspace suite passes (insurance: 21/21 tests).
- `cargo clippy -p invofi-insurance -p invofi-common --target wasm32v1-none -- -D warnings` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Insurance stakers can now withdraw their funds while the pool is paused, supporting emergency access during incidents.
  - New architectural documentation explains the pause behavior and emergency withdrawal decision.

- **Documentation**
  - Updated pause-coverage documentation to identify withdrawals as an exception.
  - Added ADR entries covering offer negotiation, invoice verification, multisig governance, and emergency withdrawals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->