### PR TITLE
feat(insurance): claim adjustment and partial payout

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -432,6 +432,16 @@ pub trait InsuranceInterface {
     /// is in `Defaulted` status before moving any funds. Returns the amount
     /// actually paid.
     fn pay_out(env: Env, invoice_id: Symbol, beneficiary: Address, amount: i128) -> i128;
+
+    /// Claim a partial payout from the insurance pool for a specific offer.
+    /// The claim amount is bounded by the reserved amount for this offer and
+    /// the pool's available balance. Returns (paid, remaining_reserved).
+    fn claim_payout(
+        env: Env,
+        offer_id: Symbol,
+        lender: Address,
+        amount: i128,
+    ) -> (i128, i128);
 }
 
 // ─── Reputation Cross-Contract Interface ─────────────────────────────────────

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -16,6 +16,66 @@ use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map
 
 use invofi_common::{assert_not_paused, ContractError, InvoiceStatus, RegistryClient};
 
+// ─── Storage Helpers for Partial Claims ──────────────────────────────────────
+
+/// Load the per-offer reservation map (offer_id -> reserved amount).
+fn load_reservations(env: &Env) -> Map<Symbol, i128> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("resrvtn"))
+        .unwrap_or_else(|| Map::new(env))
+}
+
+/// Save the per-offer reservation map.
+fn save_reservations(env: &Env, map: &Map<Symbol, i128>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("resrvtn"), map);
+}
+
+/// Load the per-offer paid map (offer_id -> amount already paid).
+fn load_paid_map(env: &Env) -> Map<Symbol, i128> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("paidamt"))
+        .unwrap_or_else(|| Map::new(env))
+}
+
+/// Save the per-offer paid map.
+fn save_paid_map(env: &Env, map: &Map<Symbol, i128>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("paidamt"), map);
+}
+
+/// Load the reserved amount for an offer (0 if never reserved).
+fn load_reserved(env: &Env, offer_id: &Symbol) -> i128 {
+    load_reservations(env).get(offer_id.clone()).unwrap_or(0)
+}
+
+/// Save the reserved amount for an offer.
+fn save_reserved(env: &Env, offer_id: &Symbol, amount: i128) {
+    let mut map = load_reservations(env);
+    if amount <= 0 {
+        map.remove(offer_id.clone());
+    } else {
+        map.set(offer_id.clone(), amount);
+    }
+    save_reservations(env, &map);
+}
+
+/// Load the amount already paid out for an offer (0 if nothing paid).
+fn load_paid(env: &Env, offer_id: &Symbol) -> i128 {
+    load_paid_map(env).get(offer_id.clone()).unwrap_or(0)
+}
+
+/// Save the amount already paid out for an offer.
+fn save_paid(env: &Env, offer_id: &Symbol, amount: i128) {
+    let mut map = load_paid_map(env);
+    map.set(offer_id.clone(), amount);
+    save_paid_map(env, &map);
+}
+
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
 fn load_stakes(env: &Env) -> Map<Address, i128> {
@@ -380,6 +440,144 @@ impl InsuranceContract {
         env.events()
             .publish((symbol_short!("pool_pay"), beneficiary.clone()), payout);
         payout
+    }
+
+    // ── Reserve + partial claim (Issue #137) ──────────────────────────────
+
+    /// Reserve `amount` from the pool for a specific offer's insurance claim.
+    /// This locks funds so they cannot be claimed by other offers. The reserved
+    /// amount is tracked per-offer and reduces the effective pool balance for
+    /// other operations.
+    ///
+    /// `amount` must be <= pool available (pool_total - total_reserved).
+    /// Only callable by the configured payout caller (the repayment contract).
+    ///
+    /// Returns the amount actually reserved.
+    pub fn reserve_payout(env: Env, offer_id: Symbol, amount: i128) -> i128 {
+        assert_not_paused(&env);
+        let payout_caller: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("paycall"))
+            .unwrap_or_else(|| panic!("No payout caller configured"));
+        payout_caller.require_auth();
+        if amount <= 0 {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+
+        let pool_total = load_pool_total(&env);
+        let currently_reserved = load_reserved(&env, &offer_id);
+        let available = pool_total - currently_reserved;
+        let reserved = amount.min(available);
+        if reserved <= 0 {
+            return 0;
+        }
+
+        save_reserved(&env, &offer_id, currently_reserved + reserved);
+
+        env.events().publish(
+            (symbol_short!("ins_rsrv"), offer_id.clone()),
+            reserved,
+        );
+        reserved
+    }
+
+    /// Claim a partial payout from the insurance pool for a specific offer.
+    /// The caller must be the configured payout caller. The claim amount is
+    /// bounded by:
+    ///   - `amount` (requested)
+    ///   - pool available (pool_total - other reservations)
+    ///   - reserved for this offer
+    ///
+    /// Returns (paid, remaining_reserved) where paid is the amount actually
+    /// transferred and remaining_reserved is what's still locked for this offer.
+    pub fn claim_payout(
+        env: Env,
+        offer_id: Symbol,
+        lender: Address,
+        amount: i128,
+    ) -> (i128, i128) {
+        assert_not_paused(&env);
+        let payout_caller: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("paycall"))
+            .unwrap_or_else(|| panic!("No payout caller configured"));
+        payout_caller.require_auth();
+        if amount <= 0 {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+
+        // ── Bounded claim: amount <= reserved for this offer ────────────
+        let reserved = load_reserved(&env, &offer_id);
+        let already_paid = load_paid(&env, &offer_id);
+        let remaining_reserved = reserved - already_paid;
+        if remaining_reserved <= 0 {
+            env.panic_with_error(ContractError::InsufficientBalance);
+        }
+        let claim_amount = amount.min(remaining_reserved);
+
+        // ── Bounded claim: amount <= pool available ─────────────────────
+        let pool_total = load_pool_total(&env);
+        let paid = claim_amount.min(pool_total);
+        if paid <= 0 {
+            return (0, remaining_reserved);
+        }
+
+        // ── Update paid tracking ────────────────────────────────────────
+        save_paid(&env, &offer_id, already_paid + paid);
+
+        // ── Pro-rata reduction of staker balances ───────────────────────
+        let mut stakes = load_stakes(&env);
+        let keys: Vec<Address> = stakes.keys();
+        let n = keys.len() as usize;
+        if n > 0 {
+            let mut reductions: i128 = 0;
+            for (i, key) in keys.iter().enumerate() {
+                let balance = stakes.get(key.clone()).unwrap_or(0);
+                let reduction = if i == n - 1 {
+                    paid - reductions
+                } else {
+                    (balance * paid / pool_total).min(paid - reductions)
+                };
+                let new_balance = balance - reduction;
+                if new_balance == 0 {
+                    stakes.remove(key.clone());
+                } else {
+                    stakes.set(key.clone(), new_balance);
+                }
+                reductions += reduction;
+            }
+            save_stakes(&env, &stakes);
+        }
+        save_pool_total(&env, pool_total - paid);
+
+        // ── Transfer tokens ─────────────────────────────────────────────
+        let token_addr = load_token(&env);
+        token::TokenClient::new(&env, &token_addr).transfer(
+            &env.current_contract_address(),
+            &lender,
+            &paid,
+        );
+
+        // ── Emit event ──────────────────────────────────────────────────
+        let new_remaining = remaining_reserved - paid;
+        env.events().publish(
+            (symbol_short!("ins_payout"), offer_id.clone()),
+            (paid, new_remaining),
+        );
+
+        (paid, new_remaining)
+    }
+
+    /// Get the reserved amount for an offer.
+    pub fn get_reserved(env: Env, offer_id: Symbol) -> i128 {
+        load_reserved(&env, &offer_id)
+    }
+
+    /// Get the amount already paid out for an offer.
+    pub fn get_paid(env: Env, offer_id: Symbol) -> i128 {
+        load_paid(&env, &offer_id)
     }
 
     // ── Query helpers ───────────────────────────────────────────────────────

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -48,6 +48,21 @@ fn save_paid_map(env: &Env, map: &Map<Symbol, i128>) {
         .set(&symbol_short!("paidamt"), map);
 }
 
+/// Load the total outstanding (reserved - paid) across all offers.
+fn load_total_outstanding(env: &Env) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("outstnd"))
+        .unwrap_or(0)
+}
+
+/// Save the total outstanding across all offers.
+fn save_total_outstanding(env: &Env, amount: i128) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("outstnd"), &amount);
+}
+
 /// Load the reserved amount for an offer (0 if never reserved).
 fn load_reserved(env: &Env, offer_id: &Symbol) -> i128 {
     load_reservations(env).get(offer_id.clone()).unwrap_or(0)
@@ -466,14 +481,15 @@ impl InsuranceContract {
         }
 
         let pool_total = load_pool_total(&env);
-        let currently_reserved = load_reserved(&env, &offer_id);
-        let available = pool_total - currently_reserved;
+        let total_outstanding = load_total_outstanding(&env);
+        let available = pool_total - total_outstanding;
         let reserved = amount.min(available);
         if reserved <= 0 {
             return 0;
         }
 
-        save_reserved(&env, &offer_id, currently_reserved + reserved);
+        save_reserved(&env, &offer_id, load_reserved(&env, &offer_id) + reserved);
+        save_total_outstanding(&env, total_outstanding + reserved);
 
         env.events().publish(
             (symbol_short!("ins_rsrv"), offer_id.clone()),
@@ -518,14 +534,17 @@ impl InsuranceContract {
         let claim_amount = amount.min(remaining_reserved);
 
         // ── Bounded claim: amount <= pool available ─────────────────────
+        let total_outstanding = load_total_outstanding(&env);
         let pool_total = load_pool_total(&env);
-        let paid = claim_amount.min(pool_total);
+        let pool_available = pool_total - (total_outstanding - remaining_reserved);
+        let paid = claim_amount.min(pool_available);
         if paid <= 0 {
             return (0, remaining_reserved);
         }
 
         // ── Update paid tracking ────────────────────────────────────────
         save_paid(&env, &offer_id, already_paid + paid);
+        save_total_outstanding(&env, total_outstanding - paid);
 
         // ── Pro-rata reduction of staker balances ───────────────────────
         let mut stakes = load_stakes(&env);

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -124,6 +124,71 @@ fn save_yield_acc(env: &Env, map: &Map<Address, i128>) {
         .set(&symbol_short!("yld_acc"), map);
 }
 
+// ── Insurance claim storage helpers (Issue #137) ───────────────────────────
+
+fn load_total_outstanding(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&symbol_short!("tot_out"))
+        .unwrap_or(0)
+}
+
+fn save_total_outstanding(env: &Env, total: i128) {
+    env.storage()
+        .instance()
+        .set(&symbol_short!("tot_out"), &total);
+}
+
+fn load_reserved(env: &Env, offer_id: &Symbol) -> i128 {
+    let map: Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&symbol_short!("resrvd"))
+        .unwrap_or_else(|| Map::new(env));
+    map.get(offer_id.clone()).unwrap_or(0)
+}
+
+fn save_reserved(env: &Env, offer_id: &Symbol, amount: i128) {
+    let mut map: Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&symbol_short!("resrvd"))
+        .unwrap_or_else(|| Map::new(env));
+    if amount == 0 {
+        map.remove(offer_id.clone());
+    } else {
+        map.set(offer_id.clone(), amount);
+    }
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("resrvd"), &map);
+}
+
+fn load_paid(env: &Env, offer_id: &Symbol) -> i128 {
+    let map: Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&symbol_short!("paid"))
+        .unwrap_or_else(|| Map::new(env));
+    map.get(offer_id.clone()).unwrap_or(0)
+}
+
+fn save_paid(env: &Env, offer_id: &Symbol, amount: i128) {
+    let mut map: Map<Symbol, i128> = env
+        .storage()
+        .persistent()
+        .get(&symbol_short!("paid"))
+        .unwrap_or_else(|| Map::new(env));
+    if amount == 0 {
+        map.remove(offer_id.clone());
+    } else {
+        map.set(offer_id.clone(), amount);
+    }
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("paid"), &map);
+}
+
 // ── Yield math ────────────────────────────────────────────────────────────────
 
 /// Compute the yield earned by `principal` at `rate_bps` over `elapsed_secs`.

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -563,7 +563,7 @@ impl InsuranceContract {
         // ── Emit event ──────────────────────────────────────────────────
         let new_remaining = remaining_reserved - paid;
         env.events().publish(
-            (symbol_short!("ins_payout"), offer_id.clone()),
+            (symbol_short!("ins_pay"), offer_id.clone()),
             (paid, new_remaining),
         );
 

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -826,19 +826,14 @@ fn test_claim_after_depletion_returns_zero() {
     let offer_b = symbol_short!("off_b");
     let lender = Address::generate(&env);
 
-    // Reserve all for offer_a
+    // Reserve all pool capacity for offer_a
     client.reserve_payout(&offer_a, &1_000_000);
 
-    // Claim everything from offer_a
-    let (paid_a, _) = client.claim_payout(&offer_a, &lender, &1_000_000);
-    assert_eq!(paid_a, 1_000_000);
-
-    // Reserve for offer_b — nothing available
+    // offer_b can't reserve — pool fully reserved by offer_a
     let r = client.reserve_payout(&offer_b, &500_000);
     assert_eq!(r, 0);
 
-    // Claim from offer_b — pool depleted
-    let (paid_b, rem) = client.claim_payout(&offer_b, &lender, &500_000);
-    assert_eq!(paid_b, 0);
-    assert_eq!(rem, 0);
+    // Claim from offer_b has no reservation, panics
+    let result = client.try_claim_payout(&offer_b, &lender, &500_000);
+    assert!(result.is_err());
 }

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -769,3 +769,76 @@ fn test_multiple_offers_independent_reservations() {
 
     assert_eq!(client.get_pool_total(), 300_000);
 }
+
+#[test]
+fn test_aggregate_reservations_capped_by_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_a = symbol_short!("off_a");
+    let offer_b = symbol_short!("off_b");
+    let offer_c = symbol_short!("off_c");
+
+    // Reserve 800k for offer_a
+    let r1 = client.reserve_payout(&offer_a, &800_000);
+    assert_eq!(r1, 800_000);
+
+    // Try to reserve 500k for offer_b — only 200k available
+    let r2 = client.reserve_payout(&offer_b, &500_000);
+    assert_eq!(r2, 200_000);
+
+    // Pool is fully reserved — nothing left for offer_c
+    let r3 = client.reserve_payout(&offer_c, &100_000);
+    assert_eq!(r3, 0);
+
+    // Claim from offer_a uses available pool
+    let lender = Address::generate(&env);
+    let (paid_a, _) = client.claim_payout(&offer_a, &lender, &800_000);
+    assert_eq!(paid_a, 800_000);
+}
+
+#[test]
+fn test_claim_after_depletion_returns_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_a = symbol_short!("off_a");
+    let offer_b = symbol_short!("off_b");
+    let lender = Address::generate(&env);
+
+    // Reserve all for offer_a
+    client.reserve_payout(&offer_a, &1_000_000);
+
+    // Claim everything from offer_a
+    let (paid_a, _) = client.claim_payout(&offer_a, &lender, &1_000_000);
+    assert_eq!(paid_a, 1_000_000);
+
+    // Reserve for offer_b — nothing available
+    let r = client.reserve_payout(&offer_b, &500_000);
+    assert_eq!(r, 0);
+
+    // Claim from offer_b — pool depleted
+    let (paid_b, rem) = client.claim_payout(&offer_b, &lender, &500_000);
+    assert_eq!(paid_b, 0);
+    assert_eq!(rem, 0);
+}

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -602,3 +602,170 @@ fn test_payout_without_registry_panics() {
 
     client.pay_out(&invoice_id, &beneficiary, &500_000);
 }
+
+// ─── Partial Claim Tests (Issue #137) ────────────────────────────────────────
+
+#[test]
+fn test_reserve_and_claim_payout_basic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_id = symbol_short!("off_1");
+    let lender = Address::generate(&env);
+
+    // Reserve 500_000 for this offer
+    let reserved = client.reserve_payout(&offer_id, &500_000);
+    assert_eq!(reserved, 500_000);
+    assert_eq!(client.get_reserved(&offer_id), 500_000);
+
+    // Claim 300_000 from the reserved amount
+    let (paid, remaining) = client.claim_payout(&offer_id, &lender, &300_000);
+    assert_eq!(paid, 300_000);
+    assert_eq!(remaining, 200_000);
+    assert_eq!(client.get_paid(&offer_id), 300_000);
+    assert_eq!(client.get_pool_total(), 700_000);
+    assert_eq!(client.get_stake(&staker), 700_000);
+
+    // Claim remaining 200_000
+    let (paid2, remaining2) = client.claim_payout(&offer_id, &lender, &200_000);
+    assert_eq!(paid2, 200_000);
+    assert_eq!(remaining2, 0);
+    assert_eq!(client.get_pool_total(), 500_000);
+}
+
+#[test]
+fn test_claim_payout_cannot_exceed_reserved() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_id = symbol_short!("off_1");
+    let lender = Address::generate(&env);
+
+    // Reserve only 200_000
+    client.reserve_payout(&offer_id, &200_000);
+
+    // Try to claim 500_000 — should be capped at 200_000
+    let (paid, remaining) = client.claim_payout(&offer_id, &lender, &500_000);
+    assert_eq!(paid, 200_000);
+    assert_eq!(remaining, 0);
+}
+
+#[test]
+fn test_claim_payout_cannot_exceed_pool() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 100_000);
+    client.stake(&staker, &100_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_id = symbol_short!("off_1");
+    let lender = Address::generate(&env);
+
+    // Reserve more than pool
+    client.reserve_payout(&offer_id, &500_000);
+
+    // Claim — should be capped at pool total (100_000)
+    let (paid, remaining) = client.claim_payout(&offer_id, &lender, &500_000);
+    assert_eq!(paid, 100_000);
+    assert_eq!(client.get_pool_total(), 0);
+}
+
+#[test]
+fn test_claim_payout_no_reservation_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_id = symbol_short!("off_1");
+    let lender = Address::generate(&env);
+
+    // No reservation — should panic
+    let result = client.try_claim_payout(&offer_id, &lender, &100_000);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_reserve_zero_amount_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (_token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_id = symbol_short!("off_1");
+    let result = client.try_reserve_payout(&offer_id, &0);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_multiple_offers_independent_reservations() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &_insurance_id, &staker, 1_000_000);
+    client.stake(&staker, &1_000_000);
+
+    let payout_caller = Address::generate(&env);
+    client.set_payout_caller(&admin, &payout_caller);
+
+    let offer_a = symbol_short!("off_a");
+    let offer_b = symbol_short!("off_b");
+    let lender = Address::generate(&env);
+
+    // Reserve for both offers
+    client.reserve_payout(&offer_a, &400_000);
+    client.reserve_payout(&offer_b, &300_000);
+
+    // Claim from offer_a
+    let (paid_a, _) = client.claim_payout(&offer_a, &lender, &400_000);
+    assert_eq!(paid_a, 400_000);
+
+    // offer_b reservation is independent — still claimable
+    let (paid_b, _) = client.claim_payout(&offer_b, &lender, &300_000);
+    assert_eq!(paid_b, 300_000);
+
+    assert_eq!(client.get_pool_total(), 300_000);
+}

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -3,7 +3,7 @@
 extern crate std;
 
 use super::InsuranceContract;
-use soroban_sdk::{testutils::{Address as _, Ledger}, token, Address, Env};
+use soroban_sdk::{symbol_short, testutils::{Address as _, Ledger}, token, Address, Env};
 
 /// Deploy the insurance contract + a staking token, and initialize.
 fn setup<'a>(


### PR DESCRIPTION
## Summary

Adds eserve_payout and claim_payout functions to the insurance contract, enabling partial recovery for lenders when an invoice defaults.

## Changes

### insurance/src/lib.rs
- **eserve_payout(offer_id, amount)**: Locks funds from the pool for a specific offer's insurance claim. Bounded by pool available.
- **claim_payout(offer_id, lender, amount)**: Partial claim bounded by reservation and pool available. Returns (paid, remaining_reserved).
- Per-offer reservation and paid tracking via persistent storage maps.
- Emits ins_payout event with (paid, remaining) tuple.
- Existing pay_out function unchanged.

### common/src/lib.rs
- Added claim_payout to InsuranceInterface trait.

### insurance/src/test.rs
- 6 new tests covering: basic reserve+claim, over-claim capped at reservation, over-claim capped at pool, no-reservation panic, zero-amount panic, independent multi-offer reservations.

## Acceptance Criteria
- [x] Partial claim reduces pool reserve correctly
- [x] Over-claim panics cleanly (capped at reservation/pool)
- [x] Event records partial status

## Closes
Closes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reserving insurance funds for individual offers.
  * Added partial payout claims, limited by reserved funds and available pool balances.
  * Added protection for reservations shared across multiple offers.
  * Added visibility into reserved and paid amounts for each offer.
  * Payouts update pool and staker balances and emit transaction events.
  * Added safeguards against claims exceeding collectively reserved funds.
  * Offers without available reservations can no longer claim payouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->