### PR TITLE
feat(insurance): add configurable flat yield on staked funds

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,10 +113,10 @@ register_invoice()  →  create_offer()  →  accept_offer()
 | `get_contract_token_balance()` | Anyone | Actual on-chain balance — audit check that accounting matches |
 | `pay_out(beneficiary, amount)` | Payout caller only (repayment) | Pay up to `amount`, capped at pool balance; returns amount actually paid |
 | `get_payout_caller()` | Anyone | Read the configured payout caller |
+| `set_yield_rate(admin, rate_bps)` | Admin | Set the annual flat yield rate in basis points (e.g. 500 = 5 %). Banks existing yield prospectively before applying the new rate |
+| `get_yield_rate()` | Anyone | Read the current annual yield rate in basis points |
+| `accrued_yield(staker)` | Anyone | Preview the total accrued yield for a staker (banked + since last checkpoint) |
 | `set_staking_token / pause / unpause / transfer_admin` | Admin | Admin controls |
-
-> Yield-rate calculation remains intentionally out of scope — the pool is flat accounting with
-> payout-on-default wired through `pay_out`. See ADR-0003 for the payout design.
 
 ---
 
@@ -171,6 +171,7 @@ Every state-mutating function publishes a Soroban contract event. Topics are
 | `pool_stk` | `stake` (insurance) | `amount` |
 | `pool_un` | `unstake` (insurance) | `amount` |
 | `pool_pay` | `pay_out` (insurance) | `amount paid` |
+| `pool_yld` | `unstake` (insurance) | `yield paid` — emitted only when yield > 0 |
 | `reputn` | `record_outcome` (reputation) | `outcome` |
 
 ---

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -7,14 +7,43 @@
 //! configured payout caller) calls `pay_out`, which compensates the lender
 //! from the pool up to the pool's available balance and reduces every
 //! staker's claim pro-rata so accounting stays exactly consistent (unstake
-//! can never exceed actual pool funds). Yield-rate calculation stays out of
-//! scope.
+//! can never exceed actual pool funds).
 //!
-//! Task 10 security: pay_out verifies invoice.status == Defaulted on-chain.
+//! # Flat yield (issue #130)
+//!
+//! An admin-configurable annual yield rate (in basis points) accrues linearly
+//! on each staker's principal from the moment they stake. Yield is computed
+//! and paid out when the staker calls `unstake`.
+//!
+//! Key design decisions:
+//! - Rate is stored as a `u32` annual basis-points value (`"yldrate"`,
+//!   instance storage). Default is 0 — the pool is economically inert until
+//!   an admin sets the rate.
+//! - Per-staker stake start-time is tracked in `"stk_ts"` (persistent
+//!   `Map<Address, u64>`, ledger timestamp in seconds).
+//! - Banked yield (accrued under prior rate slabs) is stored separately in
+//!   `"yld_acc"` (persistent `Map<Address, i128>`). When a staker top-ups
+//!   their stake or the admin changes the rate, all existing stakers'
+//!   outstanding yield is computed at the *current* rate and banked, then the
+//!   clock resets. This ensures rate changes are **strictly prospective**.
+//! - Formula: `yield = principal × rate_bps × elapsed_secs
+//!             / (10_000 × SECONDS_PER_YEAR)`
+//!   where `SECONDS_PER_YEAR = 31_536_000`.
+//! - No compounding; no per-staker rate differentiation.
+//! - Yield is paid out separately from the pool principal — it is *not*
+//!   included in `pool_total` bookkeeping — so payouts and unstake accounting
+//!   are unaffected unless the pool has enough balance to cover the yield
+//!   component on top of the principal.
+//! - The `pool_yld` event is emitted on every yield payout.
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{assert_not_paused, ContractError, InvoiceStatus, RegistryClient};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Seconds in a 365-day year. Mirrors `MAX_OFFER_DURATION_SECS` in common.
+const SECONDS_PER_YEAR: u64 = 31_536_000;
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -49,6 +78,108 @@ fn load_token(env: &Env) -> Address {
         .instance()
         .get(&symbol_short!("token"))
         .unwrap_or_else(|| panic!("Not initialized"))
+}
+
+// ── Yield storage helpers ────────────────────────────────────────────────────
+
+/// Annual yield rate in basis points (e.g. 500 = 5.00%). Default 0.
+fn load_yield_rate(env: &Env) -> u32 {
+    env.storage()
+        .instance()
+        .get(&symbol_short!("yldrate"))
+        .unwrap_or(0)
+}
+
+fn save_yield_rate(env: &Env, rate_bps: u32) {
+    env.storage()
+        .instance()
+        .set(&symbol_short!("yldrate"), &rate_bps);
+}
+
+/// Stake-start timestamps: `Address -> ledger timestamp (seconds)`.
+fn load_stake_ts(env: &Env) -> Map<Address, u64> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("stk_ts"))
+        .unwrap_or_else(|| Map::new(env))
+}
+
+fn save_stake_ts(env: &Env, map: &Map<Address, u64>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("stk_ts"), map);
+}
+
+/// Banked (already-accrued) yield waiting for the staker to claim.
+fn load_yield_acc(env: &Env) -> Map<Address, i128> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("yld_acc"))
+        .unwrap_or_else(|| Map::new(env))
+}
+
+fn save_yield_acc(env: &Env, map: &Map<Address, i128>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("yld_acc"), map);
+}
+
+// ── Yield math ────────────────────────────────────────────────────────────────
+
+/// Compute the yield earned by `principal` at `rate_bps` over `elapsed_secs`.
+///
+/// Formula: `principal * rate_bps * elapsed_secs / (10_000 * SECONDS_PER_YEAR)`
+///
+/// Integer truncation means yield rounds **down** (in the protocol's favour).
+/// Overflow: `principal` fits in i128 (≤ 2^127 − 1); `rate_bps` ≤ 65 535;
+/// `elapsed_secs` ≤ 31 536 000.  The intermediate product can reach
+/// ~2^127 × 65 535 × 3.15×10^7 which overflows plain i128.  We therefore
+/// split the multiplication into two steps, dividing by SECONDS_PER_YEAR
+/// first to keep the intermediate value inside i128.
+fn compute_yield(principal: i128, rate_bps: u32, elapsed_secs: u64) -> i128 {
+    if principal == 0 || rate_bps == 0 || elapsed_secs == 0 {
+        return 0;
+    }
+    // Step 1: principal * elapsed_secs  (always positive and fits in i128 for
+    //         realistic values: 2^127 / SECONDS_PER_YEAR ~ 5.4×10^31, which
+    //         exceeds any realistic token supply)
+    let numerator = principal * elapsed_secs as i128;
+    // Step 2: divide by SECONDS_PER_YEAR first to tame the value, then
+    //         multiply by rate_bps, then divide by 10_000.
+    numerator / SECONDS_PER_YEAR as i128 * rate_bps as i128 / 10_000
+}
+
+/// Bank the yield accrued since the staker's last timestamp, then reset the
+/// timestamp to `now`. Returns the amount just banked.
+///
+/// This is called:
+/// - On `stake` top-up (so the new principal doesn't inflate historical yield)
+/// - On `set_yield_rate` for all existing stakers (so the new rate applies
+///   only from this point forward)
+/// - On `unstake` just before paying out
+fn bank_accrued_yield(
+    env: &Env,
+    staker: &Address,
+    stakes: &Map<Address, i128>,
+    timestamps: &mut Map<Address, u64>,
+    accruals: &mut Map<Address, i128>,
+    now: u64,
+) -> i128 {
+    let principal = stakes.get(staker.clone()).unwrap_or(0);
+    if principal == 0 {
+        return 0;
+    }
+    let start = timestamps.get(staker.clone()).unwrap_or(now);
+    let elapsed = now.saturating_sub(start);
+    let rate = load_yield_rate(env);
+    let earned = compute_yield(principal, rate, elapsed);
+    if earned > 0 {
+        let prev = accruals.get(staker.clone()).unwrap_or(0);
+        accruals.set(staker.clone(), prev + earned);
+    }
+    // Reset the timestamp so future accrual starts from now.
+    timestamps.set(staker.clone(), now);
+    earned
 }
 
 // ─── Contract ────────────────────────────────────────────────────────────────
@@ -170,6 +301,52 @@ impl InsuranceContract {
         env.storage().instance().get(&symbol_short!("registry"))
     }
 
+    // ── Yield rate (issue #130) ─────────────────────────────────────────────
+
+    /// Set the annual flat yield rate for all stakers, expressed in basis
+    /// points (e.g. 500 = 5.00 %).
+    ///
+    /// **Prospective-only**: before the new rate takes effect, every existing
+    /// staker's yield accrued at the *old* rate is computed and banked. From
+    /// this point forward the new rate applies. Stakers who unstake after the
+    /// rate change receive their previously banked yield (at old rate) plus
+    /// yield accrued at the new rate since this call.
+    ///
+    /// Admin only. Rate may be set to 0 to disable yield entirely.
+    pub fn set_yield_rate(env: Env, admin: Address, rate_bps: u32) {
+        assert_not_paused(&env);
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        // Bank outstanding yield for every staker at the current rate before
+        // the new rate takes effect. This is the key invariant: rate changes
+        // are strictly prospective.
+        let stakes = load_stakes(&env);
+        let mut timestamps = load_stake_ts(&env);
+        let mut accruals = load_yield_acc(&env);
+        let now = env.ledger().timestamp();
+        let keys: Vec<Address> = stakes.keys();
+        for key in keys.iter() {
+            bank_accrued_yield(&env, &key, &stakes, &mut timestamps, &mut accruals, now);
+        }
+        save_stake_ts(&env, &timestamps);
+        save_yield_acc(&env, &accruals);
+
+        save_yield_rate(&env, rate_bps);
+    }
+
+    /// Read the current annual yield rate in basis points. Default is 0.
+    pub fn get_yield_rate(env: Env) -> u32 {
+        load_yield_rate(&env)
+    }
+
     // ── Pause / unpause (Task 4A circuit breaker) ───────────────────────────
 
     pub fn pause(env: Env, admin: Address) {
@@ -215,6 +392,11 @@ impl InsuranceContract {
     /// The staker must first approve this contract as a spender (the same
     /// approve + transfer_from pattern accept_offer uses on the financing
     /// contract). Credits the staker's balance and the pool total.
+    ///
+    /// If the staker already has an existing balance, the yield accrued since
+    /// the last stake is banked at the current rate before the new principal
+    /// is added, and the clock resets. This ensures top-ups do not
+    /// retroactively inflate historical yield.
     pub fn stake(env: Env, staker: Address, amount: i128) {
         assert_not_paused(&env);
         staker.require_auth();
@@ -224,7 +406,8 @@ impl InsuranceContract {
 
         let token_addr = load_token(&env);
         let token_client = token::TokenClient::new(&env, &token_addr);
-        // CEI: External interaction before state mutations. Safe because the token is a trusted standard Soroban token without reentrant hooks.
+        // CEI: External interaction before state mutations. Safe because the
+        // token is a trusted standard Soroban token without reentrant hooks.
         token_client.transfer_from(
             &env.current_contract_address(),
             &staker,
@@ -233,9 +416,31 @@ impl InsuranceContract {
         );
 
         let mut stakes = load_stakes(&env);
-        let balance = stakes.get(staker.clone()).unwrap_or(0);
-        stakes.set(staker.clone(), balance + amount);
+        let mut timestamps = load_stake_ts(&env);
+        let mut accruals = load_yield_acc(&env);
+        let now = env.ledger().timestamp();
+
+        // If staker already has a balance, bank their yield before top-up so
+        // the new principal doesn't inflate historical accrual.
+        let existing = stakes.get(staker.clone()).unwrap_or(0);
+        if existing > 0 {
+            bank_accrued_yield(
+                &env,
+                &staker,
+                &stakes,
+                &mut timestamps,
+                &mut accruals,
+                now,
+            );
+        } else {
+            // First stake — just record the start time.
+            timestamps.set(staker.clone(), now);
+        }
+
+        stakes.set(staker.clone(), existing + amount);
         save_stakes(&env, &stakes);
+        save_stake_ts(&env, &timestamps);
+        save_yield_acc(&env, &accruals);
 
         let mut total = load_pool_total(&env);
         total += amount;
@@ -247,6 +452,11 @@ impl InsuranceContract {
 
     /// Withdraw `amount` back to the staker. Reduces the staker's balance and
     /// the pool total; the pool pays the staker directly from its holdings.
+    ///
+    /// Any yield accrued since the last bank is computed at the current rate,
+    /// added to the banked amount, and transferred to the staker together with
+    /// the requested principal. The `pool_yld` event is emitted for the yield
+    /// component if non-zero.
     pub fn unstake(env: Env, staker: Address, amount: i128) {
         assert_not_paused(&env);
         staker.require_auth();
@@ -260,13 +470,38 @@ impl InsuranceContract {
             env.panic_with_error(ContractError::InsufficientBalance);
         }
 
+        // ── Yield accounting ──────────────────────────────────────────────
+        // Bank any yield accrued since the last checkpoint, then flush the
+        // entire banked amount to the staker.
+        let mut timestamps = load_stake_ts(&env);
+        let mut accruals = load_yield_acc(&env);
+        let now = env.ledger().timestamp();
+
+        bank_accrued_yield(
+            &env,
+            &staker,
+            &stakes,
+            &mut timestamps,
+            &mut accruals,
+            now,
+        );
+        let yield_payout = accruals.get(staker.clone()).unwrap_or(0);
+
+        // ── Principal accounting ───────────────────────────────────────────
         let new_balance = balance - amount;
         if new_balance == 0 {
             stakes.remove(staker.clone());
+            timestamps.remove(staker.clone());
+            accruals.remove(staker.clone());
         } else {
             stakes.set(staker.clone(), new_balance);
+            // Clock already reset by bank_accrued_yield; clear banked yield
+            // since we're paying it all out now.
+            accruals.set(staker.clone(), 0);
         }
         save_stakes(&env, &stakes);
+        save_stake_ts(&env, &timestamps);
+        save_yield_acc(&env, &accruals);
 
         let mut total = load_pool_total(&env);
         total -= amount;
@@ -274,8 +509,21 @@ impl InsuranceContract {
 
         let token_addr = load_token(&env);
         let token_client = token::TokenClient::new(&env, &token_addr);
-        // CEI: External interaction after state mutations (Effects before Interactions). Compliant.
+        // CEI: External interactions after all state mutations (Checks-Effects-Interactions).
+
+        // Transfer principal.
         token_client.transfer(&env.current_contract_address(), &staker, &amount);
+
+        // Transfer yield separately (if any). The yield comes from the pool's
+        // token balance — the protocol must ensure the contract holds enough
+        // tokens to cover accrued yield on top of staked principal.
+        if yield_payout > 0 {
+            token_client.transfer(&env.current_contract_address(), &staker, &yield_payout);
+            env.events().publish(
+                (symbol_short!("pool_yld"), staker.clone()),
+                yield_payout,
+            );
+        }
 
         env.events()
             .publish((symbol_short!("pool_un"), staker.clone()), amount);
@@ -405,6 +653,26 @@ impl InsuranceContract {
         let token_addr = load_token(&env);
         // CEI: Read-only cross-contract call.
         token::TokenClient::new(&env, &token_addr).balance(&env.current_contract_address())
+    }
+
+    /// Compute the total accrued yield for `staker` at the current moment:
+    /// previously banked yield plus yield earned since the last checkpoint at
+    /// the current rate. This is a read-only preview; no state is mutated.
+    pub fn accrued_yield(env: Env, staker: Address) -> i128 {
+        let stakes = load_stakes(&env);
+        let timestamps = load_stake_ts(&env);
+        let accruals = load_yield_acc(&env);
+
+        let principal = stakes.get(staker.clone()).unwrap_or(0);
+        let banked = accruals.get(staker.clone()).unwrap_or(0);
+        if principal == 0 {
+            return banked;
+        }
+        let now = env.ledger().timestamp();
+        let start = timestamps.get(staker.clone()).unwrap_or(now);
+        let elapsed = now.saturating_sub(start);
+        let rate = load_yield_rate(&env);
+        banked + compute_yield(principal, rate, elapsed)
     }
 
     pub fn version(env: Env) -> soroban_sdk::String {

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -131,22 +131,25 @@ fn save_yield_acc(env: &Env, map: &Map<Address, i128>) {
 /// Formula: `principal * rate_bps * elapsed_secs / (10_000 * SECONDS_PER_YEAR)`
 ///
 /// Integer truncation means yield rounds **down** (in the protocol's favour).
-/// Overflow: `principal` fits in i128 (≤ 2^127 − 1); `rate_bps` ≤ 65 535;
-/// `elapsed_secs` ≤ 31 536 000.  The intermediate product can reach
-/// ~2^127 × 65 535 × 3.15×10^7 which overflows plain i128.  We therefore
-/// split the multiplication into two steps, dividing by SECONDS_PER_YEAR
-/// first to keep the intermediate value inside i128.
+///
+/// **Overflow analysis** (all multiplications happen before any division):
+/// - `principal` for any realistic token supply ≤ ~10^18 stroops
+/// - `elapsed_secs` ≤ 31_536_000 (~3.15 × 10^7)
+/// - `rate_bps` ≤ 10_000 (100 %)
+/// - Worst-case intermediate: 10^18 × 3.15×10^7 × 10^4 = 3.15 × 10^29
+/// - i128 max ≈ 1.7 × 10^38  →  comfortable headroom, no overflow
+///
+/// Multiplying before dividing avoids the precision loss that "divide before
+/// multiply" introduces on sub-year or sub-full-principal stakes.
 fn compute_yield(principal: i128, rate_bps: u32, elapsed_secs: u64) -> i128 {
     if principal == 0 || rate_bps == 0 || elapsed_secs == 0 {
         return 0;
     }
-    // Step 1: principal * elapsed_secs  (always positive and fits in i128 for
-    //         realistic values: 2^127 / SECONDS_PER_YEAR ~ 5.4×10^31, which
-    //         exceeds any realistic token supply)
-    let numerator = principal * elapsed_secs as i128;
-    // Step 2: divide by SECONDS_PER_YEAR first to tame the value, then
-    //         multiply by rate_bps, then divide by 10_000.
-    numerator / SECONDS_PER_YEAR as i128 * rate_bps as i128 / 10_000
+    // All multiplications first, single division at the end.
+    // This preserves maximum precision and avoids the divide-before-multiply
+    // precision loss that Scout's detector flags.
+    let denominator = SECONDS_PER_YEAR as i128 * 10_000;
+    principal * elapsed_secs as i128 * rate_bps as i128 / denominator
 }
 
 /// Bank the yield accrued since the staker's last timestamp, then reset the

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -602,3 +602,359 @@ fn test_payout_without_registry_panics() {
 
     client.pay_out(&invoice_id, &beneficiary, &500_000);
 }
+
+// ─── Yield tests (issue #130) ─────────────────────────────────────────────────
+//
+// All yield tests advance ledger timestamps with `env.ledger().set_timestamp`
+// so the elapsed-seconds formula can be verified against known values.
+//
+// Formula reminder:
+//   yield = principal * rate_bps * elapsed_secs / (10_000 * 31_536_000)
+
+/// Helper: set a fresh ledger timestamp (seconds since Unix epoch).
+fn set_ts(env: &Env, ts: u64) {
+    env.ledger().set_timestamp(ts);
+}
+
+/// Mint tokens to the insurance contract itself so it can pay out yield.
+/// In production the pool accumulates revenue from protocol fees / donations;
+/// in tests we mint directly.
+fn fund_yield_reserve(env: &Env, token_id: &Address, insurance_id: &Address, amount: i128) {
+    let asset = token::StellarAssetClient::new(env, token_id);
+    asset.mint(insurance_id, &amount);
+}
+
+// ── Zero-rate baseline ────────────────────────────────────────────────────────
+
+/// With the default yield rate of 0 bps, accrued_yield must always return 0
+/// and unstake pays exactly the principal — no yield is transferred or emitted.
+#[test]
+fn test_zero_yield_rate_no_accrual() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    assert_eq!(client.get_yield_rate(), 0);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+
+    set_ts(&env, 0);
+    client.stake(&staker, &1_000_000);
+
+    // Advance one full year.
+    set_ts(&env, 31_536_000);
+
+    // No yield at 0 bps.
+    assert_eq!(client.accrued_yield(&staker), 0);
+
+    // Unstake returns exactly the principal.
+    client.unstake(&staker, &1_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 1_000_000);
+}
+
+// ── Correct math at a known bps rate ─────────────────────────────────────────
+
+/// Stake 1_000_000 at 500 bps (5 %) for exactly one year.
+/// Expected yield = 1_000_000 * 500 / 10_000 = 50_000.
+#[test]
+fn test_yield_math_one_year_500_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &500); // 5 % annual
+    assert_eq!(client.get_yield_rate(), 500);
+
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 100_000);
+
+    set_ts(&env, 0);
+    client.stake(&staker, &1_000_000);
+
+    // Advance exactly one year.
+    set_ts(&env, 31_536_000);
+
+    // Preview: 1_000_000 * 500 * 31_536_000 / (10_000 * 31_536_000) = 50_000
+    assert_eq!(client.accrued_yield(&staker), 50_000);
+
+    // Unstake pays principal + yield.
+    client.unstake(&staker, &1_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 1_050_000); // 1_000_000 + 50_000
+}
+
+/// Stake 2_000_000 at 1000 bps (10 %) for half a year.
+/// Expected yield = 2_000_000 * 1000 * (31_536_000/2) / (10_000 * 31_536_000)
+///               = 2_000_000 * 1000 / (10_000 * 2) = 100_000.
+#[test]
+fn test_yield_math_half_year_1000_bps() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &1_000); // 10 % annual
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 2_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
+
+    set_ts(&env, 0);
+    client.stake(&staker, &2_000_000);
+
+    set_ts(&env, 31_536_000 / 2);
+
+    assert_eq!(client.accrued_yield(&staker), 100_000);
+
+    client.unstake(&staker, &2_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 2_100_000);
+}
+
+// ── Unstake pays principal + yield ────────────────────────────────────────────
+
+/// Partial unstake: staker withdraws half their principal mid-period.
+/// All banked yield is paid out on the partial unstake; the remaining stake
+/// starts a fresh accrual period from that point.
+#[test]
+fn test_partial_unstake_pays_full_yield_then_resets() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &500); // 5 % annual
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 2_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
+
+    // Stake 2_000_000 at t=0.
+    set_ts(&env, 0);
+    client.stake(&staker, &2_000_000);
+
+    // Advance one full year → yield on 2_000_000 at 500 bps = 100_000.
+    set_ts(&env, 31_536_000);
+    assert_eq!(client.accrued_yield(&staker), 100_000);
+
+    // Unstake half (1_000_000). All yield (100_000) is paid out and the
+    // clock resets for the remaining 1_000_000 stake.
+    client.unstake(&staker, &1_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    // Received: 1_000_000 principal + 100_000 yield = 1_100_000.
+    assert_eq!(token_client.balance(&staker), 1_100_000);
+
+    // Pool still has 1_000_000 staked, yield clock just reset.
+    assert_eq!(client.get_stake(&staker), 1_000_000);
+    assert_eq!(client.accrued_yield(&staker), 0);
+
+    // After another year the remaining 1_000_000 accrues 50_000 more.
+    set_ts(&env, 31_536_000 * 2);
+    assert_eq!(client.accrued_yield(&staker), 50_000);
+
+    client.unstake(&staker, &1_000_000);
+    // Received additional: 1_000_000 + 50_000 = 1_050_000; total = 2_150_000.
+    assert_eq!(token_client.balance(&staker), 2_150_000);
+}
+
+// ── Rate change is prospective only ──────────────────────────────────────────
+
+/// Staker stakes for one year at 500 bps, then admin changes rate to 1000 bps.
+/// Accrual to date (50_000) must be banked and not retroactively altered.
+/// After another year the staker earns an additional 100_000 at 1000 bps.
+#[test]
+fn test_rate_change_prospective_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &500); // 5 % annual
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 300_000);
+
+    set_ts(&env, 0);
+    client.stake(&staker, &1_000_000);
+
+    // Advance one year → 50_000 accrued at 500 bps.
+    set_ts(&env, 31_536_000);
+    assert_eq!(client.accrued_yield(&staker), 50_000);
+
+    // Admin changes rate to 1000 bps. This banks the 50_000 for all stakers.
+    client.set_yield_rate(&admin, &1_000);
+
+    // Immediately after rate change, accrued_yield should still show 50_000
+    // (the banked amount; no new accrual yet because elapsed since bank = 0).
+    assert_eq!(client.accrued_yield(&staker), 50_000);
+
+    // Advance another year — new yield = 1_000_000 * 1000 / 10_000 = 100_000.
+    set_ts(&env, 31_536_000 * 2);
+    assert_eq!(client.accrued_yield(&staker), 150_000); // 50_000 banked + 100_000 new
+
+    // Unstake: 1_000_000 principal + 150_000 yield.
+    client.unstake(&staker, &1_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 1_150_000);
+}
+
+/// Rate decreasing: staker stakes for one year at 1000 bps, rate drops to 0.
+/// Previously accrued yield must be preserved and paid on unstake.
+#[test]
+fn test_rate_decrease_preserves_accrued_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &1_000); // 10 % annual
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
+
+    set_ts(&env, 0);
+    client.stake(&staker, &1_000_000);
+
+    // One year → 100_000 accrued at 1000 bps.
+    set_ts(&env, 31_536_000);
+    assert_eq!(client.accrued_yield(&staker), 100_000);
+
+    // Admin drops rate to 0. The 100_000 must be banked.
+    client.set_yield_rate(&admin, &0);
+    assert_eq!(client.accrued_yield(&staker), 100_000); // banked amount unchanged
+
+    // No further accrual at 0 bps.
+    set_ts(&env, 31_536_000 * 2);
+    assert_eq!(client.accrued_yield(&staker), 100_000);
+
+    client.unstake(&staker, &1_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 1_100_000);
+}
+
+// ── Top-up stake banks yield and resets clock ─────────────────────────────────
+
+/// Staker stakes at t=0, tops up at t=1_year. The first year's yield must
+/// be banked on the top-up; the second year accrues on the new total.
+#[test]
+fn test_topup_banks_yield_and_resets_clock() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &500); // 5 % annual
+    let staker = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker, 3_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
+
+    // Initial stake of 1_000_000 at t=0.
+    set_ts(&env, 0);
+    client.stake(&staker, &1_000_000);
+    assert_eq!(client.get_stake(&staker), 1_000_000);
+
+    // Advance one year → 50_000 yield accrued on 1_000_000.
+    set_ts(&env, 31_536_000);
+    assert_eq!(client.accrued_yield(&staker), 50_000);
+
+    // Top-up with 2_000_000. This banks the 50_000 and resets the clock.
+    client.stake(&staker, &2_000_000);
+    assert_eq!(client.get_stake(&staker), 3_000_000);
+    // 50_000 is banked; no new time has elapsed since bank.
+    assert_eq!(client.accrued_yield(&staker), 50_000);
+
+    // Advance another year → new yield = 3_000_000 * 500 / 10_000 = 150_000.
+    set_ts(&env, 31_536_000 * 2);
+    // Total: 50_000 banked + 150_000 new = 200_000.
+    assert_eq!(client.accrued_yield(&staker), 200_000);
+
+    client.unstake(&staker, &3_000_000);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker), 3_200_000); // 3_000_000 + 200_000
+}
+
+// ── Multiple stakers, independent yield clocks ────────────────────────────────
+
+/// Two stakers stake at different times; their yield clocks are independent.
+#[test]
+fn test_multiple_stakers_independent_yield() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (token_id, insurance_id, client) = setup(&env, &admin);
+
+    client.set_yield_rate(&admin, &500); // 5 % annual
+    let staker_a = Address::generate(&env);
+    let staker_b = Address::generate(&env);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker_a, 1_000_000);
+    mint_and_approve(&env, &token_id, &insurance_id, &staker_b, 2_000_000);
+    fund_yield_reserve(&env, &token_id, &insurance_id, 300_000);
+
+    // A stakes at t=0.
+    set_ts(&env, 0);
+    client.stake(&staker_a, &1_000_000);
+
+    // B stakes at t=half_year.
+    set_ts(&env, 31_536_000 / 2);
+    client.stake(&staker_b, &2_000_000);
+
+    // At t=1_year:
+    // A has been staking for a full year  → 50_000 yield.
+    // B has been staking for half a year  → 50_000 yield.
+    set_ts(&env, 31_536_000);
+    assert_eq!(client.accrued_yield(&staker_a), 50_000);
+    assert_eq!(client.accrued_yield(&staker_b), 50_000);
+
+    // Unstake both and verify balances.
+    client.unstake(&staker_a, &1_000_000);
+    client.unstake(&staker_b, &2_000_000);
+
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&staker_a), 1_050_000);
+    assert_eq!(token_client.balance(&staker_b), 2_050_000);
+}
+
+// ── set_yield_rate guard: admin only ─────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_set_yield_rate_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (_, _, client) = setup(&env, &admin);
+
+    let impostor = Address::generate(&env);
+    // Calling with an address that is not the admin — must panic Unauthorized.
+    // mock_all_auths satisfies the require_auth; the explicit admin-equality
+    // check rejects the call.
+    client.set_yield_rate(&impostor, &500);
+}
+
+// ── accrued_yield for non-staker returns 0 ───────────────────────────────────
+
+#[test]
+fn test_accrued_yield_non_staker_returns_zero() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let (_, _, client) = setup(&env, &admin);
+    client.set_yield_rate(&admin, &500);
+
+    let stranger = Address::generate(&env);
+    set_ts(&env, 31_536_000);
+    assert_eq!(client.accrued_yield(&stranger), 0);
+}


### PR DESCRIPTION
## Summary

Closes #130

Adds a **linear flat yield mechanism** to the insurance pool so stakers earn a configurable annual return on locked capital, making the pool economically attractive while keeping the implementation simple — no compounding, no per-staker rate differentiation.

---

## Problem

The insurance pool had no yield mechanism — stakers locked funds for default coverage but earned nothing. A flat rate accruing on staked principal addresses this while remaining easy to audit and reason about.

---

## Changes

### `insurance/src/lib.rs`

**New storage keys**

| Key | Type | Description |
|---|---|---|
| `yldrate` | instance, u32 | Annual yield rate in basis points; default 0 |
| `stk_ts` | persistent, Map\<Address,u64\> | Per-staker epoch-start timestamp |
| `yld_acc` | persistent, Map\<Address,i128\> | Banked yield from prior rate slabs |

**New / modified public API**

| Function | Auth | Description |
|---|---|---|
| `set_yield_rate(admin, rate_bps)` | Admin | Set annual rate in bps. Banks all existing yield at the old rate before switching — strictly prospective. |
| `get_yield_rate()` | Anyone | Read current rate |
| `accrued_yield(staker)` | Anyone | Preview banked + live yield |
| `stake()` | Staker | Banks yield before top-up, records start timestamp on first stake |
| `unstake()` | Staker | Banks + flushes yield; pays principal and yield in separate transfers; emits `pool_yld` |

**Yield formula**
```
yield = principal × rate_bps × elapsed_secs / (10_000 × 31_536_000)
```
Integer division truncates (protocol-favourable). Overflow-safe by dividing by `SECONDS_PER_YEAR` before multiplying by `rate_bps`.

**New event**

| Event | Emitted by | Data |
|---|---|---|
| `pool_yld` | `unstake` | yield amount paid — emitted only when yield > 0 |

### `insurance/src/test.rs`

10 new test cases added:

| Test | What it proves |
|---|---|
| `test_zero_yield_rate_no_accrual` | Default 0 bps → no yield ever |
| `test_yield_math_one_year_500_bps` | 1 year at 5 % → exactly 50 000 on 1 M |
| `test_yield_math_half_year_1000_bps` | ½ year at 10 % → exactly 100 000 on 2 M |
| `test_partial_unstake_pays_full_yield_then_resets` | Partial unstake flushes all yield, clock resets |
| `test_rate_change_prospective_only` | Old yield banked; new rate only from rate-change ts |
| `test_rate_decrease_preserves_accrued_yield` | Rate drop to 0 preserves previously banked yield |
| `test_topup_banks_yield_and_resets_clock` | Top-up banks yield before adding new principal |
| `test_multiple_stakers_independent_yield` | Two stakers, different stake times, independent clocks |
| `test_set_yield_rate_non_admin_panics` | Non-admin call → Unauthorized (#1) |
| `test_accrued_yield_non_staker_returns_zero` | Stranger → 0 |

### `README.md`

- Added `set_yield_rate`, `get_yield_rate`, `accrued_yield` to the Insurance function table.
- Added `pool_yld` to the Protocol Events canonical table.

---

## Acceptance criteria (from issue)

- [x] Yield math correct at a known bps rate over a simulated period  
- [x] Unstake pays principal + accrued yield  
- [x] Rate change does not retroactively alter accrued amounts  

---

## Testing

All 173 tests pass:

```
test result: ok. 31 passed  (insurance — 10 new yield tests)
test result: ok. 40 passed  (financing)
test result: ok. 52 passed  (registry)
test result: ok. 33 passed  (repayment)
test result: ok. 12 passed  (integration)
test result: ok.  5 passed  (reputation)
```

Command used:
```bash
cargo test --target $(rustc -vV | sed -n 's/^host: //p')
```

---

## Design notes

- Yield is paid out of the contract's token balance. The pool must hold surplus tokens (from protocol fee donations or external funding) to cover yield. The principal accounting (`pool_total`) is unchanged so `pay_out` and pro-rata payout logic are unaffected.
- Rate changes are strictly prospective — the `bank_accrued_yield` helper is called for every active staker before the new rate is stored. This is O(n) over active stakers, which is acceptable for realistic pool sizes.
- No compounding, no per-staker rate differentiation (per scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable annual yield rates for staked insurance funds.
  * Added yield-rate retrieval and accrued-yield preview capabilities.
  * Yield accrues over time without compounding and is paid separately from principal when unstaking.
  * Added support for partial unstaking, stake top-ups, and rate changes while preserving accrued yield.

* **Documentation**
  * Updated contract documentation with yield configuration, retrieval, preview functions, and yield payment events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->