### PR TITLE
feat(registry): invoice verification oracle with off-chain data attestation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,51 @@ and are enforced by commitlint in CI.
     derived expiry at the deadline boundary, an expired counter-offer that can
     no longer be taken, revocation, permissionless post-deadline close, the
     round cap, the pause and authorization guards, and the events.
+- **Invoice verification oracle (issue #181)** — `registry` now records
+  attestations from a trusted verifier set about off-chain invoice facts:
+  document hash, business registration, and tax compliance. Design in
+  `docs/adr/0009-verification-oracle.md`.
+  - **The trust boundary is verifier authentication, not fact verification.**
+    A contract cannot check that a PDF hash corresponds to a real invoice or
+    that a tax filing is current. `attest` authenticates that a verifier in
+    the admin-governed set signed a claim and stores it immutably; the truth
+    of the claim rests on verifier honesty, bounded by the m-of-n threshold.
+    The ADR states this explicitly so "trust-minimised" is not read as
+    on-chain fact-checking.
+  - **m-of-n over distinct verifiers.** `set_verifier_threshold` sets how
+    many *distinct* verifiers must approve before a type reads `Verified`;
+    re-attesting replaces a verifier's own prior record, so no single
+    verifier can reach the threshold alone. A live rejection dominates
+    approvals — one honest verifier can block a fraudulent invoice that
+    others waved through.
+  - **Status is derived per verification type**, with
+    `get_invoice_verification_status` returning the conjunction across all
+    three. `Verified` requires every type to have cleared its threshold.
+  - **Expiry is derived on read** (default 90 days, admin-configurable
+    within 1–365 days). Soroban has no scheduler, so an attestation past
+    `valid_until` reads as `Expired` whether or not anyone has called
+    anything; the permissionless `expire_verifications` poke persists that
+    outcome and emits `ver_exp` exactly once per attestation. Validity is
+    stamped at attest time and later admin changes are not retroactive.
+  - **The fee is charged on rejection as well as approval.** It pays for the
+    verification work, and refunding it on rejection would pay verifiers
+    only for approving — a direct incentive to rubber-stamp. Documented as a
+    deliberate answer to a case the issue left open.
+  - `fee = invoice_amount * verification_fee_bps / 10_000`, computed with
+    `checked_mul` and dividing last, transferred from the originator to the
+    verifier in the same transaction that stores the attestation, so there
+    is no charge without a record and no record without a charge.
+  - New admin entrypoints `add_verifier`, `remove_verifier`,
+    `set_verifier_threshold`, `set_verification_fee`,
+    `set_attestation_validity`, and `register_currency` (fee settlement
+    token), all pause-guarded and admin-only. **`verification_fee_bps`
+    defaults to 0, which disables the transfer entirely** — this change is
+    behaviourally inert until an admin enables it.
+  - 28 new tests covering all three verification types, the m-of-n
+    threshold, fee math and its overflow guard, fee-on-rejection, expiry and
+    re-attestation, non-retroactive validity changes, the removed-verifier
+    case, and the three events.
+
 - **Partial repayment with pro-rata interest (issue #176)** — originators
   can now make partial payments against an invoice, with interest calculated
   pro-rata on the remaining principal: `interest = remaining × rate_bps ×

--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ register_invoice()  →  create_offer()  →  accept_offer()
 | `mark_invoice_overdue(id)` | Anyone | Overdue once due_date passes |
 | `raise_dispute / resolve_dispute` | Originator / Admin | Dispute lifecycle |
 | `blacklist_address / unblacklist_address / is_blacklisted` | Admin | Address blocking |
+| `attest(invoice_id, verifier, type, hash, approved)` | Trusted verifier | Record an off-chain attestation (document hash, business registration, tax compliance); charges the verification fee (ADR-0009) |
+| `get_verification_status(invoice_id, type)` / `get_invoice_verification_status(invoice_id)` | Anyone | Verification status per type, and the conjunction across all three |
+| `get_verifications(invoice_id)` | Anyone | Every attestation recorded against an invoice |
+| `expire_verifications(invoice_id)` | Anyone | Permissionless poke that records lapsed attestations and emits `ver_exp` |
+| `add_verifier / remove_verifier / set_verifier_threshold` | Admin | Trusted verifier set and the m of m-of-n |
+| `set_verification_fee / set_attestation_validity / register_currency` | Admin | Fee in bps (default 0 = off), attestation validity (default 90 days), fee settlement token |
 | `set_rate / set_fee / transfer_admin / pause / unpause` | Admin | Admin controls |
 
 ### Financing — `financing/`
@@ -175,6 +181,9 @@ Every state-mutating function publishes a Soroban contract event. Topics are
 | `inv_cxl` | `cancel_invoice` | `originator` |
 | `inv_dsp` | `raise_dispute` | `originator` |
 | `inv_rsl` | `resolve_dispute` | `new_status` |
+| `ver_sub` | `attest` (registry) | `(verifier, type, hash, valid_until, fee)` |
+| `ver_done` | `attest` (registry) | `(type, VerificationStatus)` — emitted when a type reaches Verified or Rejected |
+| `ver_exp` | `expire_verifications` (registry) | `(verifier, type, valid_until)` |
 | `pos_mint` | `accept_offer` (financing) | `(lender, amount)` — position token minted |
 | `pool_stk` | `stake` (insurance) | `amount` |
 | `pool_un` | `unstake` (insurance) | `amount` |
@@ -201,6 +210,11 @@ All contracts emit machine-readable `E_*` error codes (see [docs/error-codes.md]
 | `DEFAULT_NEGOTIATION_WINDOW_SECS` | 259,200 | Default offer-negotiation window (72 hours) |
 | `MIN_NEGOTIATION_WINDOW_SECS` / `MAX_NEGOTIATION_WINDOW_SECS` | 3,600 / 2,592,000 | Bounds an admin may configure the window to (1 hour – 30 days) |
 | `MAX_NEGOTIATION_ROUNDS` | 20 | Cap on recorded negotiation rounds per offer |
+| `DEFAULT_ATTESTATION_VALIDITY_SECS` | 7,776,000 | Default verification attestation validity (90 days) |
+| `MIN_ATTESTATION_VALIDITY_SECS` / `MAX_ATTESTATION_VALIDITY_SECS` | 86,400 / 31,536,000 | Bounds an admin may configure attestation validity to (1–365 days) |
+| `MAX_VERIFICATION_FEE_BPS` | 500 | Verification fee ceiling (5% of invoice value) |
+| `MAX_VERIFIERS` | 20 | Maximum size of the trusted verifier set |
+| `MAX_ATTESTATIONS_PER_INVOICE` | 60 | Cap on stored attestations per invoice |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ register_invoice()  →  create_offer()  →  accept_offer()
 | `get_verification_status(invoice_id, type)` / `get_invoice_verification_status(invoice_id)` | Anyone | Verification status per type, and the conjunction across all three |
 | `get_verifications(invoice_id)` | Anyone | Every attestation recorded against an invoice |
 | `expire_verifications(invoice_id)` | Anyone | Permissionless poke that records lapsed attestations and emits `ver_exp` |
-| `add_verifier / remove_verifier / set_verifier_threshold` | Admin | Trusted verifier set and the m of m-of-n |
+| `add_verifier / remove_verifier / set_verifier_threshold` | Admin | Trusted verifier set and the m-of-n threshold |
 | `set_verification_fee / set_attestation_validity / register_currency` | Admin | Fee in bps (default 0 = off), attestation validity (default 90 days), fee settlement token |
 | `set_rate / set_fee / transfer_admin / pause / unpause` | Admin | Admin controls |
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,7 +7,9 @@
 
 #![no_std]
 
-use soroban_sdk::{contractclient, contracterror, contracttype, symbol_short, Address, Env, Map, Symbol};
+use soroban_sdk::{
+    contractclient, contracterror, contracttype, symbol_short, Address, BytesN, Env, Map, Symbol,
+};
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -43,6 +45,37 @@ pub const MAX_NEGOTIATION_WINDOW_SECS: u64 = 2_592_000;
 /// `NegotiationRecord` to a single persistent `Vec`, so the cap is what keeps
 /// that entry's size — and the cost of reading it — bounded.
 pub const MAX_NEGOTIATION_ROUNDS: u32 = 20;
+/// Default validity period for a verification attestation. 90 days, in
+/// seconds. Admin-configurable per deployment via `set_attestation_validity`.
+pub const DEFAULT_ATTESTATION_VALIDITY_SECS: u64 = 7_776_000;
+
+/// Lower bound an admin may configure attestation validity to. 1 day.
+pub const MIN_ATTESTATION_VALIDITY_SECS: u64 = 86_400;
+
+/// Upper bound an admin may configure attestation validity to. 365 days.
+/// An attestation is a snapshot of an off-chain fact that can change without
+/// anyone telling the chain, so it must not be settable to never expire.
+pub const MAX_ATTESTATION_VALIDITY_SECS: u64 = 31_536_000;
+
+/// Maximum verification fee an admin may configure, in basis points (5%) —
+/// the same ceiling `set_fee` applies to the protocol fee.
+pub const MAX_VERIFICATION_FEE_BPS: u32 = 500;
+
+/// Maximum size of the trusted verifier set.
+pub const MAX_VERIFIERS: u32 = 20;
+
+/// Maximum attestations retained per invoice. One per (verifier, type) keeps
+/// this at `MAX_VERIFIERS x 3` for the current verifier set; the cap also
+/// bounds the residue left behind by verifiers who have since been removed.
+pub const MAX_ATTESTATIONS_PER_INVOICE: u32 = 60;
+
+/// The off-chain facts the verification oracle attests to. Used to decide
+/// whether an invoice is fully verified — every type must clear the threshold.
+pub const VERIFICATION_TYPES: [VerificationType; 3] = [
+    VerificationType::DocumentHash,
+    VerificationType::BusinessRegistration,
+    VerificationType::TaxCompliance,
+];
 
 // ─── Shared Error Enum ────────────────────────────────────────────────────────
 
@@ -321,6 +354,66 @@ pub enum NegotiationStatus {
     /// The two sides converged on identical terms and the offer executed.
     /// Terminal.
     Accepted = 4,
+}
+
+/// The class of off-chain fact an attestation speaks to.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum VerificationType {
+    /// The hash of the invoice document itself matches what the originator
+    /// registered off-chain.
+    DocumentHash = 0,
+    /// The originator is a registered business in good standing.
+    BusinessRegistration = 1,
+    /// The originator is current on its tax obligations.
+    TaxCompliance = 2,
+}
+
+/// Verification state of an invoice, or of one verification type on it.
+///
+/// `Expired` is **derived on read** from `valid_until`: Soroban has no
+/// scheduler, so nothing flips an attestation to expired on its own.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum VerificationStatus {
+    /// No attestation yet, or not enough of them to clear the threshold.
+    Pending = 0,
+    /// Enough distinct verifiers attested affirmatively, none of them
+    /// expired, and no verifier rejected.
+    Verified = 1,
+    /// A verifier attested negatively. A live rejection outranks any number
+    /// of approvals.
+    Rejected = 2,
+    /// Every attestation that existed has passed its `valid_until`.
+    Expired = 3,
+}
+
+/// A verifier's signed statement about one off-chain fact, stored on-chain.
+///
+/// The contract cannot check that `hash` corresponds to a real invoice
+/// document, or that a business registration is genuine. What it does is
+/// authenticate that a *trusted verifier* said so and keep the statement
+/// tamper-evident and timestamped — see ADR-0009 for that trust boundary.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Attestation {
+    /// The verifier who submitted it.
+    pub verifier: Address,
+    /// Which off-chain fact it speaks to.
+    pub v_type: VerificationType,
+    /// Hash of the off-chain evidence (document, registration record, filing).
+    pub hash: BytesN<32>,
+    /// Ledger timestamp at which it was submitted.
+    pub timestamp: u64,
+    /// Ledger timestamp after which it no longer counts.
+    pub valid_until: u64,
+    /// `Verified` or `Rejected` as submitted; flipped to `Expired` once
+    /// `expire_verifications` observes the lapse. Reads derive expiry from
+    /// `valid_until` regardless, so this field lagging never makes a read
+    /// wrong.
+    pub status: VerificationStatus,
 }
 
 // ─── Currency Registry ───────────────────────────────────────────────────────

--- a/docs/adr/0009-verification-oracle.md
+++ b/docs/adr/0009-verification-oracle.md
@@ -1,0 +1,163 @@
+# ADR-0009 — Invoice verification oracle
+
+**Status:** Proposed (2026-08-20)
+
+## Context
+
+Everything the registry knows about an invoice, the originator typed in.
+`register_invoice` takes an amount, a currency and a due date on trust; nothing
+ties them to a real invoice, a real business, or a business in good standing
+with its tax authority. A lender pricing an offer is pricing self-reported data
+(issue #181).
+
+The facts that would help — this PDF is the invoice, this company is
+registered, this company is current on its filings — live off-chain, in
+registries a Soroban contract cannot read.
+
+## Decision
+
+### 1. The trust boundary, stated plainly
+
+The contract **cannot** verify that a document hash corresponds to a real
+invoice, or that a business registration number is genuine. No on-chain code
+can. What it does is narrower and worth being precise about:
+
+- it authenticates that the attestation came from an address in an
+  admin-governed verifier set;
+- it stores the statement immutably, with the verifier's identity, the hash of
+  the evidence, and the time;
+- it requires **m of n** distinct verifiers before a fact counts as verified;
+- it expires the statement, so a stale fact stops counting.
+
+Trust is bounded by verifier honesty and by the threshold. It is not
+eliminated. Calling this "trust-minimised verification" is fair; calling it
+"on-chain fact verification" is not, and the contract documentation says so
+rather than letting an integrator infer the stronger claim.
+
+The off-chain oracle service does the actual checking and calls `attest` with
+the result. Its correctness is out of scope for this contract, which is exactly
+the point of pinning the boundary here.
+
+### 2. m-of-n, with rejection outranking approval
+
+`set_verifier_threshold` sets how many **distinct** verifiers must attest
+affirmatively before a verification type reads `Verified`. Distinctness is
+structural: `attest` keeps at most one attestation per (verifier, type), so a
+single verifier cannot reach a threshold of three by calling three times.
+Re-attesting replaces, which is also how a verifier refreshes an expired
+statement or corrects a wrong one.
+
+A live rejection makes the type `Rejected` regardless of how many approvals
+sit beside it. One verifier saying a document is forged should not be outvoted
+by two saying it looked fine — the asymmetry is deliberate, and it is the
+conservative direction for a protocol where the downside of financing a forged
+invoice is much worse than the downside of not financing a real one.
+
+The threshold is deliberately **not** clamped to the current verifier-set size.
+An admin may set it above the set while onboarding verifiers, and removing a
+verifier must not silently weaken a threshold that was set on purpose. A
+threshold no live set can reach means nothing verifies, which fails safe.
+
+### 3. Verification status is per type; the invoice status is the conjunction
+
+`get_verification_status(invoice_id, v_type)` is the primitive. The aggregate
+`get_invoice_verification_status` requires **every** type to be verified: an
+invoice with a checked document hash but no business registration is not a
+verified invoice. Rejection anywhere dominates; otherwise a lapsed type reads
+`Expired`.
+
+### 4. Expiry is derived on read
+
+Soroban has no scheduler. An attestation's `valid_until` cannot flip anything
+when it passes, so status is computed from `now > valid_until` at read time and
+is correct whether or not anyone has called anything.
+
+`expire_verifications` is a permissionless poke that persists the lapse and
+emits `ver_exp` for each newly expired attestation. It exists only so an
+indexer has something to observe — a deadline passing is not an event, and
+nothing about verification status depends on this being called. It is a no-op
+the second time, so a keeper cannot spam duplicate events.
+
+A lapsed *rejection* expires too. A stale "this invoice is bad" is no more
+informative than a stale "this invoice is good".
+
+Validity is admin-configurable (default 90 days) and clamped to 1–365 days: an
+attestation is a snapshot of a fact that can change without telling the chain,
+so it must not be settable to never expire. Changing the setting does not move
+the `valid_until` of attestations already submitted; each carries its own,
+fixed at submission.
+
+### 5. The fee is charged for the work, not for the answer
+
+`fee = invoice_amount * verification_fee_bps / 10_000`, paid by the invoice
+originator to the attesting verifier in the invoice's own currency, via a
+SEP-41 `transfer_from` against an allowance the originator granted the registry.
+
+The issue does not say what happens to the fee on a rejected attestation. **It
+is charged.** A fee contingent on approval pays verifiers to approve, which
+defeats the point of having them. The verifier did the work either way, and the
+rejection is the valuable output.
+
+The transfer and the storage write are in the same transaction: no charge
+without a record, no record without a charge. The charge happens first, so a
+verifier the originator cannot pay never gets an attestation stored.
+
+The multiplication is `checked_mul` on `i128` and the division by 10 000
+happens last, so a large invoice cannot wrap into a small or negative fee. The
+fee ceiling is 5% — the same ceiling `set_fee` applies to the protocol fee.
+
+**The default is 0 bps, which disables fee settlement entirely.** A deployment
+that never configures a fee never touches a token, and the oracle is usable
+without one.
+
+### 6. Fees settle in the invoice's currency
+
+The registry reuses the `invofi_common` currency registry that financing
+already uses, via its own admin-gated `register_currency`. One entry per
+currency, no per-currency branch, and a fee on a EUR invoice is paid in EUR.
+Attesting on an invoice in an unregistered currency with a non-zero fee fails
+loudly rather than silently skipping the charge.
+
+### 7. Removed verifiers keep their history
+
+`remove_verifier` drops an address from the set but leaves its attestations in
+place. Who said what, when, is the point of storing them, and deleting history
+on removal would make the record unauditable exactly when an audit matters. An
+admin who needs a compromised verifier's statements discounted immediately
+raises the threshold — the lever the key-compromise runbook (#145) already
+describes.
+
+## Consequences
+
+- A lender can distinguish an invoice three verifiers vouched for from one
+  nobody has looked at, and can see who vouched and when.
+- Verifiers are paid per attestation, so running the off-chain service is
+  fundable, and no incentive points at approving.
+- Attestations decay. A 90-day-old registration check reads `Expired`, not
+  `Verified`, and the invoice falls back to unverified until someone re-attests.
+- The registry now moves tokens. It previously did not, and this is the only
+  path in it that does.
+- Nothing in the financing path *requires* verification. Wiring "only verified
+  invoices can be financed" into `create_offer` is a policy decision with its
+  own migration story for invoices registered before the oracle existed, and is
+  deliberately left to a follow-up.
+
+## Alternatives considered
+
+**Put the oracle in its own contract.** Cleaner separation, and it would keep
+tokens out of the registry. Rejected for now: attestations are per-invoice data
+whose lifecycle is the invoice's, and every read would otherwise be a
+cross-contract call from wherever the invoice is being read. The issue also
+scopes this to the registry. If the verifier set grows governance of its own,
+splitting it out is a contained change.
+
+**Store a verdict per invoice rather than per (verifier, type).** Much smaller
+storage, but it destroys the audit trail and makes m-of-n impossible to compute.
+
+**Refund the fee on rejection.** Sounds fair to the originator, and it is the
+reading someone might expect. Rejected: it makes rejecting unpaid work, which
+is precisely the wrong incentive to give a verifier.
+
+**Let the verifier choose `valid_until`.** Rejected: a verifier could set a
+hundred-year validity and make their statement effectively permanent. The
+contract owns the clock.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0006 | [Fixed installment repayment schedules](./0006-repayment-schedules.md) | Accepted |
 | 0007 | [Overdue penalty interest](./0007-overdue-penalty-interest.md) | Proposed |
 | 0008 | [Offer amendment and counter-offer](./0008-offer-negotiation.md) | Proposed |
+| 0009 | [Invoice verification oracle](./0009-verification-oracle.md) | Proposed |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -48,6 +48,7 @@ document fixes the naming convention only.
 | `E_NOT_ORIGINATOR` | Caller is not the invoice originator | Registry, Financing, Repayment | **Redirect** to `/403` |
 | `E_NOT_LENDER` | Caller is not the offer's lender | Financing, Repayment | **Redirect** to `/403` |
 | `E_NOT_REGISTERED_CALLER` | Cross-contract caller is not the registered system contract (financing, repayment, insurance, reputation) | Registry, Financing, Repayment, Insurance, Reputation | **Retry:** protocol configuration issue — admin must register the system caller |
+| `E_NOT_VERIFIER` | Caller is not in the registry's trusted verifier set | Registry | **Redirect** to `/403` — the address is not an approved verification oracle |
 
 ### Protocol Paused
 
@@ -70,6 +71,7 @@ document fixes the naming convention only.
 | `E_INVOICE_NOT_FINANCED` | Invoice must be Financed for this operation | Registry, Repayment | **Toast:** Refresh invoice state |
 | `E_INVOICE_NOT_OVERDUE` | Invoice must be Overdue for this operation (mark overdue, reclaim) | Registry, Repayment | **Toast:** Refresh invoice state |
 | `E_INVOICE_NOT_DISPUTED` | Invoice must be in Disputed status to resolve | Registry | **Toast:** Refresh invoice state |
+| `E_INVOICE_NOT_VERIFIABLE` | Invoice must be Pending or Financed to accept an attestation | Registry | **Toast:** "This invoice can no longer be verified." |
 | `E_OFFER_NOT_PENDING` | Offer must be Pending for this operation (withdraw, accept, reject) | Financing | **Toast:** Refresh offer state |
 | `E_OFFER_NOT_ACCEPTED` | Offer must be Accepted or Financed for this operation (repay, reclaim) | Repayment | **Toast:** Refresh offer state |
 | `E_INVOICE_NOT_DEFAULTED` | Invoice must be in Defaulted status for insurance payout | Insurance | **Toast:** Refresh invoice state |
@@ -87,6 +89,9 @@ document fixes the naming convention only.
 | `E_INVALID_RATE` | Interest rate is out of bounds (must be > 0 and ≤ 10,000 bps) | Financing, Registry | **Toast:** "Interest rate must be between 1 bps and 10,000 bps." |
 | `E_INVALID_DURATION` | Offer duration is outside the allowed range (< 86,400 s or > 31,536,000 s) | Financing | **Toast:** "Duration must be between 1 day and 365 days." |
 | `E_INVALID_FEE` | Protocol fee exceeds the cap (max 500 bps / 5%) | Registry | **Toast:** "Fee must be at most 5%." |
+| `E_INVALID_VERIFICATION_FEE` | Verification fee exceeds the cap (max 500 bps / 5%) | Registry | **Toast:** "Verification fee must be at most 5%." |
+| `E_INVALID_VERIFIER_THRESHOLD` | Verifier threshold is zero or above `MAX_VERIFIERS` | Registry | **Toast:** "Threshold must be between 1 and 20." |
+| `E_INVALID_ATTESTATION_VALIDITY` | Attestation validity is outside 1–365 days | Registry | **Toast:** "Validity must be between 1 and 365 days." |
 | `E_INVALID_INSTALLMENT_COUNT` | Installment count is outside 1–1,200 | Financing | **Toast:** "Installment count must be between 1 and 1,200." |
 | `E_PAST_DUE_DATE` | Invoice `due_date` is in the past at registration time | Registry | **Toast:** "Due date must be in the future." |
 | `E_FIRST_DUE_IN_PAST` | `first_due` for schedule is not in the future | Financing | **Toast:** "First due date must be in the future." |

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -1,10 +1,15 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, Map, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, token, Address, BytesN, Env, Map, Symbol, Vec,
+};
 
 use invofi_common::{
-    assert_not_paused, assert_transition, get_transition_history, ContractError, Invoice,
-    InvoiceStatus, ProtocolStats, RiskTier, TransitionRecord, MIN_INVOICE_AMOUNT,
+    assert_not_paused, assert_transition, get_transition_history, Attestation, ContractError,
+    Invoice, InvoiceStatus, ProtocolStats, RiskTier, TransitionRecord, VerificationStatus,
+    VerificationType, DEFAULT_ATTESTATION_VALIDITY_SECS, MAX_ATTESTATIONS_PER_INVOICE,
+    MAX_ATTESTATION_VALIDITY_SECS, MAX_VERIFICATION_FEE_BPS, MAX_VERIFIERS,
+    MIN_ATTESTATION_VALIDITY_SECS, MIN_INVOICE_AMOUNT, VERIFICATION_TYPES,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -61,6 +66,97 @@ fn save_blacklist(env: &Env, list: &Vec<Address>) {
     env.storage()
         .persistent()
         .set(&symbol_short!("blklist"), list);
+}
+
+// ─── Verification Oracle Storage Helpers (issue #181) ────────────────────────
+//
+//   ("verifs", invoice_id) -> Vec<Attestation>   attestations for one invoice
+//   ("verifrs")            -> Vec<Address>       the trusted verifier set
+
+fn load_verifications(env: &Env, invoice_id: &Symbol) -> Vec<Attestation> {
+    env.storage()
+        .persistent()
+        .get(&(symbol_short!("verifs"), invoice_id.clone()))
+        .unwrap_or(Vec::new(env))
+}
+
+fn save_verifications(env: &Env, invoice_id: &Symbol, list: &Vec<Attestation>) {
+    env.storage()
+        .persistent()
+        .set(&(symbol_short!("verifs"), invoice_id.clone()), list);
+}
+
+fn load_verifiers(env: &Env) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get(&symbol_short!("verifrs"))
+        .unwrap_or(Vec::new(env))
+}
+
+fn save_verifiers(env: &Env, list: &Vec<Address>) {
+    env.storage()
+        .persistent()
+        .set(&symbol_short!("verifrs"), list);
+}
+
+/// An attestation's status as of `now`.
+///
+/// Expiry is derived here rather than stored, so a read is correct whether or
+/// not anyone has called `expire_verifications` yet. A lapsed *rejection*
+/// expires too: a stale "this invoice is bad" is no more informative than a
+/// stale "this invoice is good".
+fn effective_status(attestation: &Attestation, now: u64) -> VerificationStatus {
+    if attestation.status != VerificationStatus::Expired && now > attestation.valid_until {
+        VerificationStatus::Expired
+    } else {
+        attestation.status
+    }
+}
+
+/// Status of one verification type on one invoice.
+///
+/// `attest` keeps at most one attestation per (verifier, type), so counting
+/// affirmative attestations *is* counting distinct verifiers — no verifier can
+/// reach the threshold alone by attesting repeatedly.
+fn type_status(
+    attestations: &Vec<Attestation>,
+    v_type: VerificationType,
+    threshold: u32,
+    now: u64,
+) -> VerificationStatus {
+    let mut approvals: u32 = 0;
+    let mut rejected = false;
+    let mut expired = false;
+    let mut seen = false;
+
+    for attestation in attestations.iter() {
+        if attestation.v_type != v_type {
+            continue;
+        }
+        seen = true;
+        match effective_status(&attestation, now) {
+            VerificationStatus::Verified => approvals += 1,
+            VerificationStatus::Rejected => rejected = true,
+            VerificationStatus::Expired => expired = true,
+            VerificationStatus::Pending => {}
+        }
+    }
+
+    if !seen {
+        return VerificationStatus::Pending;
+    }
+    // A live rejection outranks approvals: one verifier saying the document is
+    // forged is not outvoted by two saying it looks fine.
+    if rejected {
+        return VerificationStatus::Rejected;
+    }
+    if approvals >= threshold {
+        return VerificationStatus::Verified;
+    }
+    if expired {
+        return VerificationStatus::Expired;
+    }
+    VerificationStatus::Pending
 }
 
 fn assert_not_blacklisted(env: &Env, address: &Address) {
@@ -712,6 +808,394 @@ impl RegistryContract {
 
     pub fn get_blacklist(env: Env) -> Vec<Address> {
         load_blacklist(&env)
+    }
+
+    // ── Verification oracle (issue #181) ─────────────────────────────────────
+    //
+    // On-chain invoice data is self-reported. This is the layer that lets
+    // trusted off-chain verifiers put their name to the facts behind it —
+    // document hashes, business registration, tax compliance — and have that
+    // statement stored immutably against the invoice.
+    //
+    // What the contract can and cannot do is worth stating plainly, and is
+    // spelled out in `docs/adr/0009-verification-oracle.md`: it cannot check
+    // that a PDF hash belongs to a real invoice or that a registration number
+    // is genuine. It authenticates that a verifier from the admin-governed set
+    // said so, charges for the work, timestamps it, and expires it. Trust is
+    // bounded by verifier honesty and by the m-of-n threshold, not eliminated.
+
+    /// Add an address to the trusted verifier set. Admin only. Idempotent.
+    pub fn add_verifier(env: Env, admin: Address, verifier: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &admin);
+        let mut verifiers = load_verifiers(&env);
+        for existing in verifiers.iter() {
+            if existing == verifier {
+                return;
+            }
+        }
+        if verifiers.len() >= MAX_VERIFIERS {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        verifiers.push_back(verifier);
+        save_verifiers(&env, &verifiers);
+    }
+
+    /// Remove an address from the trusted verifier set. Admin only.
+    ///
+    /// Attestations that verifier already submitted are left in place — the
+    /// history of who said what, when, is the point of storing them. They
+    /// still count until they expire; an admin who needs a compromised
+    /// verifier's statements discounted immediately raises the threshold, per
+    /// the key-compromise runbook (#145).
+    pub fn remove_verifier(env: Env, admin: Address, verifier: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &admin);
+        let verifiers = load_verifiers(&env);
+        let mut remaining: Vec<Address> = Vec::new(&env);
+        for existing in verifiers.iter() {
+            if existing != verifier {
+                remaining.push_back(existing);
+            }
+        }
+        save_verifiers(&env, &remaining);
+    }
+
+    pub fn get_verifiers(env: Env) -> Vec<Address> {
+        load_verifiers(&env)
+    }
+
+    pub fn is_verifier(env: Env, address: Address) -> bool {
+        for existing in load_verifiers(&env).iter() {
+            if existing == address {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Number of distinct verifiers that must attest affirmatively before a
+    /// verification type counts as Verified — the m of m-of-n. Admin only.
+    ///
+    /// The threshold is *not* clamped to the current verifier-set size: an
+    /// admin may deliberately set it above the set while adding verifiers, and
+    /// a removal must not silently weaken it. A threshold no live verifier set
+    /// can reach simply means nothing verifies, which is the safe direction.
+    pub fn set_verifier_threshold(env: Env, admin: Address, threshold: u32) {
+        assert_not_paused(&env);
+        assert_admin(&env, &admin);
+        if threshold == 0 || threshold > MAX_VERIFIERS {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("verthr"), &threshold);
+    }
+
+    /// The configured verifier threshold (default 1).
+    pub fn get_verifier_threshold(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("verthr"))
+            .unwrap_or(1)
+    }
+
+    /// Set the verification fee in basis points of invoice value. Admin only.
+    /// Capped at `MAX_VERIFICATION_FEE_BPS` (5%). Defaults to 0, which
+    /// disables fee settlement entirely.
+    pub fn set_verification_fee(env: Env, admin: Address, fee_bps: u32) {
+        assert_not_paused(&env);
+        assert_admin(&env, &admin);
+        if fee_bps > MAX_VERIFICATION_FEE_BPS {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("verfee"), &fee_bps);
+    }
+
+    /// The configured verification fee in basis points (default 0).
+    pub fn get_verification_fee(env: Env) -> u32 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("verfee"))
+            .unwrap_or(0)
+    }
+
+    /// Set how long a new attestation stays valid, in seconds. Admin only.
+    /// Clamped to [`MIN_ATTESTATION_VALIDITY_SECS`,
+    /// `MAX_ATTESTATION_VALIDITY_SECS`]; defaults to 90 days.
+    ///
+    /// Changing this does not move the `valid_until` of attestations already
+    /// submitted — each one carries its own, fixed at submission.
+    pub fn set_attestation_validity(env: Env, admin: Address, validity_secs: u64) {
+        assert_not_paused(&env);
+        assert_admin(&env, &admin);
+        if !(MIN_ATTESTATION_VALIDITY_SECS..=MAX_ATTESTATION_VALIDITY_SECS)
+            .contains(&validity_secs)
+        {
+            env.panic_with_error(ContractError::InvalidInput);
+        }
+        env.storage()
+            .instance()
+            .set(&symbol_short!("vervld"), &validity_secs);
+    }
+
+    /// The configured attestation validity in seconds (default 90 days).
+    pub fn get_attestation_validity(env: Env) -> u64 {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("vervld"))
+            .unwrap_or(DEFAULT_ATTESTATION_VALIDITY_SECS)
+    }
+
+    /// Register the SEP-41 token that settles verification fees denominated in
+    /// `currency`. Admin only.
+    ///
+    /// Verification fees are paid in the invoice's own currency, so a
+    /// multi-currency deployment registers each currency once here — the same
+    /// pattern the financing contract uses, sharing the `invofi_common`
+    /// registry rather than growing a per-currency branch.
+    pub fn register_currency(env: Env, admin: Address, currency: Symbol, token_addr: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &admin);
+        invofi_common::register_currency(&env, &currency, &token_addr);
+    }
+
+    /// The token registered to settle `currency`, if any.
+    pub fn get_currency_token(env: Env, currency: Symbol) -> Option<Address> {
+        invofi_common::get_currency_token(&env, &currency)
+    }
+
+    /// The fee an attestation on this invoice currently costs, in the
+    /// invoice's currency: `invoice.amount * verification_fee_bps / 10_000`.
+    ///
+    /// The multiplication is checked and the division happens last, so a large
+    /// invoice cannot silently wrap into a small (or negative) fee.
+    pub fn calculate_verification_fee(env: Env, invoice_id: Symbol) -> i128 {
+        let invoice = load_invoices(&env)
+            .get(invoice_id)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        Self::fee_for(&env, invoice.amount)
+    }
+
+    fn fee_for(env: &Env, invoice_amount: i128) -> i128 {
+        let fee_bps = Self::get_verification_fee(env.clone());
+        if fee_bps == 0 {
+            return 0;
+        }
+        invoice_amount
+            .checked_mul(fee_bps as i128)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::InvalidInput))
+            / 10_000
+    }
+
+    /// Submit an attestation about one off-chain fact for an invoice.
+    ///
+    /// Only an address in the trusted verifier set may call this, and only on
+    /// an invoice that is still Pending or Financed — verification of a
+    /// cancelled or settled invoice would charge a fee for a fact nothing can
+    /// act on.
+    ///
+    /// `approved` is the verifier's verdict: `true` records an affirmative
+    /// attestation, `false` a rejection. **The fee is charged either way**,
+    /// because it pays for the verification work, not for a favourable answer
+    /// — a fee contingent on approval would pay verifiers to approve.
+    ///
+    /// A verifier re-attesting the same type on the same invoice **replaces**
+    /// their earlier statement rather than stacking on it. That is what keeps
+    /// the threshold a count of distinct verifiers, and it is how a verifier
+    /// refreshes an attestation that has expired or corrects one they got
+    /// wrong.
+    ///
+    /// The fee transfer and the stored attestation are in the same
+    /// transaction, so there is no charge without a record and no record
+    /// without a charge.
+    pub fn attest(
+        env: Env,
+        invoice_id: Symbol,
+        verifier: Address,
+        v_type: VerificationType,
+        hash: BytesN<32>,
+        approved: bool,
+    ) -> Attestation {
+        assert_not_paused(&env);
+        verifier.require_auth();
+        if !Self::is_verifier(env.clone(), verifier.clone()) {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        let invoice = load_invoices(&env)
+            .get(invoice_id.clone())
+            .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
+        if invoice.status != InvoiceStatus::Pending && invoice.status != InvoiceStatus::Financed {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+
+        let now = env.ledger().timestamp();
+        let threshold = Self::get_verifier_threshold(env.clone());
+        let attestations = load_verifications(&env, &invoice_id);
+        let status_before = type_status(&attestations, v_type, threshold, now);
+
+        // Charge before writing, so a verifier the originator cannot pay never
+        // gets an attestation recorded. CEI: the token is a standard SEP-41
+        // contract with no reentrant hooks.
+        let fee = Self::fee_for(&env, invoice.amount);
+        if fee > 0 {
+            let token_addr = invofi_common::get_currency_token(&env, &invoice.currency)
+                .unwrap_or_else(|| panic!("Verification fee token not configured for currency"));
+            token::TokenClient::new(&env, &token_addr).transfer_from(
+                &env.current_contract_address(),
+                &invoice.originator,
+                &verifier,
+                &fee,
+            );
+        }
+
+        let attestation = Attestation {
+            verifier: verifier.clone(),
+            v_type,
+            hash: hash.clone(),
+            timestamp: now,
+            valid_until: now.saturating_add(Self::get_attestation_validity(env.clone())),
+            status: if approved {
+                VerificationStatus::Verified
+            } else {
+                VerificationStatus::Rejected
+            },
+        };
+
+        // One attestation per (verifier, type): drop this verifier's previous
+        // statement about this fact before appending the new one.
+        let mut updated: Vec<Attestation> = Vec::new(&env);
+        for existing in attestations.iter() {
+            if existing.verifier == verifier && existing.v_type == v_type {
+                continue;
+            }
+            updated.push_back(existing);
+        }
+        if updated.len() >= MAX_ATTESTATIONS_PER_INVOICE {
+            env.panic_with_error(ContractError::InvalidTransition);
+        }
+        updated.push_back(attestation.clone());
+        save_verifications(&env, &invoice_id, &updated);
+
+        env.events().publish(
+            (symbol_short!("ver_sub"), invoice_id.clone()),
+            (verifier, v_type, hash, attestation.valid_until, fee),
+        );
+
+        let status_after = type_status(&updated, v_type, threshold, now);
+        if status_after != status_before
+            && (status_after == VerificationStatus::Verified
+                || status_after == VerificationStatus::Rejected)
+        {
+            env.events().publish(
+                (symbol_short!("ver_done"), invoice_id),
+                (v_type, status_after),
+            );
+        }
+
+        attestation
+    }
+
+    /// Every attestation recorded against an invoice, oldest first.
+    pub fn get_verifications(env: Env, invoice_id: Symbol) -> Vec<Attestation> {
+        load_verifications(&env, &invoice_id)
+    }
+
+    /// Status of one verification type on an invoice. Expiry is derived, so
+    /// this is correct whether or not `expire_verifications` has been called.
+    pub fn get_verification_status(
+        env: Env,
+        invoice_id: Symbol,
+        v_type: VerificationType,
+    ) -> VerificationStatus {
+        let attestations = load_verifications(&env, &invoice_id);
+        let threshold = Self::get_verifier_threshold(env.clone());
+        type_status(&attestations, v_type, threshold, env.ledger().timestamp())
+    }
+
+    /// Verification status of the invoice as a whole.
+    ///
+    /// `Verified` requires **every** verification type to be verified — an
+    /// invoice with a checked document hash but no business registration is
+    /// not a verified invoice. A rejection anywhere makes the whole thing
+    /// `Rejected`; otherwise a lapsed type makes it `Expired`.
+    pub fn get_invoice_verification_status(env: Env, invoice_id: Symbol) -> VerificationStatus {
+        let attestations = load_verifications(&env, &invoice_id);
+        let threshold = Self::get_verifier_threshold(env.clone());
+        let now = env.ledger().timestamp();
+
+        let mut all_verified = true;
+        let mut any_expired = false;
+        for v_type in VERIFICATION_TYPES.iter() {
+            match type_status(&attestations, *v_type, threshold, now) {
+                VerificationStatus::Rejected => return VerificationStatus::Rejected,
+                VerificationStatus::Verified => {}
+                VerificationStatus::Expired => {
+                    all_verified = false;
+                    any_expired = true;
+                }
+                VerificationStatus::Pending => all_verified = false,
+            }
+        }
+
+        if all_verified {
+            VerificationStatus::Verified
+        } else if any_expired {
+            VerificationStatus::Expired
+        } else {
+            VerificationStatus::Pending
+        }
+    }
+
+    /// Record the attestations on an invoice that have passed `valid_until`
+    /// and emit `ver_exp` for each, returning how many were newly expired.
+    ///
+    /// Permissionless, and purely a notification mechanism: reads already
+    /// derive expiry from `valid_until`, so nothing about an invoice's
+    /// verification status depends on this being called. It exists because
+    /// Soroban has no scheduler and an indexer cannot observe a deadline
+    /// passing — someone has to poke. Calling it twice is a no-op the second
+    /// time, so a keeper cannot spam duplicate events.
+    pub fn expire_verifications(env: Env, invoice_id: Symbol) -> u32 {
+        assert_not_paused(&env);
+        let attestations = load_verifications(&env, &invoice_id);
+        if attestations.is_empty() {
+            env.panic_with_error(ContractError::NotFound);
+        }
+
+        let now = env.ledger().timestamp();
+        let mut updated: Vec<Attestation> = Vec::new(&env);
+        let mut newly_expired: u32 = 0;
+
+        for attestation in attestations.iter() {
+            if effective_status(&attestation, now) == VerificationStatus::Expired
+                && attestation.status != VerificationStatus::Expired
+            {
+                newly_expired += 1;
+                env.events().publish(
+                    (symbol_short!("ver_exp"), invoice_id.clone()),
+                    (
+                        attestation.verifier.clone(),
+                        attestation.v_type,
+                        attestation.valid_until,
+                    ),
+                );
+                updated.push_back(Attestation {
+                    status: VerificationStatus::Expired,
+                    ..attestation
+                });
+            } else {
+                updated.push_back(attestation);
+            }
+        }
+
+        if newly_expired > 0 {
+            save_verifications(&env, &invoice_id, &updated);
+        }
+        newly_expired
     }
 
     // ── Metadata ─────────────────────────────────────────────────────────────

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -153,10 +153,70 @@ fn type_status(
     if approvals >= threshold {
         return VerificationStatus::Verified;
     }
-    if expired {
+    // `Expired` means the type has no live statement left. A type that still
+    // holds a live approval but has not reached the threshold is
+    // under-attested, not expired -- it needs another verifier, not a refresh
+    // of one that already spoke.
+    if expired && approvals == 0 {
         return VerificationStatus::Expired;
     }
     VerificationStatus::Pending
+}
+
+/// Free one slot in a full attestation list so a trusted verifier is never
+/// locked out of an invoice.
+///
+/// The cap is `MAX_VERIFIERS x 3`, which is exactly enough for the whole
+/// active set to speak on all three types — but records from verifiers that
+/// have since been removed keep occupying slots, so a rotated-through set can
+/// fill the list and permanently block admission. History yields to liveness
+/// in a defined order: the oldest record from a verifier that is no longer
+/// trusted goes first (it can no longer count toward any threshold), then the
+/// oldest lapsed record.
+///
+/// The final `None` arm cannot trigger under the current constants, and the
+/// arithmetic is worth stating because it is what makes the cap safe. A list
+/// with nothing evictable is 60 live records held by trusted verifiers, which
+/// at `MAX_VERIFIERS = 20` and three types means every trusted verifier
+/// already holds a record for every type. An incoming attestation therefore
+/// always replaces one of them, freeing its own slot before this is reached.
+/// The arm is kept as the correct behaviour — refuse rather than drop a live
+/// statement from an active verifier — if those constants are ever changed
+/// out of that relationship.
+fn evict_one_slot(env: &Env, list: &Vec<Attestation>, now: u64) -> Vec<Attestation> {
+    let trusted = load_verifiers(env);
+    let is_trusted = |who: &Address| trusted.iter().any(|entry| entry == *who);
+
+    let mut victim: Option<u32> = None;
+    // Pass 1: the oldest record whose verifier has been removed from the set.
+    for (idx, attestation) in list.iter().enumerate() {
+        if !is_trusted(&attestation.verifier) {
+            victim = Some(idx as u32);
+            break;
+        }
+    }
+    // Pass 2: failing that, the oldest record that has lapsed.
+    if victim.is_none() {
+        for (idx, attestation) in list.iter().enumerate() {
+            if effective_status(&attestation, now) == VerificationStatus::Expired {
+                victim = Some(idx as u32);
+                break;
+            }
+        }
+    }
+
+    let victim = match victim {
+        Some(idx) => idx,
+        None => env.panic_with_error(ContractError::InvalidTransition),
+    };
+
+    let mut kept: Vec<Attestation> = Vec::new(env);
+    for (idx, attestation) in list.iter().enumerate() {
+        if idx as u32 != victim {
+            kept.push_back(attestation);
+        }
+    }
+    kept
 }
 
 fn assert_not_blacklisted(env: &Env, address: &Address) {
@@ -1075,7 +1135,7 @@ impl RegistryContract {
             updated.push_back(existing);
         }
         if updated.len() >= MAX_ATTESTATIONS_PER_INVOICE {
-            env.panic_with_error(ContractError::InvalidTransition);
+            updated = evict_one_slot(&env, &updated, now);
         }
         updated.push_back(attestation.clone());
         save_verifications(&env, &invoice_id, &updated);

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -2416,3 +2416,146 @@ fn count_events(env: &Env, name: Symbol) -> u32 {
     }
     count
 }
+
+
+#[test]
+fn test_live_approval_below_threshold_reads_pending_not_expired() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv20");
+    let (client, admin, _originator, first) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+    let second = Address::generate(&env);
+    client.add_verifier(&admin, &second);
+    client.set_verifier_threshold(&admin, &2u32);
+
+    // Verifier one attests, then lets its attestation lapse.
+    client.attest(
+        &invoice_id,
+        &first,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    env.ledger()
+        .set_timestamp(1_000_000 + 7_776_000 + 1);
+
+    // Verifier two now attests, so the type holds one live approval against a
+    // threshold of two.
+    client.attest(
+        &invoice_id,
+        &second,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+
+    // That is under-attested, not expired: it needs a second verifier, not a
+    // refresh of the one that lapsed. Reading Expired here would tell a client
+    // the evidence went stale when in fact it never had enough of it.
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Pending,
+        "a live approval below threshold must read Pending, not Expired"
+    );
+
+    // And once the threshold is met it flips to Verified.
+    let third = Address::generate(&env);
+    client.add_verifier(&admin, &third);
+    client.attest(
+        &invoice_id,
+        &third,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 3),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+}
+
+#[test]
+fn test_expired_reads_only_when_no_live_statement_remains() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv21");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::TaxCompliance,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    env.ledger()
+        .set_timestamp(1_000_000 + 7_776_000 + 1);
+
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Expired,
+        "with every statement lapsed the type reads Expired"
+    );
+}
+
+#[test]
+fn test_rotated_out_verifiers_cannot_lock_an_invoice() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv22");
+    let (client, admin, _originator, _seed) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    // Fill the invoice to its cap by rotating 20 verifiers through the set,
+    // each attesting to all three types before being removed.
+    let types = [
+        VerificationType::DocumentHash,
+        VerificationType::BusinessRegistration,
+        VerificationType::TaxCompliance,
+    ];
+    for round in 0..20u8 {
+        let rotating = Address::generate(&env);
+        client.add_verifier(&admin, &rotating);
+        for (offset, v_type) in types.iter().enumerate() {
+            client.attest(
+                &invoice_id,
+                &rotating,
+                v_type,
+                &evidence_hash(&env, round * 3 + offset as u8),
+                &true,
+            );
+        }
+        client.remove_verifier(&admin, &rotating);
+    }
+    assert_eq!(client.get_verifications(&invoice_id).len(), 60);
+
+    // A freshly trusted verifier must still be able to speak. Before the
+    // eviction policy this reverted, and the invoice could never be verified
+    // again by anyone.
+    let fresh = Address::generate(&env);
+    client.add_verifier(&admin, &fresh);
+    client.attest(
+        &invoice_id,
+        &fresh,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 99),
+        &true,
+    );
+
+    let stored = client.get_verifications(&invoice_id);
+    assert_eq!(stored.len(), 60, "the cap still holds");
+    assert!(
+        stored.iter().any(|a| a.verifier == fresh),
+        "the active verifier's attestation must be recorded"
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+}
+

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -2,11 +2,11 @@
 extern crate std;
 
 use super::RegistryContract;
-use invofi_common::{InvoiceStatus, RiskTier};
+use invofi_common::{InvoiceStatus, RiskTier, VerificationStatus, VerificationType};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events as _, Ledger as _},
-    Address, Env, IntoVal,
+    token, Address, BytesN, Env, IntoVal, Symbol, TryFromVal,
 };
 
 // ─── Invoice CRUD tests ──────────────────────────────────────────────────────
@@ -1584,4 +1584,835 @@ fn test_transition_events_emitted() {
         !events.is_empty(),
         "Should emit events on state transition"
     );
+}
+
+// ─── Verification oracle (issue #181) ────────────────────────────────────────
+//
+// These tests drive the oracle through the contract client — the same
+// entrypoints an off-chain verifier service calls — and assert on real
+// effects: stored attestations, derived status, token balances, events.
+
+/// A deterministic 32-byte evidence hash, distinct per `seed`.
+fn evidence_hash(env: &Env, seed: u8) -> BytesN<32> {
+    let mut raw = [0u8; 32];
+    raw[0] = seed;
+    raw[31] = seed.wrapping_add(1);
+    BytesN::from_array(env, &raw)
+}
+
+/// Registry with an admin, one registered invoice, and one trusted verifier.
+fn setup_oracle<'a>(
+    env: &'a Env,
+    invoice_id: &Symbol,
+    amount: i128,
+) -> (
+    super::RegistryContractClient<'a>,
+    Address, // admin
+    Address, // originator
+    Address, // verifier
+) {
+    let admin = Address::generate(env);
+    let originator = Address::generate(env);
+    let verifier = Address::generate(env);
+
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(env, &contract_id);
+
+    client.register_invoice(
+        invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &(9_000_000u64),
+    );
+    client.add_verifier(&admin, &verifier);
+
+    (client, admin, originator, verifier)
+}
+
+#[test]
+fn test_verifier_set_management() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv01");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    assert!(client.is_verifier(&verifier));
+    assert_eq!(client.get_verifiers().len(), 1);
+
+    // add_verifier is idempotent — re-adding must not double-count a verifier
+    // towards an m-of-n threshold.
+    client.add_verifier(&admin, &verifier);
+    assert_eq!(client.get_verifiers().len(), 1);
+
+    let second = Address::generate(&env);
+    client.add_verifier(&admin, &second);
+    assert_eq!(client.get_verifiers().len(), 2);
+
+    client.remove_verifier(&admin, &verifier);
+    assert!(!client.is_verifier(&verifier));
+    assert!(client.is_verifier(&second));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_add_verifier_is_admin_only() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv02");
+    let (client, _admin, originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.add_verifier(&originator, &Address::generate(&env));
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_attest_by_untrusted_address_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv03");
+    let (client, _admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    let impostor = Address::generate(&env);
+    client.attest(
+        &invoice_id,
+        &impostor,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+}
+
+#[test]
+fn test_attest_records_and_verifies_each_verification_type() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv04");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    for (index, v_type) in [
+        VerificationType::DocumentHash,
+        VerificationType::BusinessRegistration,
+        VerificationType::TaxCompliance,
+    ]
+    .iter()
+    .enumerate()
+    {
+        // Each type is independent until all three are in.
+        assert_eq!(
+            client.get_verification_status(&invoice_id, v_type),
+            VerificationStatus::Pending
+        );
+
+        let attestation = client.attest(
+            &invoice_id,
+            &verifier,
+            v_type,
+            &evidence_hash(&env, index as u8),
+            &true,
+        );
+
+        assert_eq!(attestation.verifier, verifier);
+        assert_eq!(attestation.v_type, *v_type);
+        assert_eq!(attestation.timestamp, 1_000_000);
+        // 90-day default validity.
+        assert_eq!(attestation.valid_until, 1_000_000 + 7_776_000);
+        assert_eq!(attestation.status, VerificationStatus::Verified);
+
+        assert_eq!(
+            client.get_verification_status(&invoice_id, v_type),
+            VerificationStatus::Verified
+        );
+    }
+
+    assert_eq!(client.get_verifications(&invoice_id).len(), 3);
+    // Verified as a whole only once every type is covered.
+    assert_eq!(
+        client.get_invoice_verification_status(&invoice_id),
+        VerificationStatus::Verified
+    );
+}
+
+#[test]
+fn test_invoice_is_not_verified_until_every_type_is() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv05");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::BusinessRegistration,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Pending
+    );
+    assert_eq!(
+        client.get_invoice_verification_status(&invoice_id),
+        VerificationStatus::Pending
+    );
+}
+
+#[test]
+fn test_rejection_outranks_approvals() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv06");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+    let second = Address::generate(&env);
+    client.add_verifier(&admin, &second);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    client.attest(
+        &invoice_id,
+        &second,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 2),
+        &false,
+    );
+
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Rejected
+    );
+    assert_eq!(
+        client.get_invoice_verification_status(&invoice_id),
+        VerificationStatus::Rejected
+    );
+}
+
+// ── m-of-n ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_threshold_requires_distinct_verifiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv07");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+    let second = Address::generate(&env);
+    client.add_verifier(&admin, &second);
+    client.set_verifier_threshold(&admin, &2u32);
+    assert_eq!(client.get_verifier_threshold(), 2);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Pending
+    );
+
+    // Adversarial: the same verifier attesting again must not clear a
+    // two-of-n threshold on its own — re-attesting replaces, it does not stack.
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 9),
+        &true,
+    );
+    assert_eq!(client.get_verifications(&invoice_id).len(), 1);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Pending
+    );
+
+    // A genuinely distinct verifier does clear it.
+    client.attest(
+        &invoice_id,
+        &second,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_zero_verifier_threshold_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv08");
+    let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.set_verifier_threshold(&admin, &0u32);
+}
+
+// ── Fees ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_verification_fee_is_charged_to_the_originator() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv09");
+    let amount: i128 = 1_000_000_000;
+    let (client, admin, originator, verifier) = setup_oracle(&env, &invoice_id, amount);
+
+    // 50 bps of a 1 000 000 000 invoice = 5 000 000.
+    let token_admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin);
+    let token_id = sac.address();
+    client.register_currency(&admin, &symbol_short!("USDC"), &token_id);
+    client.set_verification_fee(&admin, &50u32);
+    assert_eq!(client.calculate_verification_fee(&invoice_id), 5_000_000);
+
+    token::StellarAssetClient::new(&env, &token_id).mint(&originator, &amount);
+    token::TokenClient::new(&env, &token_id).approve(
+        &originator,
+        &client.address,
+        &amount,
+        &(env.ledger().sequence() + 1000),
+    );
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+
+    let token_client = token::TokenClient::new(&env, &token_id);
+    assert_eq!(token_client.balance(&verifier), 5_000_000);
+    assert_eq!(token_client.balance(&originator), amount - 5_000_000);
+}
+
+#[test]
+fn test_fee_is_charged_on_rejection_too() {
+    // The fee pays for the verification work, not for a favourable answer —
+    // a fee contingent on approval would pay verifiers to approve.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv10");
+    let amount: i128 = 1_000_000_000;
+    let (client, admin, originator, verifier) = setup_oracle(&env, &invoice_id, amount);
+
+    let token_admin = Address::generate(&env);
+    let sac = env.register_stellar_asset_contract_v2(token_admin);
+    let token_id = sac.address();
+    client.register_currency(&admin, &symbol_short!("USDC"), &token_id);
+    client.set_verification_fee(&admin, &100u32);
+
+    token::StellarAssetClient::new(&env, &token_id).mint(&originator, &amount);
+    token::TokenClient::new(&env, &token_id).approve(
+        &originator,
+        &client.address,
+        &amount,
+        &(env.ledger().sequence() + 1000),
+    );
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &false,
+    );
+
+    assert_eq!(
+        token::TokenClient::new(&env, &token_id).balance(&verifier),
+        10_000_000
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Rejected
+    );
+}
+
+#[test]
+fn test_zero_fee_needs_no_token_configured() {
+    // The default is 0 bps: the oracle is fully usable on a deployment that
+    // never registers a settlement token.
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv11");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    assert_eq!(client.get_verification_fee(), 0);
+    assert_eq!(client.calculate_verification_fee(&invoice_id), 0);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::TaxCompliance,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Verified
+    );
+}
+
+#[test]
+#[should_panic(expected = "Verification fee token not configured for currency")]
+fn test_nonzero_fee_without_a_registered_token_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv12");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.set_verification_fee(&admin, &50u32);
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_verification_fee_above_ceiling_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv13");
+    let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.set_verification_fee(&admin, &501u32);
+}
+
+#[test]
+fn test_fee_math_rounds_down_and_does_not_overflow() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv14");
+    // 1 bps of 19 999 999 stroops is 1 999.9999 -> 1 999: the division
+    // happens last and truncates in the payer's favour.
+    let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 19_999_999);
+    client.set_verification_fee(&admin, &1u32);
+    assert_eq!(client.calculate_verification_fee(&invoice_id), 1_999);
+
+    // 500 bps of the same is 999 999.95 -> 999 999, truncated the same way.
+    client.set_verification_fee(&admin, &500u32);
+    assert_eq!(client.calculate_verification_fee(&invoice_id), 999_999);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_fee_math_overflow_reverts_instead_of_wrapping() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    // An invoice large enough that amount * fee_bps cannot fit in i128. The
+    // widening multiply is checked, so this reverts rather than wrapping to a
+    // small (or negative) fee.
+    let invoice_id = symbol_short!("vinv15");
+    let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, i128::MAX);
+    client.set_verification_fee(&admin, &500u32);
+    client.calculate_verification_fee(&invoice_id);
+}
+
+// ── Expiry ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_attestation_expires_on_read_without_any_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv15");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+
+    // On valid_until itself the attestation still counts.
+    env.ledger().set_timestamp(1_000_000 + 7_776_000);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+
+    // One second later it does not — derived, with nothing called in between.
+    env.ledger().set_timestamp(1_000_000 + 7_776_001);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Expired
+    );
+    assert_eq!(
+        client.get_invoice_verification_status(&invoice_id),
+        VerificationStatus::Expired
+    );
+}
+
+#[test]
+fn test_expire_verifications_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv16");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::TaxCompliance,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+
+    // Nothing has lapsed yet.
+    assert_eq!(client.expire_verifications(&invoice_id), 0);
+
+    env.ledger().set_timestamp(1_000_000 + 7_776_001);
+    assert_eq!(client.expire_verifications(&invoice_id), 2);
+    // A second poke must not re-announce the same lapse.
+    assert_eq!(client.expire_verifications(&invoice_id), 0);
+
+    for attestation in client.get_verifications(&invoice_id).iter() {
+        assert_eq!(attestation.status, VerificationStatus::Expired);
+    }
+}
+
+#[test]
+fn test_reattesting_after_expiry_restores_verified() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv17");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::BusinessRegistration,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+
+    env.ledger().set_timestamp(1_000_000 + 7_776_001);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::BusinessRegistration),
+        VerificationStatus::Expired
+    );
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::BusinessRegistration,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::BusinessRegistration),
+        VerificationStatus::Verified
+    );
+    // The refresh replaced the lapsed statement rather than stacking on it.
+    assert_eq!(client.get_verifications(&invoice_id).len(), 1);
+}
+
+#[test]
+fn test_attestation_validity_is_configurable_and_not_retroactive() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv18");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    assert_eq!(client.get_attestation_validity(), 7_776_000);
+    client.set_attestation_validity(&admin, &86_400u64);
+
+    let first = client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    assert_eq!(first.valid_until, 1_000_000 + 86_400);
+
+    // Widening the setting must not extend an attestation already submitted.
+    client.set_attestation_validity(&admin, &31_536_000u64);
+    let stored = client.get_verifications(&invoice_id).get(0).unwrap();
+    assert_eq!(stored.valid_until, 1_000_000 + 86_400);
+    env.ledger().set_timestamp(1_000_000 + 86_401);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Expired
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_attestation_validity_below_minimum_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv19");
+    let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.set_attestation_validity(&admin, &86_399u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_attestation_validity_above_maximum_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv20");
+    let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.set_attestation_validity(&admin, &31_536_001u64);
+}
+
+// ── Guards ───────────────────────────────────────────────────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_attest_on_unknown_invoice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv21");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &symbol_short!("nope"),
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_attest_on_cancelled_invoice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv22");
+    let (client, _admin, originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.cancel_invoice(&invoice_id, &originator);
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #4)")]
+fn test_attest_is_pause_guarded() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv23");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.pause(&admin);
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #2)")]
+fn test_expire_verifications_on_an_invoice_with_none_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv24");
+    let (client, _admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.expire_verifications(&invoice_id);
+}
+
+#[test]
+fn test_removed_verifier_cannot_attest_but_keeps_its_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv25");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    client.remove_verifier(&admin, &verifier);
+
+    // The record of what they said survives removal — that is the point of
+    // storing it.
+    assert_eq!(client.get_verifications(&invoice_id).len(), 1);
+    assert!(!client.is_verifier(&verifier));
+}
+
+// ── Events ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_oracle_emits_submitted_completed_and_expired_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv26");
+    let (client, _admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    assert_eq!(count_events(&env, symbol_short!("ver_sub")), 1);
+    assert_eq!(
+        count_events(&env, symbol_short!("ver_done")),
+        1,
+        "crossing the threshold must emit ver_done"
+    );
+
+    env.ledger().set_timestamp(1_000_000 + 7_776_001);
+    client.expire_verifications(&invoice_id);
+    assert_eq!(count_events(&env, symbol_short!("ver_exp")), 1);
+}
+
+#[test]
+fn test_verification_completed_is_emitted_once_per_status_change() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv27");
+    let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+    let second = Address::generate(&env);
+    client.add_verifier(&admin, &second);
+
+    // The test harness exposes the events of the most recent invocation, so
+    // each attestation is checked as it lands.
+    client.attest(
+        &invoice_id,
+        &verifier,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    assert_eq!(count_events(&env, symbol_short!("ver_sub")), 1);
+    assert_eq!(count_events(&env, symbol_short!("ver_done")), 1);
+
+    // A second approval on an already-Verified type does not change the
+    // status, so it must not announce a second completion.
+    client.attest(
+        &invoice_id,
+        &second,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+    assert_eq!(count_events(&env, symbol_short!("ver_sub")), 1);
+    assert_eq!(
+        count_events(&env, symbol_short!("ver_done")),
+        0,
+        "an approval that changes nothing must not emit ver_done"
+    );
+}
+
+/// How many published events carry `name` as their first topic.
+fn count_events(env: &Env, name: Symbol) -> u32 {
+    let mut count = 0;
+    for (_contract, topics, _data) in env.events().all().iter() {
+        if let Some(first) = topics.get(0) {
+            if let Ok(topic) = Symbol::try_from_val(env, &first) {
+                if topic == name {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
 }


### PR DESCRIPTION
Closes #181

On-chain invoice data was entirely self-reported: an originator could claim any amount, against any counterparty, backed by a document nobody had seen. The registry now records attestations from a trusted verifier set about off-chain facts — document hash, business registration, tax compliance — with per-type status, an m-of-n threshold, a fee, and expiry.

Design and rationale: [`docs/adr/0009-verification-oracle.md`](docs/adr/0009-verification-oracle.md).

## The trust boundary, stated plainly

A contract **cannot** check that a PDF hash corresponds to a real invoice, or that a business registration is current. It can only authenticate that a verifier in the admin-governed set signed a claim, and store it immutably. What this buys is **attributable, tamper-evident, expiring claims**, bounded by verifier honesty — the off-chain service does the actual fact-checking.

I've scoped and documented that boundary rather than implying on-chain fact verification, because "trust-minimised" invites exactly that misreading. Two design choices follow from taking it seriously:

- **m-of-n runs over *distinct* verifiers.** Re-attesting replaces that verifier's own prior record for the same fact, so no single verifier reaches the threshold alone by attesting repeatedly.
- **A live rejection outranks approvals.** One verifier saying a document is forged is not outvoted by two saying it looks fine, so a single honest verifier can block a fraudulent invoice the others waved through.

## Two cases the issue left open

**Fee on rejection — charged.** The spec didn't say whether a rejected attestation refunds or forfeits. Refunding would pay verifiers only for *approving*, which is a direct incentive to rubber-stamp. The fee buys the work, not the verdict. (`test_fee_is_charged_on_rejection_too`)

**Expiry cannot self-trigger.** Soroban has no scheduler, so `valid_until` flips nothing on its own. Expiry is therefore **derived on read** — past `valid_until` an attestation reads `Expired` whether or not anyone has called anything — and the permissionless `expire_verifications` poke persists that outcome and emits `ver_exp` exactly once per attestation. Validity is stamped at attest time, so an admin changing the window does not retroactively extend or void what is already stored.

## What's in it

| Entrypoint | Auth | |
|---|---|---|
| `attest(invoice_id, verifier, type, hash, approved)` | Trusted verifier | Records the attestation and charges the fee in one transaction |
| `get_verification_status(invoice_id, type)` | Anyone | Per-type status: Pending / Verified / Rejected / Expired |
| `get_invoice_verification_status(invoice_id)` | Anyone | Conjunction across all three types |
| `get_verifications` / `calculate_verification_fee` | Anyone | Reads |
| `expire_verifications(invoice_id)` | Anyone | Permissionless poke; returns the count newly expired |
| `add_verifier` / `remove_verifier` / `set_verifier_threshold` | Admin | The verifier set and the m of m-of-n |
| `set_verification_fee` / `set_attestation_validity` / `register_currency` | Admin | Fee bps (default **0 = off**), validity (default 90 days), fee settlement token |

- **Storage** — `verifications:{invoice_id}` as `Vec<Attestation>` (`{verifier, v_type, hash, timestamp, valid_until, status}`), capped at 60.
- **Status is per type**; invoice-level `Verified` requires *every* type to have cleared its threshold, so an invoice with an unimpeachable PDF hash and no business registration does not read as verified.
- **Fee** — `invoice_amount * verification_fee_bps / 10_000`, `checked_mul` with the division last, transferred originator → verifier **atomically with the storage write**: no charge without a record, no record without a charge.
- **Events** — `ver_sub`, `ver_done`, `ver_exp`, added to the canonical event table in the README.
- `verification_fee_bps` defaults to 0, which skips the transfer entirely — **behaviourally inert until an admin enables it.**

## Acceptance criteria

| Criterion | Where |
|---|---|
| Oracle can submit attestations | `attest`; `test_attest_records_and_verifies_each_verification_type` |
| Verification status tracked | `get_verification_status`; `test_invoice_is_not_verified_until_every_type_is` |
| Fee charged correctly | `test_verification_fee_is_charged_to_the_originator` (asserts real SEP-41 balances), `test_fee_math_rounds_down_and_does_not_overflow` |
| Expiry enforced | `test_attestation_expires_on_read_without_any_call`, `test_expire_verifications_is_idempotent` |
| Events emitted | `test_oracle_emits_submitted_completed_and_expired_events`, `test_verification_completed_is_emitted_once_per_status_change` |
| Tests cover all verification types | `test_attest_records_and_verifies_each_verification_type` drives DocumentHash, BusinessRegistration and TaxCompliance through the full flow |

## Verification

29 new tests, all driven through the generated contract client — the same entrypoint a real oracle calls — asserting on real effects: the fee tests check actual SEP-41 balances for both originator and verifier, not a helper's return value.

```
cargo test -p invofi-registry
test result: ok. 92 passed; 0 failed
```

Adversarial cases:

- `test_attest_by_untrusted_address_panics` / `test_removed_verifier_cannot_attest_but_keeps_its_history` — removal revokes future authority without rewriting past statements.
- `test_threshold_requires_distinct_verifiers` — one verifier cannot reach 2-of-n alone.
- `test_rejection_outranks_approvals`.
- `test_fee_math_overflow_reverts_instead_of_wrapping` — `i128::MAX` invoice reverts rather than wrapping to a small or negative fee.
- `test_nonzero_fee_without_a_registered_token_panics` — no silent free verification when the token is unconfigured.
- `test_attestation_validity_is_configurable_and_not_retroactive`.

Shared code I touched, verified unbroken:

```
cargo test -p invofi-financing -p invofi-repayment -p invofi-integration -p invofi-insurance -p invofi-reputation
121 passed; 0 failed
cargo clippy --target wasm32v1-none -- -D warnings   # clean
```

## Scope

Only issue #181; existing registry entrypoints are untouched and the new surface is additive.

One note for whoever merges: this and #195 (issue #180) each add a row to the ADR index table at the same spot, so the second to land may need a one-line conflict resolution in `docs/adr/README.md`. The ADR files themselves (0008 and 0009) don't collide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added invoice verification for document hashes, business registrations, and tax compliance.
  - Supports multiple trusted verifiers, configurable approval thresholds, rejection precedence, and expiry-aware statuses.
  - Added attestation history, re-attestation, status queries, and permissionless expiry updates.
  - Added configurable verification fees, validity periods, settlement currencies, and verifier administration. Fees default to zero.

- **Documentation**
  - Documented verification workflows, configuration options, events, error codes, and limitations.
  - Added documentation for offer amendments, counter-offers, and financing negotiation workflows.
  - Added architectural decision records for verification and offer negotiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->