### PR TITLE
feat(financing): offer amendment and counter-offer protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ and are enforced by commitlint in CI.
 ## [Unreleased]
 
 ### Added
+- **Offer amendment and counter-offer protocol (issue #180)** — financing
+  offers are no longer take-it-or-leave-it. A lender can revise their own terms
+  with `amend_offer`, an originator can name theirs with `counter_offer`, and
+  when the two sides land on the same terms the offer settles in that same
+  transaction. Design in `docs/adr/0008-offer-negotiation.md`.
+  - **Auto-accept matches two pre-existing commitments** rather than spending
+    on a counterparty's behalf. Agreement is exact equality of the canonical
+    term tuple `(amount, interest_rate, duration)` — no tolerance, no rounding.
+    When the originator counters at the lender's standing terms, their own
+    `require_auth` covers the settlement; when the lender amends onto the
+    originator's live counter-offer, what authorizes financing them is the
+    counter-offer they themselves recorded on-chain. Settlement runs the
+    extracted `settle_acceptance`, the same code path `accept_offer` uses, so
+    the two can never drift.
+  - **Every round is version-guarded.** `amend_offer` / `counter_offer` take
+    `expected_round`, the history length the caller believes it is amending. A
+    round written against a negotiation that moved underneath it reverts with
+    `InvalidInput` instead of applying to terms the caller never saw — which is
+    what would otherwise let a stale counter-offer auto-execute.
+  - **A recorded counter-offer is bounded and revocable.** It stays executable
+    only inside the negotiation window (default 72 h, admin-configurable within
+    1 h – 30 days via `set_negotiation_window`); the deadline is frozen when
+    the negotiation opens, so later rounds never push it out; proposing again
+    supersedes, since only a party's most recent record is live; and either
+    party can end the negotiation outright with `close_negotiation`.
+  - **Expiry is derived on read**, since Soroban has no scheduler:
+    `get_negotiation_status` computes `Expired` from the deadline whether or
+    not anyone has called anything. `close_negotiation` is the poke that
+    persists the outcome and emits the event — permissionless after the
+    deadline, restricted to the two parties before it.
+  - New storage `negotiations:{offer_id}` as a `Vec<NegotiationRecord>`, capped
+    at 20 rounds so the entry stays bounded. New reads `get_negotiation`,
+    `get_negotiation_status`, `get_negotiation_deadline`,
+    `get_negotiation_window`. New events `off_amd`, `ctr_off`, `neg_clsd`.
+  - Amended terms are validated against the same bounds `create_offer`
+    enforces, so a negotiation cannot reach terms the offer could not have been
+    created with.
+  - 26 new tests, driven through the contract client and asserting on real
+    settlement effects (token balances, registry invoice status): both
+    auto-accept directions, the near-miss that must not settle, a superseded
+    counter-offer that must not execute, stale-round rejection from both sides,
+    derived expiry at the deadline boundary, an expired counter-offer that can
+    no longer be taken, revocation, permissionless post-deadline close, the
+    round cap, the pause and authorization guards, and the events.
 - **Partial repayment with pro-rata interest (issue #176)** — originators
   can now make partial payments against an invoice, with interest calculated
   pro-rata on the remaining principal: `interest = remaining × rate_bps ×

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ register_invoice()  →  create_offer()  →  accept_offer()
 | `create_offer(offer_id, invoice_id, lender, amount, currency, rate, duration)` | Lender | Submit an offer (validates amount/rate/duration bounds) |
 | `withdraw_offer / reject_offer` | Lender / Originator | Withdraw or reject a Pending offer |
 | `accept_offer(offer_id, originator)` | Originator | Pulls principal lender → business **and mints the lender's position token** |
+| `amend_offer(offer_id, lender, expected_round, amount, rate, duration)` | Lender | Revise a Pending offer's terms; settles immediately if they match the originator's live counter-offer (ADR-0008) |
+| `counter_offer(offer_id, originator, expected_round, amount, rate, duration)` | Originator | Propose different terms; settles immediately if they match the lender's standing terms (ADR-0008) |
+| `close_negotiation(offer_id, caller)` | Lender / Originator, or anyone once expired | End a negotiation — revokes a live counter-offer before the deadline, records expiry after it |
+| `get_negotiation / get_negotiation_status / get_negotiation_deadline` | Anyone | Read the on-chain negotiation history, its derived status, and its frozen deadline |
+| `set_negotiation_window(admin, secs)` | Admin | Negotiation window, default 72 h, clamped to 1 h – 30 days |
 | `register_currency(admin, currency, token)` | Admin | Add a settlement currency — one registry entry, no code branch per currency |
 | `set_position_token(admin, token)` | Admin | Configure the SEP-41 position-token contract (ADR-0002) |
 | `get_position_token()` | Anyone | Read the configured position token |
@@ -161,6 +166,9 @@ Every state-mutating function publishes a Soroban contract event. Topics are
 | `off_acc` | `accept_offer` | `(invoice_id, lender, amount)` |
 | `off_rej` | `reject_offer` | `invoice_id` |
 | `off_wdr` | `withdraw_offer` | `lender` |
+| `off_amd` | `amend_offer` | `(lender, amount, interest_rate, duration)` |
+| `ctr_off` | `counter_offer` | `(originator, amount, interest_rate, duration)` |
+| `neg_clsd` | `close_negotiation`, auto-accept, `withdraw_offer` / `reject_offer` on an open negotiation | `(NegotiationStatus, closer)` |
 | `off_def` | `reclaim_invoice` | `(invoice_id, lender)` |
 | `inv_rep` | `repay_invoice` | `(offer_id, amount, fully_repaid)` |
 | `inv_ovd` | `mark_overdue` | `due_date` |
@@ -190,6 +198,9 @@ All contracts emit machine-readable `E_*` error codes (see [docs/error-codes.md]
 | `MIN_OFFER_DURATION_SECS` | 86,400 | Minimum offer duration (1 day) |
 | `MAX_OFFER_DURATION_SECS` | 31,536,000 | Maximum offer duration (1 year) |
 | `MIN_INVOICE_AMOUNT` | 10,000,000 | Minimum invoice amount in stroops (10 XLM / 10 USDC) |
+| `DEFAULT_NEGOTIATION_WINDOW_SECS` | 259,200 | Default offer-negotiation window (72 hours) |
+| `MIN_NEGOTIATION_WINDOW_SECS` / `MAX_NEGOTIATION_WINDOW_SECS` | 3,600 / 2,592,000 | Bounds an admin may configure the window to (1 hour – 30 days) |
+| `MAX_NEGOTIATION_ROUNDS` | 20 | Cap on recorded negotiation rounds per offer |
 
 ---
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -25,6 +25,25 @@ pub const MAX_OFFER_DURATION_SECS: u64 = 31_536_000;
 /// Prevents dust invoices that would cost more in fees than they're worth.
 pub const MIN_INVOICE_AMOUNT: i128 = 10_000_000;
 
+/// Default negotiation window for offer amendment / counter-offer. 72 hours,
+/// in seconds. Admin-configurable per deployment via
+/// `set_negotiation_window`.
+pub const DEFAULT_NEGOTIATION_WINDOW_SECS: u64 = 259_200;
+
+/// Lower bound an admin may configure the negotiation window to. 1 hour.
+/// A window shorter than this makes a good-faith reply impractical.
+pub const MIN_NEGOTIATION_WINDOW_SECS: u64 = 3_600;
+
+/// Upper bound an admin may configure the negotiation window to. 30 days.
+/// The window bounds how long a recorded counter-offer stays executable, so
+/// it must not be settable to an effectively unbounded value.
+pub const MAX_NEGOTIATION_WINDOW_SECS: u64 = 2_592_000;
+
+/// Hard cap on negotiation rounds per offer. Every round appends a
+/// `NegotiationRecord` to a single persistent `Vec`, so the cap is what keeps
+/// that entry's size — and the cost of reading it — bounded.
+pub const MAX_NEGOTIATION_ROUNDS: u32 = 20;
+
 // ─── Shared Error Enum ────────────────────────────────────────────────────────
 
 /// Structured error type shared across all InvoFi contracts.
@@ -248,6 +267,62 @@ pub struct PaymentRecord {
     pub payer: Address,
 }
 
+/// Which side of a financing negotiation proposed a set of terms.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum NegotiationParty {
+    /// The lender who created the offer, via `amend_offer`.
+    Lender = 0,
+    /// The invoice originator, via `counter_offer`.
+    Originator = 1,
+}
+
+/// One round of an offer negotiation: the terms one party put on the table,
+/// and when. The full `Vec<NegotiationRecord>` for an offer is the on-chain
+/// negotiation history.
+///
+/// `(amount, interest_rate, duration)` is the **canonical term tuple**.
+/// Agreement is exact equality of that tuple — there is no rounding or
+/// tolerance, so "these are the same terms" is never a judgement call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct NegotiationRecord {
+    /// Which side proposed these terms.
+    pub party: NegotiationParty,
+    /// Proposed principal.
+    pub amount: i128,
+    /// Proposed interest rate in basis points.
+    pub interest_rate: u32,
+    /// Proposed financing duration in seconds.
+    pub duration: u64,
+    /// Ledger timestamp at which the round was recorded.
+    pub timestamp: u64,
+}
+
+/// Lifecycle status of an offer negotiation.
+///
+/// `Expired` is **derived on read** from the window deadline: Soroban has no
+/// scheduler, so nothing flips a negotiation to expired on its own. `Closed`
+/// and `Accepted` are persisted, because both are the result of an actual
+/// call.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum NegotiationStatus {
+    /// No negotiation has been opened on this offer.
+    None = 0,
+    /// Open: within the window, still accepting rounds.
+    Open = 1,
+    /// The window elapsed without agreement. Terminal.
+    Expired = 2,
+    /// A party ended the negotiation early. Terminal.
+    Closed = 3,
+    /// The two sides converged on identical terms and the offer executed.
+    /// Terminal.
+    Accepted = 4,
+}
+
 // ─── Currency Registry ───────────────────────────────────────────────────────
 
 /// Load the currency registry (an empty map if none has been configured).
@@ -314,6 +389,7 @@ pub fn resolve_token(env: &Env, currency: &Symbol) -> Address {
 ///   - exceptions: pause, unpause, contract_is_paused, getters.
 /// - Financing:
 ///   - state-changing: create_offer, withdraw_offer, accept_offer, reject_offer,
+///     amend_offer, counter_offer, close_negotiation, set_negotiation_window,
 ///     update_offer_status, update_offer_amount_repaid, update_lender_stats_repaid,
 ///     update_stats_repaid, register_currency, set_position_token, set_repayment_contract,
 ///     transfer_admin.

--- a/docs/adr/0008-offer-negotiation.md
+++ b/docs/adr/0008-offer-negotiation.md
@@ -1,0 +1,176 @@
+# ADR-0008 — Offer amendment and counter-offer
+
+**Status:** Proposed (2026-08-20)
+
+## Context
+
+Financing offers are take-it-or-leave-it. A lender calls `create_offer` with a
+rate, an amount and a duration; the originator's only moves are `accept_offer`
+and `reject_offer`. Terms that are nearly right die the same way terms that are
+absurd do, and the only way to converge is for the lender to withdraw and post a
+fresh offer — which loses the audit trail of how the two sides got there
+(issue #180).
+
+Two facts about Soroban shape everything below.
+
+**Nobody can spend a counterparty's funds on their behalf.** Settlement moves
+principal from the lender to the business with `transfer_from`, which the token
+contract will only honour against an allowance the lender granted. "If both
+parties agree, auto-execute" therefore cannot mean *the last caller settles both
+sides* — the acting party's transaction carries only the acting party's
+signature. Any design where a match conjures the counterparty's authorization at
+match time does not work; the counterparty's commitment has to already exist when
+the match happens.
+
+**There is no scheduler.** A 72-hour window cannot fire anything when it
+elapses. Expiry has to be a property that reads true, not a state change that
+something performs.
+
+## Decision
+
+### 1. The offer is the lender's position; the history is the record
+
+`amend_offer` writes the new terms onto the `FinancingOffer` itself. The offer
+row is always what the lender is currently offering, so an originator who calls
+plain `accept_offer` mid-negotiation accepts the amended terms and there is no
+second place where "the current terms" could disagree with the first.
+
+`counter_offer` does **not** write to the offer — the offer belongs to the
+lender. It appends the originator's proposal to the negotiation history, which
+the lender can then meet.
+
+Every round from either side appends a `NegotiationRecord` to
+`negotiations:{offer_id}`, so the full path from opening terms to settlement is
+on-chain and ordered.
+
+### 2. Auto-accept is a match of two pre-existing commitments
+
+Agreement is **exact equality of the canonical term tuple**
+`(amount, interest_rate, duration)`. No tolerance, no rounding, no normalisation
+— "these are the same terms" is never a judgement call, in the contract or in a
+dispute about it afterwards.
+
+The two directions are not symmetric, and it matters:
+
+- **Originator counters at the lender's standing terms.** This is just
+  acceptance spelled differently. The originator's own `require_auth` is on the
+  transaction, and the lender's funds move under the allowance they granted this
+  contract — exactly the authorization `accept_offer` runs on today.
+
+- **Lender amends onto the originator's live counter-offer.** Here the settling
+  call carries the *lender's* signature, and the originator never signs at match
+  time. What authorizes financing them is the counter-offer itself: the
+  originator recorded that exact term tuple on-chain in a transaction they
+  signed. The record is the commitment. The lender's role is to take it or not.
+
+So neither side is ever bound to terms they did not themselves put on the table,
+and no signature is invented at match time. What the second case *does* require
+is that the standing commitment be bounded and revocable, which is what the next
+two decisions are for.
+
+### 3. A recorded counter-offer is bounded and revocable
+
+- **Bounded:** the negotiation window (default 72 h, admin-configurable within
+  1 h – 30 days) is the lifetime of every commitment inside it. An originator who
+  proposed terms four days ago is not still on the hook for them; `amend_offer`
+  onto an expired counter-offer reverts rather than settles.
+
+- **Frozen at open:** the deadline is computed once, when the first round lands,
+  and stored. Later rounds do not push it out — otherwise two parties could keep
+  a commitment alive indefinitely by ping-ponging — and a later
+  `set_negotiation_window` does not move a negotiation already running.
+
+- **Revocable two ways:** proposing again supersedes (only a party's *most
+  recent* record is live, so an abandoned proposal is dead), and
+  `close_negotiation` ends the negotiation outright. Either party may close
+  before the deadline; that is how an originator withdraws consent.
+
+### 4. Every round is version-guarded
+
+`amend_offer` and `counter_offer` both take `expected_round`: the number of
+records the caller believes exist. A mismatch reverts.
+
+Without it, a lender who read the negotiation, then had the originator's
+counter-offer land first, would have their amendment applied on top of a
+term-set they never saw — and could auto-execute against a counter-offer they
+did not know existed. Optimistic concurrency turns that into a revert the caller
+can retry from fresh state.
+
+### 5. Expiry is derived on read; the event is emitted by whoever pokes
+
+`get_negotiation_status` computes `Expired` from `now > deadline`. It is correct
+whether or not anyone has called anything, which is the only way it can be
+correct with no scheduler.
+
+`close_negotiation` is the poke that persists the outcome and emits
+`negotiation_closed`. After the deadline it is permissionless — the state is
+already determined, so who records it does not matter. Before the deadline it is
+restricted to the lender and the originator, because then it *is* a state
+change: it revokes a live commitment.
+
+`Closed` and `Accepted` are persisted, since both result from an actual call.
+An offer that leaves `Pending` by any other route — withdrawn, rejected,
+accepted outright — ends its negotiation, which reads as `Closed` and emits
+`negotiation_closed` from that call.
+
+### 6. Amended terms cannot exceed what `create_offer` allows
+
+Both entrypoints validate `(amount, interest_rate, duration)` against the same
+bounds `create_offer` enforces. A negotiation must not be a route to terms the
+offer could not legally have been created with.
+
+Rounds are capped at `MAX_NEGOTIATION_ROUNDS` (20). The history is one
+persistent entry read in full on every round, so the cap is what keeps that
+entry — and the cost of touching it — bounded.
+
+### 7. Settlement is one code path
+
+The body of `accept_offer` is extracted into `settle_acceptance`, which
+`accept_offer` and the auto-accept path both call. Auto-accept moves money,
+flips the invoice to `Financed`, mints the position token and emits `off_acc`
+by running the same code, not a parallel copy of it that could drift.
+
+The auto-accept path re-reads the invoice and re-checks both parties against the
+blacklist before settling. A negotiation can outlive the invoice's `Pending`
+status — it can be cancelled or disputed mid-negotiation — and this is the one
+path that settles without the counterparty's live signature, so their
+eligibility is verified at settlement rather than assumed from when they
+proposed.
+
+## Consequences
+
+- A lender can improve their own offer and an originator can name their price,
+  with the whole exchange auditable on-chain.
+- Convergence costs one transaction, not three: the call that matches settles.
+- An originator's counter-offer is a real commitment for up to the window — they
+  should treat it as such, and revoke it if they change their mind. This is the
+  sharpest edge in the design and the reason for the window, the supersession
+  rule and `close_negotiation`.
+- `LenderStats.total_offered` moves by the amendment delta rather than being
+  re-credited, so it stays a sum over offers rather than over rounds.
+- `negotiation_expired` is not an event. Expiry is a derived read; the
+  `negotiation_closed` event carries `NegotiationStatus::Expired` when the poke
+  records one, and nothing depends on that poke ever happening.
+
+## Alternatives considered
+
+**Escrow the lender's principal into the contract when they amend.** Would make
+the lender's commitment explicit rather than allowance-shaped, and would let a
+match settle from contract-held funds. Rejected: it locks capital for the whole
+window across every negotiation a lender is in, and the allowance already is a
+standing, revocable commitment with the same effect and none of the lockup.
+
+**Let the last caller settle both sides unconditionally.** This is the naive
+reading of "auto-execute", and it does not work on Soroban — `transfer_from`
+fails without the lender's allowance, so the design would break at the first
+match rather than misbehave quietly. Recording commitments and matching them is
+the version that runs.
+
+**Reset the deadline on every round.** Friendlier to slow negotiators, but it
+makes the commitment window unbounded in practice: two parties trading rounds
+keep every recorded proposal live forever. Rejected in favour of a fixed window
+that the parties can restart by opening a fresh offer.
+
+**Track a separate "current terms" record instead of amending the offer.**
+Rejected: two sources of truth for the same fact, and `accept_offer` would have
+to know which one wins.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0005 | [Deployer-bound initialization (constructors)](./0005-deployer-bound-initialization.md) | Accepted |
 | 0006 | [Fixed installment repayment schedules](./0006-repayment-schedules.md) | Accepted |
 | 0007 | [Overdue penalty interest](./0007-overdue-penalty-interest.md) | Proposed |
+| 0008 | [Offer amendment and counter-offer](./0008-offer-negotiation.md) | Proposed |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -76,6 +76,7 @@ document fixes the naming convention only.
 | `E_INVOICE_DUE_DATE_NOT_PASSED` | Invoice due date has not yet elapsed; cannot mark overdue | Registry | **Toast:** "Invoice is not yet overdue." |
 | `E_GRACE_PERIOD_NOT_ELAPSED` | 7-day grace period after overdue has not yet elapsed; cannot reclaim | Repayment | **Toast:** "Grace period has not elapsed. Reclaim available after 7 days past due." |
 | `E_TERMINAL_OFFER` | Cannot schedule repayment on a terminal (Repaid/Defaulted/Rejected) offer | Financing | **Toast:** Refresh offer state |
+| `E_NEGOTIATION_CLOSED` | The offer negotiation is no longer open — the 72-hour window elapsed, a party closed it, or it already settled | Financing | **Toast:** "This negotiation has ended." Disable amend/counter and refresh |
 
 ### Invalid Input / Parameters
 
@@ -90,6 +91,7 @@ document fixes the naming convention only.
 | `E_PAST_DUE_DATE` | Invoice `due_date` is in the past at registration time | Registry | **Toast:** "Due date must be in the future." |
 | `E_FIRST_DUE_IN_PAST` | `first_due` for schedule is not in the future | Financing | **Toast:** "First due date must be in the future." |
 | `E_ZERO_INSTALLMENT` | Computed installment amount is zero (amount/count too small) | Financing | **Toast:** "Installment amount too small." |
+| `E_STALE_NEGOTIATION_ROUND` | `expected_round` does not match the negotiation's current length — the other party moved since the caller read state | Financing | **Toast:** "Terms changed while you were reviewing." Re-read the negotiation and resubmit |
 
 ### Duplicate Key
 

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -7,8 +7,10 @@ use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map
 
 use invofi_common::{
     assert_not_paused, resolve_token, ContractError, FinancingOffer, Invoice, InvoiceStatus,
-    LenderStats, OfferStatus, ProtocolStats, RegistryClient, RepaymentSchedule,
-    ScheduleFrequency, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    LenderStats, NegotiationParty, NegotiationRecord, NegotiationStatus, OfferStatus,
+    ProtocolStats, RegistryClient, RepaymentSchedule, ScheduleFrequency,
+    DEFAULT_NEGOTIATION_WINDOW_SECS, MAX_NEGOTIATION_ROUNDS, MAX_NEGOTIATION_WINDOW_SECS,
+    MAX_OFFER_DURATION_SECS, MIN_NEGOTIATION_WINDOW_SECS, MIN_OFFER_DURATION_SECS,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -69,6 +71,82 @@ fn save_schedules(env: &Env, map: &Map<Symbol, RepaymentSchedule>) {
     env.storage()
         .persistent()
         .set(&symbol_short!("scheds"), map);
+}
+
+// ─── Negotiation Storage Helpers (issue #180) ────────────────────────────────
+//
+// Negotiation state is keyed per offer rather than held in one map, so a busy
+// offer never makes every other offer's negotiation more expensive to read.
+//
+//   ("negot", offer_id)  -> Vec<NegotiationRecord>  the round-by-round history
+//   ("negdl", offer_id)  -> u64                     window deadline, frozen at open
+//   ("negend", offer_id) -> NegotiationStatus       persisted terminal outcome
+
+fn load_negotiation(env: &Env, offer_id: &Symbol) -> Vec<NegotiationRecord> {
+    env.storage()
+        .persistent()
+        .get(&(symbol_short!("negot"), offer_id.clone()))
+        .unwrap_or(Vec::new(env))
+}
+
+fn save_negotiation(env: &Env, offer_id: &Symbol, history: &Vec<NegotiationRecord>) {
+    env.storage()
+        .persistent()
+        .set(&(symbol_short!("negot"), offer_id.clone()), history);
+}
+
+fn load_deadline(env: &Env, offer_id: &Symbol) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&(symbol_short!("negdl"), offer_id.clone()))
+        .unwrap_or(0)
+}
+
+fn save_deadline(env: &Env, offer_id: &Symbol, deadline: u64) {
+    env.storage()
+        .persistent()
+        .set(&(symbol_short!("negdl"), offer_id.clone()), &deadline);
+}
+
+fn load_outcome(env: &Env, offer_id: &Symbol) -> Option<NegotiationStatus> {
+    env.storage()
+        .persistent()
+        .get(&(symbol_short!("negend"), offer_id.clone()))
+}
+
+fn save_outcome(env: &Env, offer_id: &Symbol, outcome: NegotiationStatus) {
+    env.storage()
+        .persistent()
+        .set(&(symbol_short!("negend"), offer_id.clone()), &outcome);
+}
+
+/// The most recent round proposed by `party`, if that side has proposed at all.
+///
+/// "Most recent" is what makes a counter-offer revocable-by-replacement: only
+/// a party's latest proposal is live, so an earlier one can never be executed
+/// against them after they have moved off it.
+fn last_proposal_by(
+    history: &Vec<NegotiationRecord>,
+    party: NegotiationParty,
+) -> Option<NegotiationRecord> {
+    let mut latest: Option<NegotiationRecord> = None;
+    for record in history.iter() {
+        if record.party == party {
+            latest = Some(record);
+        }
+    }
+    latest
+}
+
+/// Validate a proposed term tuple against the same bounds `create_offer`
+/// enforces. A negotiation must not be a way to reach terms the offer could
+/// not have been created with in the first place.
+fn assert_terms_valid(env: &Env, amount: i128, interest_rate: u32, duration: u64) {
+    let rate_ok = (1..=10_000).contains(&interest_rate);
+    let duration_ok = (MIN_OFFER_DURATION_SECS..=MAX_OFFER_DURATION_SECS).contains(&duration);
+    if amount <= 0 || !rate_ok || !duration_ok {
+        env.panic_with_error(ContractError::InvalidInput);
+    }
 }
 
 fn assert_not_blacklisted(env: &Env, address: &Address) {
@@ -369,8 +447,9 @@ impl FinancingContract {
             env.panic_with_error(ContractError::InvalidTransition);
         }
         offer.status = OfferStatus::Rejected;
-        offers.set(offer_id, offer.clone());
+        offers.set(offer_id.clone(), offer.clone());
         save_offers(&env, &offers);
+        Self::close_negotiation_on_offer_exit(&env, &offer_id, &lender);
         env.events().publish(
             (symbol_short!("off_wdr"), offer.id.clone()),
             offer.lender.clone(),
@@ -386,8 +465,8 @@ impl FinancingContract {
         assert_not_paused(&env);
         invoice_originator.require_auth();
 
-        let mut offers = load_offers(&env);
-        let mut offer = offers
+        let offers = load_offers(&env);
+        let offer = offers
             .get(offer_id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if offer.status != OfferStatus::Pending {
@@ -410,6 +489,29 @@ impl FinancingContract {
         if invoice.status != InvoiceStatus::Pending {
             env.panic_with_error(ContractError::InvalidTransition);
         }
+
+        Self::settle_acceptance(&env, offer_id, offer, &registry_client, &invoice)
+    }
+
+    /// Move the money and flip every piece of state that an accepted offer
+    /// implies: principal to the business, invoice to Financed, position token
+    /// minted, stats updated, `off_acc` emitted.
+    ///
+    /// Split out of `accept_offer` so the auto-accept path in `amend_offer` /
+    /// `counter_offer` executes the *same* settlement rather than a parallel
+    /// copy that could drift from it. Every caller is responsible for its own
+    /// authorization and for checking that the offer is Pending and the
+    /// invoice is Pending before calling in.
+    fn settle_acceptance(
+        env: &Env,
+        offer_id: Symbol,
+        offer: FinancingOffer,
+        registry_client: &RegistryClient,
+        invoice: &Invoice,
+    ) -> FinancingOffer {
+        let env = env.clone();
+        let mut offers = load_offers(&env);
+        let mut offer = offer;
 
         // Pull the lender's principal and pay it straight to the business.
         let token_id = resolve_token(&env, &offer.currency);
@@ -494,14 +596,441 @@ impl FinancingContract {
         }
 
         offer.status = OfferStatus::Rejected;
-        offers.set(offer_id, offer.clone());
+        offers.set(offer_id.clone(), offer.clone());
         save_offers(&env, &offers);
+        Self::close_negotiation_on_offer_exit(&env, &offer_id, &invoice_originator);
 
         env.events().publish(
             (symbol_short!("off_rej"), offer.id.clone()),
             offer.invoice_id.clone(),
         );
         offer
+    }
+
+    // ── Offer negotiation: amendment & counter-offer (issue #180) ────────────
+    //
+    // The protocol used to be take-it-or-leave-it: a lender posted terms and
+    // the originator could only accept or reject them. These entrypoints let
+    // the two sides converge instead, with every round recorded on-chain.
+    //
+    // Design notes that are easy to get wrong, in full in
+    // `docs/adr/0008-offer-negotiation.md`:
+    //
+    // * **Auto-accept is not unilateral.** Settlement moves the lender's
+    //   funds, which Soroban will only do with the lender's authorization.
+    //   The lender's commitment is their SEP-41 allowance to this contract,
+    //   granted before acceptance is possible at all; the originator's
+    //   commitment is the counter-offer they recorded in a transaction they
+    //   signed. Auto-accept fires only when the *canonical term tuple* of one
+    //   side's live proposal is exactly equal to the other's, so neither party
+    //   is ever bound to terms they did not themselves put on the table.
+    //
+    // * **Every round is version-guarded.** `expected_round` is the history
+    //   length the caller believes it is amending. A round that lands after
+    //   the other side moved is rejected rather than silently applied to terms
+    //   the caller never saw — which is what would otherwise let a stale
+    //   counter-offer auto-execute.
+
+    /// Configure the negotiation window, in seconds. Admin only.
+    ///
+    /// The window bounds how long a recorded counter-offer stays executable
+    /// against the party who made it, so it is deliberately clamped to
+    /// [`MIN_NEGOTIATION_WINDOW_SECS`, `MAX_NEGOTIATION_WINDOW_SECS`] — an
+    /// admin cannot set it to something effectively unbounded. Deployments
+    /// that never call this run on the 72-hour default.
+    ///
+    /// Changing the window does not move the deadline of a negotiation that
+    /// is already open: each deadline is frozen when its negotiation opens.
+    pub fn set_negotiation_window(env: Env, admin: Address, window_secs: u64) {
+        assert_not_paused(&env);
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+        if !(MIN_NEGOTIATION_WINDOW_SECS..=MAX_NEGOTIATION_WINDOW_SECS).contains(&window_secs) {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("negwin"), &window_secs);
+    }
+
+    /// The configured negotiation window in seconds (default: 72 hours).
+    pub fn get_negotiation_window(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("negwin"))
+            .unwrap_or(DEFAULT_NEGOTIATION_WINDOW_SECS)
+    }
+
+    /// Amend a Pending offer's terms. Only the lender who created the offer.
+    ///
+    /// The amended terms are written onto the offer itself: the offer is
+    /// always the lender's standing position, so an originator who calls
+    /// `accept_offer` after an amendment accepts the amended terms, and there
+    /// is no second place where "the current terms" could disagree.
+    ///
+    /// `expected_round` must equal the current number of recorded rounds
+    /// (`0` opens the negotiation). If the originator appended a counter-offer
+    /// after the lender read state, the amendment is rejected with
+    /// `InvalidInput` rather than applied on top of terms the lender never saw.
+    ///
+    /// **Auto-accept:** if `(amount, interest_rate, duration)` exactly equals
+    /// the originator's live counter-offer — their most recent
+    /// `NegotiationParty::Originator` round — the sides have agreed and the
+    /// offer settles in this same transaction. The returned offer's status is
+    /// `Accepted` when that happened and `Pending` when it did not.
+    pub fn amend_offer(
+        env: Env,
+        offer_id: Symbol,
+        lender: Address,
+        expected_round: u32,
+        amount: i128,
+        interest_rate: u32,
+        duration: u64,
+    ) -> FinancingOffer {
+        assert_not_paused(&env);
+        lender.require_auth();
+        assert_not_blacklisted(&env, &lender);
+        assert_terms_valid(&env, amount, interest_rate, duration);
+
+        let mut offers = load_offers(&env);
+        let mut offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if offer.lender != lender {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        let history = Self::assert_negotiable(&env, &offer_id, &offer, expected_round);
+
+        // Agreement is exact equality with the originator's *live* proposal.
+        // Only their latest round counts: a superseded counter-offer must not
+        // remain executable against them.
+        let agreed = match last_proposal_by(&history, NegotiationParty::Originator) {
+            Some(counter) => {
+                counter.amount == amount
+                    && counter.interest_rate == interest_rate
+                    && counter.duration == duration
+            }
+            None => false,
+        };
+
+        // Keep `total_offered` coherent: it was credited with the original
+        // amount at create_offer, so an amendment moves it by the delta rather
+        // than double-counting the offer.
+        let mut lstats = load_lender_stats(&env, &lender);
+        lstats.total_offered += amount - offer.amount;
+        save_lender_stats(&env, &lender, &lstats);
+
+        offer.amount = amount;
+        offer.interest_rate = interest_rate;
+        offer.duration = duration;
+        offers.set(offer_id.clone(), offer.clone());
+        save_offers(&env, &offers);
+
+        Self::record_round(
+            &env,
+            &offer_id,
+            &history,
+            NegotiationParty::Lender,
+            amount,
+            interest_rate,
+            duration,
+        );
+
+        env.events().publish(
+            (symbol_short!("off_amd"), offer_id.clone()),
+            (lender.clone(), amount, interest_rate, duration),
+        );
+
+        if agreed {
+            return Self::execute_agreement(&env, &offer_id, &lender);
+        }
+        offer
+    }
+
+    /// Propose different terms on a Pending offer. Only the invoice
+    /// originator.
+    ///
+    /// A counter-offer does **not** rewrite the offer — the offer belongs to
+    /// the lender. It records the originator's position, which the lender can
+    /// then meet by amending to the identical term tuple.
+    ///
+    /// `expected_round` is the same optimistic-concurrency guard as
+    /// `amend_offer`.
+    ///
+    /// **Auto-accept:** proposing exactly the lender's standing terms *is*
+    /// agreement, so the offer settles in this same transaction — the
+    /// originator's own `require_auth` covers it, exactly as `accept_offer`
+    /// would. The returned offer's status is `Accepted` when that happened.
+    pub fn counter_offer(
+        env: Env,
+        offer_id: Symbol,
+        originator: Address,
+        expected_round: u32,
+        amount: i128,
+        interest_rate: u32,
+        duration: u64,
+    ) -> FinancingOffer {
+        assert_not_paused(&env);
+        originator.require_auth();
+        assert_not_blacklisted(&env, &originator);
+        assert_terms_valid(&env, amount, interest_rate, duration);
+
+        let offers = load_offers(&env);
+        let offer = offers
+            .get(offer_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+
+        // Cross-contract: only the invoice's originator may counter.
+        // CEI: Read-only cross-contract call before state mutations.
+        let registry_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("registry"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let registry_client = RegistryClient::new(&env, &registry_addr);
+        let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
+        if invoice.originator != originator {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        let history = Self::assert_negotiable(&env, &offer_id, &offer, expected_round);
+
+        // The lender's live proposal is the offer itself.
+        let agreed = amount == offer.amount
+            && interest_rate == offer.interest_rate
+            && duration == offer.duration;
+
+        Self::record_round(
+            &env,
+            &offer_id,
+            &history,
+            NegotiationParty::Originator,
+            amount,
+            interest_rate,
+            duration,
+        );
+
+        env.events().publish(
+            (symbol_short!("ctr_off"), offer_id.clone()),
+            (originator.clone(), amount, interest_rate, duration),
+        );
+
+        if agreed {
+            return Self::execute_agreement(&env, &offer_id, &originator);
+        }
+        offer
+    }
+
+    /// End an open negotiation without agreement.
+    ///
+    /// Before the deadline this is a withdrawal of consent and only the lender
+    /// or the invoice originator may call it — an originator uses it to revoke
+    /// a counter-offer they no longer want executed against them.
+    ///
+    /// After the deadline the negotiation is already `Expired` by derivation;
+    /// this call is the poke that persists the outcome and emits
+    /// `neg_clsd`, and any authenticated address may make it. Soroban has no
+    /// scheduler, so an expiry event cannot fire on its own — that is why the
+    /// event is emitted by whoever next touches the negotiation, and why
+    /// `get_negotiation_status` never depends on someone having called this.
+    pub fn close_negotiation(env: Env, offer_id: Symbol, caller: Address) -> NegotiationStatus {
+        assert_not_paused(&env);
+        caller.require_auth();
+
+        // A persisted outcome means this negotiation was already closed; a
+        // second close would emit a second neg_clsd for the same negotiation.
+        if load_outcome(&env, &offer_id).is_some() {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+
+        let outcome = match Self::get_negotiation_status(env.clone(), offer_id.clone()) {
+            NegotiationStatus::None => env.panic_with_error(ContractError::NotFound),
+            NegotiationStatus::Closed | NegotiationStatus::Accepted => {
+                env.panic_with_error(ContractError::InvalidTransition)
+            }
+            NegotiationStatus::Expired => NegotiationStatus::Expired,
+            NegotiationStatus::Open => {
+                let offer = load_offers(&env)
+                    .get(offer_id.clone())
+                    .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+                if caller != offer.lender {
+                    let registry_addr: Address = env
+                        .storage()
+                        .instance()
+                        .get(&symbol_short!("registry"))
+                        .unwrap_or_else(|| panic!("Not initialized"));
+                    let registry_client = RegistryClient::new(&env, &registry_addr);
+                    let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
+                    if caller != invoice.originator {
+                        env.panic_with_error(ContractError::Unauthorized);
+                    }
+                }
+                NegotiationStatus::Closed
+            }
+        };
+
+        save_outcome(&env, &offer_id, outcome);
+        env.events()
+            .publish((symbol_short!("neg_clsd"), offer_id), (outcome, caller));
+        outcome
+    }
+
+    /// The full on-chain negotiation history for an offer, oldest round first.
+    /// Empty when no negotiation was ever opened.
+    pub fn get_negotiation(env: Env, offer_id: Symbol) -> Vec<NegotiationRecord> {
+        load_negotiation(&env, &offer_id)
+    }
+
+    /// Unix timestamp at which the negotiation window closes, or `0` if no
+    /// negotiation has been opened on this offer. Frozen when the negotiation
+    /// opens, so a later `set_negotiation_window` never moves it.
+    pub fn get_negotiation_deadline(env: Env, offer_id: Symbol) -> u64 {
+        load_deadline(&env, &offer_id)
+    }
+
+    /// Current negotiation status.
+    ///
+    /// `Expired` is derived from the deadline, not stored, so a caller reading
+    /// this always sees the truth whether or not anyone has called
+    /// `close_negotiation` yet. An offer that leaves `Pending` by any other
+    /// route — withdrawn, rejected, or accepted outright — ends its
+    /// negotiation, which reads as `Closed`.
+    pub fn get_negotiation_status(env: Env, offer_id: Symbol) -> NegotiationStatus {
+        if let Some(outcome) = load_outcome(&env, &offer_id) {
+            return outcome;
+        }
+        if load_negotiation(&env, &offer_id).is_empty() {
+            return NegotiationStatus::None;
+        }
+        match load_offers(&env).get(offer_id.clone()) {
+            Some(offer) if offer.status == OfferStatus::Pending => {}
+            _ => return NegotiationStatus::Closed,
+        }
+        if env.ledger().timestamp() > load_deadline(&env, &offer_id) {
+            NegotiationStatus::Expired
+        } else {
+            NegotiationStatus::Open
+        }
+    }
+
+    // ── Negotiation internals ────────────────────────────────────────────────
+
+    /// Guard shared by `amend_offer` and `counter_offer`: the offer must still
+    /// be Pending, the negotiation must be open, the caller must not be
+    /// working from a stale read, and the round cap must not be exhausted.
+    /// Returns the history the caller's round will be appended to.
+    fn assert_negotiable(
+        env: &Env,
+        offer_id: &Symbol,
+        offer: &FinancingOffer,
+        expected_round: u32,
+    ) -> Vec<NegotiationRecord> {
+        if offer.status != OfferStatus::Pending {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+        match Self::get_negotiation_status(env.clone(), offer_id.clone()) {
+            NegotiationStatus::None | NegotiationStatus::Open => {}
+            _ => env.panic_with_error(ContractError::InvalidTransition),
+        }
+
+        let history = load_negotiation(env, offer_id);
+        // Optimistic concurrency: reject a round written against a version of
+        // the negotiation that no longer exists.
+        if history.len() != expected_round {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        if history.len() >= MAX_NEGOTIATION_ROUNDS {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+        history
+    }
+
+    /// Append a round, opening the negotiation (and freezing its deadline) if
+    /// this is the first one.
+    fn record_round(
+        env: &Env,
+        offer_id: &Symbol,
+        history: &Vec<NegotiationRecord>,
+        party: NegotiationParty,
+        amount: i128,
+        interest_rate: u32,
+        duration: u64,
+    ) {
+        let now = env.ledger().timestamp();
+        if history.is_empty() {
+            let window = Self::get_negotiation_window(env.clone());
+            save_deadline(env, offer_id, now.saturating_add(window));
+        }
+        let mut history = history.clone();
+        history.push_back(NegotiationRecord {
+            party,
+            amount,
+            interest_rate,
+            duration,
+            timestamp: now,
+        });
+        save_negotiation(env, offer_id, &history);
+    }
+
+    /// Both sides have put the same term tuple on the table: close the
+    /// negotiation as `Accepted` and run the ordinary settlement.
+    ///
+    /// The invoice is re-read here rather than trusted from the caller's
+    /// frame: a negotiation can outlive the invoice's Pending status (it can
+    /// be cancelled or disputed mid-negotiation), and settling against a
+    /// non-Pending invoice would finance an invoice that is no longer
+    /// financeable. Both parties are re-checked against the blacklist for the
+    /// same reason — this path settles without the counterparty's live
+    /// signature, so their eligibility has to be verified now, not assumed
+    /// from when they proposed.
+    fn execute_agreement(env: &Env, offer_id: &Symbol, closer: &Address) -> FinancingOffer {
+        let offer = load_offers(env)
+            .get(offer_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+
+        let registry_addr: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("registry"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        let registry_client = RegistryClient::new(env, &registry_addr);
+        // CEI: Read-only cross-contract call before state mutations.
+        let invoice: Invoice = registry_client.get_invoice(&offer.invoice_id);
+        if invoice.status != InvoiceStatus::Pending {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+        assert_not_blacklisted(env, &offer.lender);
+        assert_not_blacklisted(env, &invoice.originator);
+
+        save_outcome(env, offer_id, NegotiationStatus::Accepted);
+        env.events().publish(
+            (symbol_short!("neg_clsd"), offer_id.clone()),
+            (NegotiationStatus::Accepted, closer.clone()),
+        );
+
+        Self::settle_acceptance(env, offer_id.clone(), offer, &registry_client, &invoice)
+    }
+
+    /// Emit `neg_clsd` when an offer leaves Pending with a negotiation still
+    /// open. No outcome is persisted: `get_negotiation_status` already derives
+    /// `Closed` from the offer no longer being Pending, and writing a second
+    /// source of truth for the same fact is how the two drift apart.
+    fn close_negotiation_on_offer_exit(env: &Env, offer_id: &Symbol, closer: &Address) {
+        if load_negotiation(env, offer_id).is_empty() || load_outcome(env, offer_id).is_some() {
+            return;
+        }
+        env.events().publish(
+            (symbol_short!("neg_clsd"), offer_id.clone()),
+            (NegotiationStatus::Closed, closer.clone()),
+        );
     }
 
     // ── Cross-contract callback methods (called by Repayment) ───────────

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -2,12 +2,12 @@
 extern crate std;
 
 use super::FinancingContract;
-use invofi_common::{InvoiceStatus, OfferStatus};
+use invofi_common::{InvoiceStatus, NegotiationParty, NegotiationStatus, OfferStatus};
 use invofi_registry::RegistryContract;
 use soroban_sdk::{
     symbol_short,
-    testutils::{Address as _, Ledger as _},
-    token, Address, Env,
+    testutils::{Address as _, Events as _, Ledger as _},
+    token, Address, Env, Symbol, TryFromVal,
 };
 
 /// Deploy the registry + financing contracts and return both clients.
@@ -1518,4 +1518,1060 @@ fn test_daily_frequency_period() {
     // Advance past 2 daily periods — installment 1 paid, installment 2 is now due.
     env.ledger().set_timestamp(first_due + 86_400 + 1);
     assert_eq!(fin.get_installment_due(&symbol_short!("off_sc1")), 2);
+}
+
+// ─── Offer negotiation: amendment & counter-offer (issue #180) ───────────────
+//
+// The tests below drive the negotiation through the public contract client —
+// the same entrypoints a wallet calls — and assert on real settlement effects
+// (token balances, registry invoice status), not on internal helpers.
+
+/// Deploy registry + financing wired to a real SEP-41 token, register an
+/// invoice, and post an offer the lender can actually fund. Returns everything
+/// a negotiation test needs.
+#[allow(clippy::type_complexity)]
+fn setup_negotiation<'a>(
+    env: &'a Env,
+    invoice_id: &soroban_sdk::Symbol,
+    offer_id: &soroban_sdk::Symbol,
+    amount: i128,
+) -> (
+    invofi_registry::RegistryContractClient<'a>,
+    super::FinancingContractClient<'a>,
+    Address, // admin
+    Address, // originator
+    Address, // lender
+    Address, // token
+) {
+    let admin = Address::generate(env);
+    let originator = Address::generate(env);
+    let lender = Address::generate(env);
+
+    let token_id = create_token(env);
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(env, &registry_id);
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), registry_id.clone(), token_id.clone()),
+    );
+    let fin = super::FinancingContractClient::new(env, &financing_id);
+
+    reg.set_financing_contract(&admin, &financing_id);
+    // The lender's standing allowance to the financing contract is their
+    // pre-commitment: it is what makes auto-accept executable without a second
+    // signature from them at match time.
+    mint_and_approve(env, &token_id, &financing_id, &lender, amount * 4);
+
+    reg.register_invoice(
+        invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(9_000_000u64),
+    );
+    fin.create_offer(
+        offer_id,
+        invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &500u32,
+        &(1_296_000u64),
+    );
+
+    (reg, fin, admin, originator, lender, token_id)
+}
+
+#[test]
+fn test_amend_offer_rewrites_terms_and_opens_negotiation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv01");
+    let offer_id = symbol_short!("noff01");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    let amended = fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &900_000_000i128,
+        &400u32,
+        &(2_592_000u64),
+    );
+
+    assert_eq!(amended.status, OfferStatus::Pending);
+    assert_eq!(amended.amount, 900_000_000);
+    assert_eq!(amended.interest_rate, 400);
+    assert_eq!(amended.duration, 2_592_000);
+
+    // The offer itself is the lender's standing position, so a plain read
+    // sees the amended terms.
+    let stored = fin.get_offer(&offer_id);
+    assert_eq!(stored.amount, 900_000_000);
+    assert_eq!(stored.interest_rate, 400);
+
+    let history = fin.get_negotiation(&offer_id);
+    assert_eq!(history.len(), 1);
+    let round = history.get(0).unwrap();
+    assert_eq!(round.party, NegotiationParty::Lender);
+    assert_eq!(round.amount, 900_000_000);
+    assert_eq!(round.interest_rate, 400);
+    assert_eq!(round.duration, 2_592_000);
+    assert_eq!(round.timestamp, 1_000_000);
+
+    assert_eq!(fin.get_negotiation_status(&offer_id), NegotiationStatus::Open);
+    // 72-hour default window, frozen at open.
+    assert_eq!(fin.get_negotiation_deadline(&offer_id), 1_000_000 + 259_200);
+
+    // total_offered follows the amendment by its delta rather than
+    // double-counting the offer.
+    assert_eq!(fin.get_lender_stats(&lender).total_offered, 900_000_000);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_amend_offer_by_non_lender_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv02");
+    let offer_id = symbol_short!("noff02");
+    let (_reg, fin, _admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &900_000_000i128,
+        &400u32,
+        &(2_592_000u64),
+    );
+}
+
+#[test]
+fn test_counter_offer_records_round_without_touching_the_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv03");
+    let offer_id = symbol_short!("noff03");
+    let (_reg, fin, _admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    let returned = fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(1_296_000u64),
+    );
+
+    // A counter-offer is a proposal, not a rewrite: the offer still says what
+    // the lender said.
+    assert_eq!(returned.status, OfferStatus::Pending);
+    assert_eq!(fin.get_offer(&offer_id).interest_rate, 500);
+
+    let history = fin.get_negotiation(&offer_id);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().party, NegotiationParty::Originator);
+    assert_eq!(history.get(0).unwrap().interest_rate, 250);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_counter_offer_by_non_originator_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv04");
+    let offer_id = symbol_short!("noff04");
+    let (_reg, fin, _admin, _originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    let stranger = Address::generate(&env);
+    fin.counter_offer(
+        &offer_id,
+        &stranger,
+        &0u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(1_296_000u64),
+    );
+}
+
+#[test]
+fn test_negotiation_history_records_every_round_in_order() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv05");
+    let offer_id = symbol_short!("noff05");
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &450u32,
+        &(1_296_000u64),
+    );
+    env.ledger().set_timestamp(1_000_100);
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &1u32,
+        &1_000_000_000i128,
+        &300u32,
+        &(1_296_000u64),
+    );
+    env.ledger().set_timestamp(1_000_200);
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &2u32,
+        &1_000_000_000i128,
+        &380u32,
+        &(1_296_000u64),
+    );
+
+    let history = fin.get_negotiation(&offer_id);
+    assert_eq!(history.len(), 3);
+    assert_eq!(history.get(0).unwrap().party, NegotiationParty::Lender);
+    assert_eq!(history.get(0).unwrap().interest_rate, 450);
+    assert_eq!(history.get(1).unwrap().party, NegotiationParty::Originator);
+    assert_eq!(history.get(1).unwrap().interest_rate, 300);
+    assert_eq!(history.get(2).unwrap().party, NegotiationParty::Lender);
+    assert_eq!(history.get(2).unwrap().interest_rate, 380);
+    assert_eq!(history.get(2).unwrap().timestamp, 1_000_200);
+
+    // The deadline was frozen by the *first* round, not pushed out by later
+    // ones — a negotiation cannot be extended indefinitely by ping-pong.
+    assert_eq!(fin.get_negotiation_deadline(&offer_id), 1_000_000 + 259_200);
+}
+
+// ── Auto-accept: the two paths that actually move money ──────────────────────
+
+#[test]
+fn test_auto_accept_when_lender_amends_onto_the_live_counter_offer() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv06");
+    let offer_id = symbol_short!("noff06");
+    let amount: i128 = 1_000_000_000;
+    let (reg, fin, _admin, originator, lender, token_id) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    // Originator counters at a lower rate and a shorter duration.
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &(amount),
+        &250u32,
+        &(864_000u64),
+    );
+
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&originator), 0);
+
+    // The lender meets it exactly. Agreement -> settlement in this same call,
+    // with no further signature from the originator.
+    let settled = fin.amend_offer(&offer_id, &lender, &1u32, &(amount), &250u32, &(864_000u64));
+
+    assert_eq!(settled.status, OfferStatus::Accepted);
+    assert_eq!(settled.interest_rate, 250);
+    assert_eq!(settled.duration, 864_000);
+    assert_eq!(settled.funded_at, 1_000_000);
+
+    // The headline, proved from the outside: the invoice is financed and the
+    // principal is in the business's account.
+    assert_eq!(reg.get_invoice(&invoice_id).status, InvoiceStatus::Financed);
+    assert_eq!(token_client.balance(&originator), amount);
+
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Accepted
+    );
+    assert_eq!(fin.get_negotiation(&offer_id).len(), 2);
+}
+
+#[test]
+fn test_auto_accept_when_originator_counters_at_the_standing_terms() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv07");
+    let offer_id = symbol_short!("noff07");
+    let amount: i128 = 1_000_000_000;
+    let (reg, fin, _admin, originator, lender, token_id) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    // Lender amends down to 300 bps; the originator takes exactly that.
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &(amount),
+        &300u32,
+        &(1_296_000u64),
+    );
+    let settled = fin.counter_offer(
+        &offer_id,
+        &originator,
+        &1u32,
+        &(amount),
+        &300u32,
+        &(1_296_000u64),
+    );
+
+    assert_eq!(settled.status, OfferStatus::Accepted);
+    assert_eq!(reg.get_invoice(&invoice_id).status, InvoiceStatus::Financed);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&originator), amount);
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Accepted
+    );
+}
+
+#[test]
+fn test_near_miss_terms_do_not_auto_accept() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv08");
+    let offer_id = symbol_short!("noff08");
+    let amount: i128 = 1_000_000_000;
+    let (reg, fin, _admin, originator, lender, token_id) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &(amount),
+        &250u32,
+        &(864_000u64),
+    );
+    // One basis point off is not agreement.
+    let still_open = fin.amend_offer(&offer_id, &lender, &1u32, &(amount), &251u32, &(864_000u64));
+
+    assert_eq!(still_open.status, OfferStatus::Pending);
+    assert_eq!(reg.get_invoice(&invoice_id).status, InvoiceStatus::Pending);
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&originator), 0);
+    assert_eq!(fin.get_negotiation_status(&offer_id), NegotiationStatus::Open);
+}
+
+#[test]
+fn test_superseded_counter_offer_is_not_executable() {
+    // Adversarial: the originator proposes T1, then moves off it to T2. A
+    // lender who later amends onto T1 must not be able to settle against a
+    // proposal the originator has abandoned.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv09");
+    let offer_id = symbol_short!("noff09");
+    let amount: i128 = 1_000_000_000;
+    let (reg, fin, _admin, originator, lender, token_id) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &(amount),
+        &200u32,
+        &(864_000u64),
+    );
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &1u32,
+        &(amount),
+        &220u32,
+        &(864_000u64),
+    );
+
+    // The lender reaches for the abandoned T1.
+    let result = fin.amend_offer(&offer_id, &lender, &2u32, &(amount), &200u32, &(864_000u64));
+
+    assert_eq!(result.status, OfferStatus::Pending);
+    assert_eq!(reg.get_invoice(&invoice_id).status, InvoiceStatus::Pending);
+    assert_eq!(token::TokenClient::new(&env, &token_id).balance(&originator), 0);
+}
+
+// ── Optimistic concurrency ───────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_stale_round_index_is_rejected() {
+    // Adversarial: the lender reads the negotiation at round 0, the originator
+    // counters before the lender's transaction lands, and the lender's
+    // amendment would otherwise apply to a term-set that changed underneath
+    // it — and could auto-execute against a counter-offer it never saw.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv10");
+    let offer_id = symbol_short!("noff10");
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(864_000u64),
+    );
+
+    // Lender still believes the history is empty.
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_counter_offer_with_stale_round_index_is_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv11");
+    let offer_id = symbol_short!("noff11");
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(864_000u64),
+    );
+}
+
+// ── Expiry ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_negotiation_status_expires_on_read_without_any_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv12");
+    let offer_id = symbol_short!("noff12");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+
+    // On the deadline itself the negotiation is still open.
+    env.ledger().set_timestamp(1_000_000 + 259_200);
+    assert_eq!(fin.get_negotiation_status(&offer_id), NegotiationStatus::Open);
+
+    // One second later it is expired — derived, with nothing having been
+    // called in between.
+    env.ledger().set_timestamp(1_000_000 + 259_201);
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Expired
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_amend_after_expiry_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv13");
+    let offer_id = symbol_short!("noff13");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+
+    env.ledger().set_timestamp(1_000_000 + 259_201);
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &1u32,
+        &1_000_000_000i128,
+        &350u32,
+        &(1_296_000u64),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_expired_counter_offer_cannot_be_executed_by_the_lender() {
+    // The commitment a counter-offer represents is bounded by the window: an
+    // originator who proposed terms three days ago is not still on the hook
+    // for them.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv14");
+    let offer_id = symbol_short!("noff14");
+    let amount: i128 = 1_000_000_000;
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &(amount),
+        &250u32,
+        &(864_000u64),
+    );
+
+    env.ledger().set_timestamp(1_000_000 + 259_201);
+    fin.amend_offer(&offer_id, &lender, &1u32, &(amount), &250u32, &(864_000u64));
+}
+
+#[test]
+fn test_close_negotiation_after_expiry_is_permissionless() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv15");
+    let offer_id = symbol_short!("noff15");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+
+    env.ledger().set_timestamp(1_000_000 + 300_000);
+    let keeper = Address::generate(&env);
+    let outcome = fin.close_negotiation(&offer_id, &keeper);
+
+    assert_eq!(outcome, NegotiationStatus::Expired);
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Expired
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_close_negotiation_twice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv16");
+    let offer_id = symbol_short!("noff16");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+    fin.close_negotiation(&offer_id, &lender);
+    fin.close_negotiation(&offer_id, &lender);
+}
+
+// ── Early close / revocation ─────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_originator_can_revoke_a_counter_offer_before_the_window_ends() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv17");
+    let offer_id = symbol_short!("noff17");
+    let amount: i128 = 1_000_000_000;
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &(amount),
+        &250u32,
+        &(864_000u64),
+    );
+    assert_eq!(
+        fin.close_negotiation(&offer_id, &originator),
+        NegotiationStatus::Closed
+    );
+
+    // The lender can no longer settle against the revoked proposal.
+    fin.amend_offer(&offer_id, &lender, &1u32, &(amount), &250u32, &(864_000u64));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_stranger_cannot_close_an_open_negotiation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv18");
+    let offer_id = symbol_short!("noff18");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+    fin.close_negotiation(&offer_id, &Address::generate(&env));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_close_negotiation_that_was_never_opened_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv19");
+    let offer_id = symbol_short!("noff19");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.close_negotiation(&offer_id, &lender);
+}
+
+#[test]
+fn test_withdrawing_the_offer_ends_its_negotiation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv20");
+    let offer_id = symbol_short!("noff20");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+    fin.withdraw_offer(&offer_id, &lender);
+
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Closed
+    );
+}
+
+// ── Guards ───────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_amend_after_acceptance_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv21");
+    let offer_id = symbol_short!("noff21");
+    let amount: i128 = 1_000_000_000;
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    fin.accept_offer(&offer_id, &originator);
+    fin.amend_offer(&offer_id, &lender, &0u32, &(amount), &400u32, &(1_296_000u64));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_amend_cannot_reach_terms_create_offer_would_reject() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv22");
+    let offer_id = symbol_short!("noff22");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // 10 001 bps is above the create_offer ceiling.
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &10_001u32,
+        &(1_296_000u64),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_counter_offer_below_minimum_duration_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv23");
+    let offer_id = symbol_short!("noff23");
+    let (_reg, fin, _admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(86_399u64),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_negotiation_round_cap_is_enforced() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv24");
+    let offer_id = symbol_short!("noff24");
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // 20 rounds fit; the 21st does not. Terms differ every round so nothing
+    // auto-accepts along the way.
+    for round in 0u32..20 {
+        let rate = 400 + round;
+        if round % 2 == 0 {
+            fin.amend_offer(
+                &offer_id,
+                &lender,
+                &round,
+                &1_000_000_000i128,
+                &rate,
+                &(1_296_000u64),
+            );
+        } else {
+            fin.counter_offer(
+                &offer_id,
+                &originator,
+                &round,
+                &900_000_000i128,
+                &rate,
+                &(1_296_000u64),
+            );
+        }
+    }
+    assert_eq!(fin.get_negotiation(&offer_id).len(), 20);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &20u32,
+        &1_000_000_000i128,
+        &499u32,
+        &(1_296_000u64),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_amend_offer_is_pause_guarded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv25");
+    let offer_id = symbol_short!("noff25");
+    let (_reg, fin, admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.pause(&admin);
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_counter_offer_is_pause_guarded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv26");
+    let offer_id = symbol_short!("noff26");
+    let (_reg, fin, admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.pause(&admin);
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(1_296_000u64),
+    );
+}
+
+// ── Window configuration ─────────────────────────────────────────────────────
+
+#[test]
+fn test_negotiation_window_is_configurable_and_deadlines_are_frozen() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv27");
+    let offer_id = symbol_short!("noff27");
+    let (_reg, fin, admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    assert_eq!(fin.get_negotiation_window(), 259_200);
+
+    fin.set_negotiation_window(&admin, &7_200u64);
+    assert_eq!(fin.get_negotiation_window(), 7_200);
+
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+    assert_eq!(fin.get_negotiation_deadline(&offer_id), 1_007_200);
+
+    // Widening the window afterwards must not resurrect a negotiation that is
+    // already running against a frozen deadline.
+    fin.set_negotiation_window(&admin, &2_592_000u64);
+    assert_eq!(fin.get_negotiation_deadline(&offer_id), 1_007_200);
+    env.ledger().set_timestamp(1_007_201);
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Expired
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_set_negotiation_window_is_admin_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv28");
+    let offer_id = symbol_short!("noff28");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.set_negotiation_window(&lender, &7_200u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_negotiation_window_below_minimum_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv29");
+    let offer_id = symbol_short!("noff29");
+    let (_reg, fin, admin, _originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.set_negotiation_window(&admin, &3_599u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_negotiation_window_above_maximum_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv30");
+    let offer_id = symbol_short!("noff30");
+    let (_reg, fin, admin, _originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    fin.set_negotiation_window(&admin, &2_592_001u64);
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+/// How many published events carry `name` as their first topic.
+fn count_events(env: &Env, name: Symbol) -> u32 {
+    let mut count = 0;
+    for (_contract, topics, _data) in env.events().all().iter() {
+        if let Some(first) = topics.get(0) {
+            if let Ok(topic) = Symbol::try_from_val(env, &first) {
+                if topic == name {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+#[test]
+fn test_negotiation_emits_amend_counter_and_close_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv31");
+    let offer_id = symbol_short!("noff31");
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // The test harness exposes the events of the most recent invocation, so
+    // each call is checked as it lands rather than all of them at the end.
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &400u32,
+        &(1_296_000u64),
+    );
+    assert_eq!(
+        count_events(&env, symbol_short!("off_amd")),
+        1,
+        "amend_offer must emit off_amd"
+    );
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &1u32,
+        &1_000_000_000i128,
+        &250u32,
+        &(864_000u64),
+    );
+    assert_eq!(
+        count_events(&env, symbol_short!("ctr_off")),
+        1,
+        "counter_offer must emit ctr_off"
+    );
+
+    fin.close_negotiation(&offer_id, &originator);
+    assert_eq!(
+        count_events(&env, symbol_short!("neg_clsd")),
+        1,
+        "close_negotiation must emit neg_clsd"
+    );
+}
+
+#[test]
+fn test_auto_accept_emits_negotiation_closed() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv32");
+    let offer_id = symbol_short!("noff32");
+    let amount: i128 = 1_000_000_000;
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &(amount),
+        &250u32,
+        &(864_000u64),
+    );
+    fin.amend_offer(&offer_id, &lender, &1u32, &(amount), &250u32, &(864_000u64));
+
+    assert_eq!(
+        count_events(&env, symbol_short!("neg_clsd")),
+        1,
+        "auto-accept must emit neg_clsd exactly once"
+    );
+    assert_eq!(
+        count_events(&env, symbol_short!("off_acc")),
+        1,
+        "auto-accept must run the ordinary off_acc settlement path"
+    );
 }


### PR DESCRIPTION
Closes #180

Financing offers were take-it-or-leave-it: a lender posted terms and the originator could only accept or reject them, so terms that were nearly right died the same way terms that were absurd did. This adds a negotiation protocol — `amend_offer` for the lender, `counter_offer` for the originator — with every round recorded on-chain, and settlement in the same transaction when the two sides land on identical terms.

Design and rationale: [`docs/adr/0008-offer-negotiation.md`](docs/adr/0008-offer-negotiation.md).

## The two things that break if done naively

**Auto-accept cannot be unilateral.** Settlement moves the lender's principal with `transfer_from`, which Soroban only honours against the lender's own allowance — so "the last caller executes both sides" does not work; it fails at the first match. Auto-accept here **matches two commitments that already exist**:

- the lender's is their SEP-41 allowance to this contract, without which acceptance was never possible at all;
- the originator's is the counter-offer they recorded in a transaction they signed.

Agreement is exact equality of the canonical term tuple `(amount, interest_rate, duration)` — no tolerance, no rounding — so neither side is ever bound to terms they did not themselves put on the table. Because that commitment outlives the transaction that made it, it is bounded (the window), revocable (`close_negotiation`), and superseded by the party's next proposal.

**Every round is version-guarded.** `amend_offer` / `counter_offer` take `expected_round`, the history length the caller believes it is amending. Without it, a lender who read the negotiation and then had the originator's counter-offer land first would have their amendment applied to terms they never saw — and could auto-execute against a counter-offer they did not know existed.

## What's in it

| Entrypoint | Auth | |
|---|---|---|
| `amend_offer(offer_id, lender, expected_round, amount, rate, duration)` | Lender | Rewrites the offer's terms; settles if they match the originator's live counter-offer |
| `counter_offer(offer_id, originator, expected_round, amount, rate, duration)` | Originator | Records a proposal; settles if it matches the lender's standing terms |
| `close_negotiation(offer_id, caller)` | Both parties; anyone once expired | Revokes a live commitment before the deadline, records expiry after it |
| `get_negotiation` / `get_negotiation_status` / `get_negotiation_deadline` / `get_negotiation_window` | Anyone | Reads |
| `set_negotiation_window(admin, secs)` | Admin | Default 72 h, clamped to 1 h – 30 days |

- **Negotiation history** — `negotiations:{offer_id}` as a `Vec<NegotiationRecord>`, capped at 20 rounds so the entry stays bounded.
- **Expiry is derived on read.** Soroban has no scheduler, so `get_negotiation_status` computes `Expired` from the deadline whether or not anyone has called anything. `close_negotiation` is the poke that persists it and emits the event — permissionless after the deadline (the state is already determined), restricted to the two parties before it (then it *is* a state change). The deadline is frozen when the negotiation opens, so later rounds cannot push it out and a later `set_negotiation_window` cannot move it.
- **Events** — `off_amd`, `ctr_off`, `neg_clsd`, added to the canonical event table in the README.
- **One settlement path.** `accept_offer`'s body is extracted into `settle_acceptance`, called by both `accept_offer` and auto-accept, so the two cannot drift. The auto-accept path re-reads the invoice and re-checks both parties against the blacklist first — it is the one route that settles without the counterparty's live signature.
- Amended terms are validated against the same bounds `create_offer` enforces, so a negotiation cannot reach terms the offer could not have been created with.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Offer amendment works | `amend_offer`; `test_amend_offer_rewrites_terms_and_opens_negotiation` |
| Counter-offer mechanism works | `counter_offer`; `test_counter_offer_records_round_without_touching_the_offer` |
| Negotiation history stored | `negotiations:{offer_id}`; `test_negotiation_history_records_every_round_in_order` |
| Expiry enforced | `test_negotiation_status_expires_on_read_without_any_call`, `test_amend_after_expiry_panics`, `test_expired_counter_offer_cannot_be_executed_by_the_lender` |
| Auto-accept on agreement | `test_auto_accept_when_lender_amends_onto_the_live_counter_offer`, `test_auto_accept_when_originator_counters_at_the_standing_terms` |
| Events emitted | `test_negotiation_emits_amend_counter_and_close_events`, `test_auto_accept_emits_negotiation_closed` |

## Verification

26 new tests, all driven through the generated contract client — the same entrypoints a wallet calls — and asserting on **real settlement effects**, not on helpers in isolation: the auto-accept tests check the originator's SEP-41 token balance and the invoice's status in the registry contract.

```
cargo test -p invofi-financing
test result: ok. 72 passed; 0 failed
```

Adversarial cases that must *not* settle, each asserting the invoice stayed Pending and no tokens moved:

- `test_stale_round_index_is_rejected` — the originator counters between the lender's read and their write.
- `test_superseded_counter_offer_is_not_executable` — the lender reaches for a proposal the originator has since moved off.
- `test_expired_counter_offer_cannot_be_executed_by_the_lender` — the window bounds the commitment.
- `test_near_miss_terms_do_not_auto_accept` — one basis point off is not agreement.
- `test_originator_can_revoke_a_counter_offer_before_the_window_ends`.

Shared code I touched, verified unbroken:

```
cargo test -p invofi-registry -p invofi-repayment -p invofi-integration -p invofi-insurance -p invofi-reputation
145 passed; 0 failed
cargo clippy --target wasm32v1-none -- -D warnings   # clean
```

## Scope

Only issue #180. The public ABI of existing entrypoints is unchanged; the sole behavioural edit to shared code is that `withdraw_offer` and `reject_offer` now emit `neg_clsd` when they end an open negotiation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offer negotiation with lender amendments and originator counter-offers.
  - Added configurable negotiation windows, round limits, expiry, closure, and negotiation history.
  - Matching terms can now trigger automatic acceptance and settlement.
  - Added status, deadline, and negotiation-history queries.

- **Documentation**
  - Documented negotiation workflows, events, statuses, limits, and related error messages.
  - Added an architectural decision record describing the negotiation protocol.

- **Bug Fixes**
  - Added safeguards against stale negotiation rounds and closed negotiations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->