### PR TITLE
fix(financing): record and announce acceptance as a negotiation outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ and are enforced by commitlint in CI.
     not anyone has called anything. `close_negotiation` is the poke that
     persists the outcome and emits the event — permissionless after the
     deadline, restricted to the two parties before it.
-  - New storage `negotiations:{offer_id}` as a `Vec<NegotiationRecord>`, capped
+  - New storage keyed `("negot", offer_id)` as a `Vec<NegotiationRecord>`, capped
     at 20 rounds so the entry stays bounded. New reads `get_negotiation`,
     `get_negotiation_status`, `get_negotiation_deadline`,
     `get_negotiation_window`. New events `off_amd`, `ctr_off`, `neg_clsd`.

--- a/docs/adr/0008-offer-negotiation.md
+++ b/docs/adr/0008-offer-negotiation.md
@@ -40,7 +40,7 @@ lender. It appends the originator's proposal to the negotiation history, which
 the lender can then meet.
 
 Every round from either side appends a `NegotiationRecord` to
-`negotiations:{offer_id}`, so the full path from opening terms to settlement is
+the key `("negot", offer_id)`, so the full path from opening terms to settlement is
 on-chain and ordered.
 
 ### 2. Auto-accept is a match of two pre-existing commitments
@@ -109,9 +109,12 @@ restricted to the lender and the originator, because then it *is* a state
 change: it revokes a live commitment.
 
 `Closed` and `Accepted` are persisted, since both result from an actual call.
-An offer that leaves `Pending` by any other route — withdrawn, rejected,
-accepted outright — ends its negotiation, which reads as `Closed` and emits
-`negotiation_closed` from that call.
+An offer that leaves `Pending` by another route ends its negotiation from that
+call, and the two routes are distinguishable: acceptance — outright through
+`accept_offer` or by term convergence — records `Accepted`, while a withdrawal
+or rejection reads as `Closed`. Both announce the end with `neg_clsd`, so an
+indexer never loses a negotiation's final state and can tell a settled one from
+a walk-away.
 
 ### 6. Amended terms cannot exceed what `create_offer` allows
 
@@ -151,6 +154,9 @@ proposed.
 - `negotiation_expired` is not an event. Expiry is a derived read; the
   `negotiation_closed` event carries `NegotiationStatus::Expired` when the poke
   records one, and nothing depends on that poke ever happening.
+- The literal event topics are `off_amd`, `ctr_off` and `neg_clsd` — this ADR
+  uses the descriptive names, but `symbol_short!` caps a topic at 9 characters.
+  The README event table lists the emitted topics.
 
 ## Alternatives considered
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -76,7 +76,7 @@ document fixes the naming convention only.
 | `E_INVOICE_DUE_DATE_NOT_PASSED` | Invoice due date has not yet elapsed; cannot mark overdue | Registry | **Toast:** "Invoice is not yet overdue." |
 | `E_GRACE_PERIOD_NOT_ELAPSED` | 7-day grace period after overdue has not yet elapsed; cannot reclaim | Repayment | **Toast:** "Grace period has not elapsed. Reclaim available after 7 days past due." |
 | `E_TERMINAL_OFFER` | Cannot schedule repayment on a terminal (Repaid/Defaulted/Rejected) offer | Financing | **Toast:** Refresh offer state |
-| `E_NEGOTIATION_CLOSED` | The offer negotiation is no longer open — the 72-hour window elapsed, a party closed it, or it already settled | Financing | **Toast:** "This negotiation has ended." Disable amend/counter and refresh |
+| `E_NEGOTIATION_CLOSED` | The offer negotiation is no longer open — the negotiation window (default 72 h, admin-configurable) elapsed, a party closed it, or it already settled | Financing | **Toast:** "This negotiation has ended." Disable amend/counter and refresh |
 
 ### Invalid Input / Parameters
 

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -490,7 +490,14 @@ impl FinancingContract {
             env.panic_with_error(ContractError::InvalidTransition);
         }
 
-        Self::settle_acceptance(&env, offer_id, offer, &registry_client, &invoice)
+        Self::settle_acceptance(
+            &env,
+            offer_id,
+            offer,
+            &registry_client,
+            &invoice,
+            &invoice_originator,
+        )
     }
 
     /// Move the money and flip every piece of state that an accepted offer
@@ -508,10 +515,25 @@ impl FinancingContract {
         offer: FinancingOffer,
         registry_client: &RegistryClient,
         invoice: &Invoice,
+        closer: &Address,
     ) -> FinancingOffer {
         let env = env.clone();
         let mut offers = load_offers(&env);
         let mut offer = offer;
+
+        // Settlement ends any negotiation that was still running, whichever
+        // route reached it: term convergence in amend/counter, or the
+        // originator accepting the standing offer outright. Recording it here
+        // rather than in each caller is what keeps the two routes from
+        // diverging on the negotiation's final state.
+        if !load_negotiation(&env, &offer_id).is_empty() && load_outcome(&env, &offer_id).is_none()
+        {
+            save_outcome(&env, &offer_id, NegotiationStatus::Accepted);
+            env.events().publish(
+                (symbol_short!("neg_clsd"), offer_id.clone()),
+                (NegotiationStatus::Accepted, closer.clone()),
+            );
+        }
 
         // Pull the lender's principal and pay it straight to the business.
         let token_id = resolve_token(&env, &offer.currency);
@@ -1010,13 +1032,14 @@ impl FinancingContract {
         assert_not_blacklisted(env, &offer.lender);
         assert_not_blacklisted(env, &invoice.originator);
 
-        save_outcome(env, offer_id, NegotiationStatus::Accepted);
-        env.events().publish(
-            (symbol_short!("neg_clsd"), offer_id.clone()),
-            (NegotiationStatus::Accepted, closer.clone()),
-        );
-
-        Self::settle_acceptance(env, offer_id.clone(), offer, &registry_client, &invoice)
+        Self::settle_acceptance(
+            env,
+            offer_id.clone(),
+            offer,
+            &registry_client,
+            &invoice,
+            closer,
+        )
     }
 
     /// Emit `neg_clsd` when an offer leaves Pending with a negotiation still

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -2575,3 +2575,76 @@ fn test_auto_accept_emits_negotiation_closed() {
         "auto-accept must run the ordinary off_acc settlement path"
     );
 }
+
+#[test]
+fn test_plain_accept_closes_an_open_negotiation_as_accepted() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv33");
+    let offer_id = symbol_short!("noff33");
+    let amount: i128 = 1_000_000_000;
+    let (_reg, fin, _admin, originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    // A negotiation is under way when the originator decides to just take the
+    // lender's standing terms through accept_offer instead of countering at
+    // them. That route settles the offer, so it ends the negotiation too.
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &(amount),
+        &400u32,
+        &(1_296_000u64),
+    );
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Open
+    );
+
+    fin.accept_offer(&offer_id, &originator);
+
+    // Events are read before any getter runs: the harness exposes only the
+    // most recent invocation's events, and a read call is an invocation.
+    assert_eq!(
+        count_events(&env, symbol_short!("neg_clsd")),
+        1,
+        "accept_offer must announce the end of an open negotiation"
+    );
+    assert_eq!(count_events(&env, symbol_short!("off_acc")), 1);
+
+    // Accepted, not Closed: the negotiation ended because the offer was taken,
+    // and an indexer must be able to tell that apart from a walk-away.
+    assert_eq!(
+        fin.get_negotiation_status(&offer_id),
+        NegotiationStatus::Accepted,
+        "accept_offer must record the negotiation as Accepted"
+    );
+}
+
+#[test]
+fn test_plain_accept_without_a_negotiation_emits_no_closure() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("ninv34");
+    let offer_id = symbol_short!("noff34");
+    let amount: i128 = 1_000_000_000;
+    let (_reg, fin, _admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, amount);
+
+    // No negotiation was ever opened, so there is nothing to close and the
+    // ordinary acceptance path must stay exactly as it was.
+    fin.accept_offer(&offer_id, &originator);
+
+    assert_eq!(count_events(&env, symbol_short!("off_acc")), 1);
+    assert_eq!(
+        count_events(&env, symbol_short!("neg_clsd")),
+        0,
+        "an offer with no negotiation must not emit neg_clsd"
+    );
+    assert_eq!(fin.get_negotiation_status(&offer_id), NegotiationStatus::None);
+}


### PR DESCRIPTION
Follow-up to #195 (issue #180). That PR auto-merged while I was pushing this fix, so it carries the last CodeRabbit round rather than leaving it unresolved on a merged PR.

## The bug

An offer taken through plain `accept_offer` while a negotiation was open ended that negotiation **silently**: no `neg_clsd` was emitted, and `get_negotiation_status` derived `Closed` rather than `Accepted`. An indexer following the negotiation lifecycle could not tell a settled negotiation from a walk-away, and the one route that ends a negotiation without announcing it was the most common one.

CodeRabbit flagged the ADR sentence claiming otherwise ([review comment](https://github.com/Stellar-VaultLink/invofi-contracts/pull/195#discussion_r3821128356)) and offered two options: correct the sentence, or emit the event. The sentence described the behaviour the protocol should have, so I fixed the code.

## The fix

The closure now happens inside `settle_acceptance`, which **both** acceptance routes already funnel through — term convergence in `amend_offer` / `counter_offer`, and outright `accept_offer`. Recording it there rather than in each caller means the outcome is written once, in one place, and the two routes cannot disagree about it. It also removes the duplicate `save_outcome` + publish that the auto-accept path was carrying.

`settle_acceptance` gains a `closer` parameter so the event names whoever triggered settlement: the originator for `accept_offer`, the amending or countering party for auto-accept.

Offers with no negotiation are untouched and still emit nothing.

## Verification

```
cargo test -p invofi-financing
test result: ok. 74 passed; 0 failed
cargo clippy --target wasm32v1-none -- -D warnings   # clean
```

Two new tests:

- `test_plain_accept_closes_an_open_negotiation_as_accepted` — amend to open a negotiation, then `accept_offer`; asserts the status is `Accepted` (not `Closed`) and exactly one `neg_clsd` is emitted. Fails on the pre-fix code.
- `test_plain_accept_without_a_negotiation_emits_no_closure` — holds the ordinary acceptance path unchanged when there is nothing to close.

One note on how these are written, since it bit me: the test harness exposes only the **most recent invocation's** events, and a read call is an invocation — so the event assertions run before any getter, not after.

Also folds in the three documentation corrections from the same review round: the negotiation storage key is `("negot", offer_id)` rather than the long form (`symbol_short!` caps a symbol at 9 characters), the ADR now names the literal event topics alongside the descriptive ones, and the error registry no longer states a fixed 72-hour window for a value that is admin-configurable between 1 hour and 30 days.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Accepting an offer during an active negotiation now records the negotiation as accepted and emits a closure event.
  * Direct offer acceptance without an active negotiation remains supported without creating negotiation history.

* **Bug Fixes**
  * Negotiation outcomes now correctly distinguish accepted agreements from withdrawn or rejected negotiations.

* **Documentation**
  * Updated negotiation storage, event topics, and the default 72-hour negotiation window documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->