### PR TITLE
fix(registry): removing a verifier revokes its attestations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,9 @@ and are enforced by commitlint in CI.
   - **The trust boundary is verifier authentication, not fact verification.**
     A contract cannot check that a PDF hash corresponds to a real invoice or
     that a tax filing is current. `attest` authenticates that a verifier in
-    the admin-governed set signed a claim and stores it immutably; the truth
-    of the claim rests on verifier honesty, bounded by the m-of-n threshold.
+    the admin-governed set signed a claim and stores that verifier's current
+    attestation tamper-evidently; the truth of the claim rests on verifier
+    honesty, bounded by the m-of-n threshold.
     The ADR states this explicitly so "trust-minimised" is not read as
     on-chain fact-checking.
   - **m-of-n over distinct verifiers.** `set_verifier_threshold` sets how
@@ -69,6 +70,13 @@ and are enforced by commitlint in CI.
     verifier can reach the threshold alone. A live rejection dominates
     approvals — one honest verifier can block a fraudulent invoice that
     others waved through.
+  - **Removing a verifier revokes their statements.** Only the current
+    verifier set is counted when deriving status, so a removed verifier's
+    approvals stop satisfying a threshold immediately — otherwise removal
+    would not revoke anything, which is the whole point of removing a
+    compromised key. Their records stay readable through
+    `get_verifications`: the history of who said what is preserved, it just
+    no longer votes.
   - **Status is derived per verification type**, with
     `get_invoice_verification_status` returning the conjunction across all
     three. `Verified` requires every type to have cleared its threshold.

--- a/docs/adr/0009-verification-oracle.md
+++ b/docs/adr/0009-verification-oracle.md
@@ -118,14 +118,41 @@ currency, no per-currency branch, and a fee on a EUR invoice is paid in EUR.
 Attesting on an invoice in an unregistered currency with a non-zero fee fails
 loudly rather than silently skipping the charge.
 
-### 7. Removed verifiers keep their history
+### 7. Removal revokes a verifier's vote but keeps their history
 
-`remove_verifier` drops an address from the set but leaves its attestations in
-place. Who said what, when, is the point of storing them, and deleting history
-on removal would make the record unauditable exactly when an audit matters. An
-admin who needs a compromised verifier's statements discounted immediately
-raises the threshold — the lever the key-compromise runbook (#145) already
-describes.
+`remove_verifier` drops an address from the set and leaves its attestations in
+storage, but those records stop counting toward any status the moment the
+verifier leaves. Both halves matter, and they answer different questions.
+
+**Why the records stay:** who said what, when, is the point of storing them,
+and deleting history on removal would make the record unauditable exactly when
+an audit matters. `get_verifications` still returns them.
+
+**Why they stop counting:** removal is how an admin withdraws trust, and the
+reason is normally that the key is compromised or the verifier was found
+negligent. If their prior approvals kept satisfying a threshold, removal would
+revoke nothing — the invoice would still read `Verified` on the word of a
+verifier the protocol has just disowned. `type_status` therefore evaluates
+only the current verifier set.
+
+This is also what makes the eviction policy in decision 8 safe.
+
+### 8. History yields to liveness when an invoice hits its cap
+
+An invoice retains at most `MAX_ATTESTATIONS_PER_INVOICE` (60) attestations —
+`MAX_VERIFIERS x 3`, exactly enough for the whole active set to speak on all
+three types. But records from departed verifiers keep occupying slots, so an
+invoice that rotates through twenty verifiers fills the list and would
+otherwise lock out every future verifier permanently. Expiry does not recover
+capacity: it rewrites a record's status, it does not remove it.
+
+When the list is full, one slot is therefore freed in a defined order: the
+oldest record from a verifier no longer in the set, then the oldest lapsed
+record. Both classes are precisely the records that decision 7 already
+excludes from status, so eviction can never move a verification type off
+`Verified` or `Rejected` as a side effect of an unrelated attestation. Live
+records from active verifiers are never dropped; if nothing is evictable the
+attestation is refused instead.
 
 ## Consequences
 

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -119,6 +119,7 @@ fn effective_status(attestation: &Attestation, now: u64) -> VerificationStatus {
 /// affirmative attestations *is* counting distinct verifiers — no verifier can
 /// reach the threshold alone by attesting repeatedly.
 fn type_status(
+    env: &Env,
     attestations: &Vec<Attestation>,
     v_type: VerificationType,
     threshold: u32,
@@ -129,8 +130,18 @@ fn type_status(
     let mut expired = false;
     let mut seen = false;
 
+    // Only the current verifier set speaks to status. Removing a verifier is
+    // how the admin withdraws trust -- usually because the key is compromised
+    // or the verifier was found negligent -- so their statements must stop
+    // counting the moment they leave, or removal would not actually revoke
+    // anything. The records stay readable through `get_verifications`: the
+    // history of who said what is preserved, it just no longer votes.
+    let trusted = load_verifiers(env);
+
     for attestation in attestations.iter() {
-        if attestation.v_type != v_type {
+        if attestation.v_type != v_type
+            || !trusted.iter().any(|entry| entry == attestation.verifier)
+        {
             continue;
         }
         seen = true;
@@ -171,8 +182,11 @@ fn type_status(
 /// have since been removed keep occupying slots, so a rotated-through set can
 /// fill the list and permanently block admission. History yields to liveness
 /// in a defined order: the oldest record from a verifier that is no longer
-/// trusted goes first (it can no longer count toward any threshold), then the
-/// oldest lapsed record.
+/// trusted goes first, then the oldest lapsed record. Neither can affect any
+/// status -- `type_status` counts only the current verifier set, and lapsed
+/// records count nowhere -- so eviction can never move a verification type
+/// from `Verified` or `Rejected` as a side effect of an unrelated
+/// attestation.
 ///
 /// The final `None` arm cannot trigger under the current constants, and the
 /// arithmetic is worth stating because it is what makes the cap safe. A list
@@ -1095,7 +1109,7 @@ impl RegistryContract {
         let now = env.ledger().timestamp();
         let threshold = Self::get_verifier_threshold(env.clone());
         let attestations = load_verifications(&env, &invoice_id);
-        let status_before = type_status(&attestations, v_type, threshold, now);
+        let status_before = type_status(&env, &attestations, v_type, threshold, now);
 
         // Charge before writing, so a verifier the originator cannot pay never
         // gets an attestation recorded. CEI: the token is a standard SEP-41
@@ -1145,7 +1159,7 @@ impl RegistryContract {
             (verifier, v_type, hash, attestation.valid_until, fee),
         );
 
-        let status_after = type_status(&updated, v_type, threshold, now);
+        let status_after = type_status(&env, &updated, v_type, threshold, now);
         if status_after != status_before
             && (status_after == VerificationStatus::Verified
                 || status_after == VerificationStatus::Rejected)
@@ -1173,7 +1187,7 @@ impl RegistryContract {
     ) -> VerificationStatus {
         let attestations = load_verifications(&env, &invoice_id);
         let threshold = Self::get_verifier_threshold(env.clone());
-        type_status(&attestations, v_type, threshold, env.ledger().timestamp())
+        type_status(&env, &attestations, v_type, threshold, env.ledger().timestamp())
     }
 
     /// Verification status of the invoice as a whole.
@@ -1190,7 +1204,7 @@ impl RegistryContract {
         let mut all_verified = true;
         let mut any_expired = false;
         for v_type in VERIFICATION_TYPES.iter() {
-            match type_status(&attestations, *v_type, threshold, now) {
+            match type_status(&env, &attestations, *v_type, threshold, now) {
                 VerificationStatus::Rejected => return VerificationStatus::Rejected,
                 VerificationStatus::Verified => {}
                 VerificationStatus::Expired => {

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -2330,6 +2330,150 @@ fn test_removed_verifier_cannot_attest_but_keeps_its_history() {
     // storing it.
     assert_eq!(client.get_verifications(&invoice_id).len(), 1);
     assert!(!client.is_verifier(&verifier));
+
+    // But it no longer votes. Removal is how trust is withdrawn, normally
+    // because the key is compromised; if the approval kept standing, removal
+    // would revoke nothing.
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Pending,
+        "a removed verifier's approval must stop satisfying the threshold"
+    );
+}
+
+#[test]
+fn test_removal_revokes_a_contributing_approval_and_a_rejection() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("vinv26");
+    let (client, admin, _originator, first) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+    let second = Address::generate(&env);
+    client.add_verifier(&admin, &second);
+    client.set_verifier_threshold(&admin, &2u32);
+
+    // Two approvals clear the threshold.
+    client.attest(
+        &invoice_id,
+        &first,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    client.attest(
+        &invoice_id,
+        &second,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 2),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+
+    // Removing one of them drops the live approval count below the threshold.
+    client.remove_verifier(&admin, &second);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Pending,
+        "removal must withdraw the approval that was carrying the threshold"
+    );
+
+    // The same holds for a rejection: a disowned verifier should not keep an
+    // invoice blocked forever.
+    client.attest(
+        &invoice_id,
+        &first,
+        &VerificationType::TaxCompliance,
+        &evidence_hash(&env, 3),
+        &false,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Rejected
+    );
+    client.remove_verifier(&admin, &first);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Pending,
+        "removal must withdraw a rejection too"
+    );
+
+    // History is untouched by any of it.
+    assert_eq!(client.get_verifications(&invoice_id).len(), 3);
+}
+
+#[test]
+fn test_eviction_cannot_disturb_another_types_status() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    // The cross-type hazard: making room for a new attestation evicts a record
+    // belonging to a different verification type. That is only safe because
+    // evictable records never counted toward status in the first place.
+    let invoice_id = symbol_short!("vinv27");
+    let (client, admin, _originator, _seed) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    let types = [
+        VerificationType::DocumentHash,
+        VerificationType::BusinessRegistration,
+        VerificationType::TaxCompliance,
+    ];
+
+    // Fill the invoice to its cap with departed verifiers.
+    for round in 0..20u8 {
+        let rotating = Address::generate(&env);
+        client.add_verifier(&admin, &rotating);
+        for (offset, v_type) in types.iter().enumerate() {
+            client.attest(
+                &invoice_id,
+                &rotating,
+                v_type,
+                &evidence_hash(&env, round * 3 + offset as u8),
+                &true,
+            );
+        }
+        client.remove_verifier(&admin, &rotating);
+    }
+    assert_eq!(client.get_verifications(&invoice_id).len(), 60);
+
+    // An active verifier vouches for one type, then another, forcing evictions.
+    let active = Address::generate(&env);
+    client.add_verifier(&admin, &active);
+    client.attest(
+        &invoice_id,
+        &active,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 100),
+        &true,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+
+    client.attest(
+        &invoice_id,
+        &active,
+        &VerificationType::TaxCompliance,
+        &evidence_hash(&env, 101),
+        &true,
+    );
+
+    // Attesting to TaxCompliance evicted a record, but DocumentHash must be
+    // exactly where it was left.
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified,
+        "an unrelated attestation must not move another type's status"
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Verified
+    );
 }
 
 // ── Events ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to #198 (issue #181), which auto-merged carrying this defect. Addresses the two findings CodeRabbit raised on the final review round.

## Removal did not actually revoke anything

`remove_verifier` dropped an address from the trusted set but left its statements counting toward verification status. An invoice therefore kept reading `Verified` on the word of a verifier the protocol had just disowned.

That gets the purpose backwards. Removal is how an admin withdraws trust, and the reason is normally that a key is compromised or a verifier was found negligent — precisely when their prior approvals should stop carrying a threshold. `type_status` now evaluates only the current verifier set.

The records stay in storage and are still returned by `get_verifications`, so the audit trail of who said what is intact. It simply no longer votes. That split is the point: history is for auditing, the verifier set is for deciding.

## It also closes a cross-type hazard in the eviction policy

The cap-eviction policy added in #198 frees a slot by dropping the oldest record from a departed verifier — and those records were being counted. So attesting to one verification type could silently move an **unrelated** type off `Verified` or `Rejected`, purely as a function of vector order.

With this change both evictable classes — departed and lapsed — are exactly the records that contribute nothing to status. That is what makes evicting them safe, and it is now the stated invariant rather than an accident.

`test_eviction_cannot_disturb_another_types_status` pins it: fill an invoice to its 60-record cap with departed verifiers, have an active verifier verify `DocumentHash`, then attest to `TaxCompliance` (forcing an eviction), and assert `DocumentHash` is exactly where it was left.

## Verification

```
cargo test -p invofi-registry
test result: ok. 97 passed; 0 failed

cargo test                      # whole workspace
252 passed; 0 failed
cargo clippy --target wasm32v1-none -- -D warnings   # clean
```

Three tests, all of which fail on the pre-fix code:

- `test_removal_revokes_a_contributing_approval_and_a_rejection` — the case CodeRabbit asked for. Two approvals clear a threshold of 2; removing one verifier drops the type to `Pending`. Then the same for a rejection, since a disowned verifier should not keep an invoice blocked forever. Asserts all three records survive in `get_verifications`.
- `test_eviction_cannot_disturb_another_types_status` — the cross-type hazard above.
- `test_removed_verifier_cannot_attest_but_keeps_its_history` — extended to assert the approval no longer satisfies the threshold, which is the half it was missing.

## Docs

ADR-0009 decision 7 is rewritten to give both halves of the rule and why they differ, replacing a paragraph that documented the old behaviour and suggested raising the threshold as a workaround. The eviction policy becomes decision 8 — it was previously only documented in code, which is why its safety argument was never checked against decision 7.

The CHANGELOG no longer describes an attestation as stored "immutably", which contradicted the replacement-on-re-attest behaviour described two bullets later (CodeRabbit's second finding).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed verifiers’ attestations no longer affect verification status.
  * Historical attestations remain available for audit and review.
  * Verification correctly returns to pending when a removed verifier was required for approval.
  * Attestation eviction preserves verification status across types and never removes active records.

* **Documentation**
  * Clarified invoice verification, verifier removal, attestation retention, and eviction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->