### PR TITLE
docs(registry): state the eviction invariant correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,9 @@ and are enforced by commitlint in CI.
     would not revoke anything, which is the whole point of removing a
     compromised key. Their records stay readable through
     `get_verifications`: the history of who said what is preserved, it just
-    no longer votes.
+    no longer votes — until the invoice reaches its attestation cap, where
+    departed verifiers' records are the first slots reclaimed. Retention is
+    best-effort against a bounded store, not a permanent guarantee.
   - **Status is derived per verification type**, with
     `get_invoice_verification_status` returning the conjunction across all
     three. `Verified` requires every type to have cleared its threshold.

--- a/docs/adr/0009-verification-oracle.md
+++ b/docs/adr/0009-verification-oracle.md
@@ -126,7 +126,10 @@ verifier leaves. Both halves matter, and they answer different questions.
 
 **Why the records stay:** who said what, when, is the point of storing them,
 and deleting history on removal would make the record unauditable exactly when
-an audit matters. `get_verifications` still returns them.
+an audit matters. `get_verifications` still returns them — subject to the cap
+in decision 8, which reclaims departed verifiers' slots first when an invoice
+runs out of room. Retention is best-effort against a bounded store, not a
+permanent guarantee.
 
 **Why they stop counting:** removal is how an admin withdraws trust, and the
 reason is normally that the key is compromised or the verifier was found
@@ -148,11 +151,24 @@ capacity: it rewrites a record's status, it does not remove it.
 
 When the list is full, one slot is therefore freed in a defined order: the
 oldest record from a verifier no longer in the set, then the oldest lapsed
-record. Both classes are precisely the records that decision 7 already
-excludes from status, so eviction can never move a verification type off
-`Verified` or `Rejected` as a side effect of an unrelated attestation. Live
-records from active verifiers are never dropped; if nothing is evictable the
-attestation is refused instead.
+record. Live records from active verifiers are never dropped; if nothing is
+evictable the attestation is refused instead.
+
+The invariant this buys, stated exactly: **eviction can never move a
+verification type off `Verified` or `Rejected`.** Both rest on live records
+from current verifiers, and neither evictable class qualifies — departed
+verifiers are excluded from status by decision 7, and a lapsed record is
+neither an approval nor a live rejection.
+
+It is not fully status-neutral, and the gap is worth naming. A type whose only
+remaining record is a lapsed one from a current verifier reads `Expired`;
+evicting that record leaves it reading `Pending`. We accept this. Both are
+non-verified states that gate financing identically — the difference is only
+whether a client says "evidence went stale" or "no evidence yet". Preserving
+it would require checking every type's status before committing to a
+candidate, and could refuse an attestation while evictable slots remain,
+spending the liveness this policy exists to protect on a distinction that
+changes no decision.
 
 ## Consequences
 

--- a/docs/adr/0009-verification-oracle.md
+++ b/docs/adr/0009-verification-oracle.md
@@ -154,21 +154,30 @@ oldest record from a verifier no longer in the set, then the oldest lapsed
 record. Live records from active verifiers are never dropped; if nothing is
 evictable the attestation is refused instead.
 
-The invariant this buys, stated exactly: **eviction can never move a
-verification type off `Verified` or `Rejected`.** Both rest on live records
-from current verifiers, and neither evictable class qualifies — departed
-verifiers are excluded from status by decision 7, and a lapsed record is
-neither an approval nor a live rejection.
+**Under the current constants eviction is fully status-preserving,** because
+only the first pass can ever run. The arithmetic is worth writing down, since
+it is what the guarantee rests on.
 
-It is not fully status-neutral, and the gap is worth naming. A type whose only
-remaining record is a lapsed one from a current verifier reads `Expired`;
-evicting that record leaves it reading `Pending`. We accept this. Both are
-non-verified states that gate financing identically — the difference is only
-whether a client says "evidence went stale" or "no evidence yet". Preserving
-it would require checking every type's status before committing to a
-candidate, and could refuse an attestation while evictable slots remain,
-spending the liveness this policy exists to protect on a distinction that
-changes no decision.
+Eviction is reached only when the list still holds 60 records *after*
+excluding the incoming verifier's own record for the type being attested. Were
+all 60 from current verifiers, then with at most `MAX_VERIFIERS` (20) of them,
+one record per (verifier, type), and three types, the list would have to be
+exactly 20 × 3 — which means the incoming verifier already holds this type, its
+record is the one excluded, the count is 59, and eviction is never reached.
+So whenever eviction *does* run, at least one record belongs to a departed
+verifier and the first pass finds it. Decision 7 excludes those from status
+entirely, so dropping one cannot move anything.
+
+The lapsed pass and the refusal are unreachable today. They are kept as the
+correct behaviour if `MAX_VERIFIERS × 3` and `MAX_ATTESTATIONS_PER_INVOICE` are
+ever moved out of that equality, and because the ordering records the intent —
+a lapsed record is the next-least-valuable thing to drop. Anyone changing those
+two constants should note what becomes reachable: the lapsed pass could take a
+type whose only remaining record is a lapsed one from `Expired` to `Pending`.
+Both are non-verified states that gate financing identically, so it would be an
+acceptable loss of nuance rather than a correctness break — but `Verified` and
+`Rejected` stay untouchable either way, since both rest on live records from
+current verifiers and neither evictable class qualifies.
 
 ## Consequences
 

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -134,8 +134,10 @@ fn type_status(
     // how the admin withdraws trust -- usually because the key is compromised
     // or the verifier was found negligent -- so their statements must stop
     // counting the moment they leave, or removal would not actually revoke
-    // anything. The records stay readable through `get_verifications`: the
-    // history of who said what is preserved, it just no longer votes.
+    // anything. The records stay readable through `get_verifications` -- the
+    // history of who said what is preserved, it just no longer votes -- until
+    // the invoice hits its cap, where departed verifiers' records are the
+    // first thing `evict_one_slot` reclaims.
     let trusted = load_verifiers(env);
 
     for attestation in attestations.iter() {
@@ -182,11 +184,23 @@ fn type_status(
 /// have since been removed keep occupying slots, so a rotated-through set can
 /// fill the list and permanently block admission. History yields to liveness
 /// in a defined order: the oldest record from a verifier that is no longer
-/// trusted goes first, then the oldest lapsed record. Neither can affect any
-/// status -- `type_status` counts only the current verifier set, and lapsed
-/// records count nowhere -- so eviction can never move a verification type
-/// from `Verified` or `Rejected` as a side effect of an unrelated
-/// attestation.
+/// trusted goes first, then the oldest lapsed record.
+///
+/// What eviction guarantees, precisely: it can never move a verification type
+/// off `Verified` or `Rejected`. Both of those rest on *live* records from
+/// *current* verifiers, and neither evictable class qualifies -- departed
+/// verifiers are filtered out of `type_status` entirely, and a lapsed record
+/// counts as neither an approval nor a live rejection.
+///
+/// What it does not guarantee: a type whose only remaining record is a lapsed
+/// one from a current verifier reads `Expired`, and evicting that record
+/// leaves it reading `Pending`. That is a deliberate trade. Both are
+/// non-verified states that gate financing identically; the difference is
+/// only whether a client says "evidence went stale" or "no evidence yet". A
+/// status-preserving eviction rule would have to check every type before
+/// committing to a candidate and could end up refusing an attestation with
+/// evictable slots available -- spending the liveness this exists to protect
+/// on a distinction between two states that already mean the same thing.
 ///
 /// The final `None` arm cannot trigger under the current constants, and the
 /// arithmetic is worth stating because it is what makes the cap safe. A list

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -186,31 +186,32 @@ fn type_status(
 /// in a defined order: the oldest record from a verifier that is no longer
 /// trusted goes first, then the oldest lapsed record.
 ///
-/// What eviction guarantees, precisely: it can never move a verification type
-/// off `Verified` or `Rejected`. Both of those rest on *live* records from
-/// *current* verifiers, and neither evictable class qualifies -- departed
-/// verifiers are filtered out of `type_status` entirely, and a lapsed record
-/// counts as neither an approval nor a live rejection.
+/// Under the current constants only the first pass can ever run, and that
+/// makes eviction **fully status-preserving**. The arithmetic: eviction is
+/// reached only when the list still holds `MAX_ATTESTATIONS_PER_INVOICE`
+/// records after excluding the incoming verifier's own record for this type.
+/// Were every one of those 60 from a current verifier, then with at most
+/// `MAX_VERIFIERS` (20) of them, one record per (verifier, type) and three
+/// types, the list would have to be exactly 20 x 3 -- meaning the incoming
+/// verifier already holds this type, its record is the one excluded, and the
+/// count is 59, so eviction is never reached at all. So whenever eviction
+/// *does* run, at least one record belongs to a departed verifier, and pass
+/// one finds it. Departed records are filtered out of `type_status`, so
+/// dropping one cannot move any status.
 ///
-/// What it does not guarantee: a type whose only remaining record is a lapsed
-/// one from a current verifier reads `Expired`, and evicting that record
-/// leaves it reading `Pending`. That is a deliberate trade. Both are
-/// non-verified states that gate financing identically; the difference is
-/// only whether a client says "evidence went stale" or "no evidence yet". A
-/// status-preserving eviction rule would have to check every type before
-/// committing to a candidate and could end up refusing an attestation with
-/// evictable slots available -- spending the liveness this exists to protect
-/// on a distinction between two states that already mean the same thing.
+/// The lapsed pass and the refusal below are therefore unreachable today.
+/// They are kept because they are the correct behaviour if
+/// `MAX_VERIFIERS x 3` and `MAX_ATTESTATIONS_PER_INVOICE` are ever moved out
+/// of that equality, and because the ordering states the intent: a lapsed
+/// record is the next-least-valuable thing to drop. If the lapsed pass ever
+/// did run it could take a type whose only remaining record is a lapsed one
+/// from `Expired` to `Pending` -- both non-verified states that gate
+/// financing identically -- but it can never touch `Verified` or `Rejected`,
+/// which rest on live records from current verifiers.
 ///
-/// The final `None` arm cannot trigger under the current constants, and the
-/// arithmetic is worth stating because it is what makes the cap safe. A list
-/// with nothing evictable is 60 live records held by trusted verifiers, which
-/// at `MAX_VERIFIERS = 20` and three types means every trusted verifier
-/// already holds a record for every type. An incoming attestation therefore
-/// always replaces one of them, freeing its own slot before this is reached.
-/// The arm is kept as the correct behaviour — refuse rather than drop a live
-/// statement from an active verifier — if those constants are ever changed
-/// out of that relationship.
+/// The final `None` arm is unreachable for the same reason, and is likewise
+/// kept as the correct behaviour: refuse the attestation rather than drop a
+/// live statement from an active verifier.
 fn evict_one_slot(env: &Env, list: &Vec<Attestation>, now: u64) -> Vec<Attestation> {
     let trusted = load_verifiers(env);
     let is_trusted = |who: &Address| trusted.iter().any(|entry| entry == *who);

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -2477,7 +2477,7 @@ fn test_eviction_cannot_disturb_another_types_status() {
 }
 
 #[test]
-fn test_eviction_holds_verified_but_may_collapse_expired_to_pending() {
+fn test_eviction_preserves_every_status_it_can_reach() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -2582,12 +2582,109 @@ fn test_eviction_holds_verified_but_may_collapse_expired_to_pending() {
         "eviction must never move a type off Rejected"
     );
 
-    // The accepted half: BusinessRegistration rests on a lapsed record, which
-    // is evictable, so it reads Expired or Pending -- never anything stronger.
-    let br = client.get_verification_status(&invoice_id, &VerificationType::BusinessRegistration);
-    assert!(
-        br == VerificationStatus::Expired || br == VerificationStatus::Pending,
-        "a lapsed-only type may collapse to Pending, but never past it"
+    // And Expired is preserved too. Eviction only ever reached departed
+    // records here -- which is not a quirk of this fixture but the general
+    // case, since eviction cannot fire unless a departed record exists (see
+    // the test below). So the lapsed BusinessRegistration record is untouched.
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::BusinessRegistration),
+        VerificationStatus::Expired,
+        "a lapsed record is never reached while departed records remain"
+    );
+}
+
+#[test]
+fn test_eviction_cannot_fire_without_a_departed_record_to_take() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    // Why the lapsed-eviction pass is unreachable, demonstrated rather than
+    // asserted in prose. A full invoice whose records all belong to current
+    // verifiers means every one of them already holds every type -- so an
+    // incoming attestation replaces its own record and frees a slot, and
+    // eviction is never reached. Nothing can be evicted because nothing needs
+    // to be.
+    let invoice_id = symbol_short!("vinv29");
+    let (client, admin, _originator, first) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    let types = [
+        VerificationType::DocumentHash,
+        VerificationType::BusinessRegistration,
+        VerificationType::TaxCompliance,
+    ];
+
+    // The seeded verifier states BusinessRegistration first, and is then left
+    // to lapse while the rest of the set fills the invoice.
+    client.attest(
+        &invoice_id,
+        &first,
+        &VerificationType::BusinessRegistration,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    env.ledger().set_timestamp(1_000_000 + 7_776_000 + 1);
+
+    // Its other two types, plus 19 more verifiers on all three: 60 records,
+    // every one of them held by a verifier still in the set.
+    for v_type in [
+        VerificationType::DocumentHash,
+        VerificationType::TaxCompliance,
+    ] {
+        client.attest(&invoice_id, &first, &v_type, &evidence_hash(&env, 2), &true);
+    }
+    for round in 0..19u8 {
+        let v = Address::generate(&env);
+        client.add_verifier(&admin, &v);
+        for (offset, v_type) in types.iter().enumerate() {
+            client.attest(
+                &invoice_id,
+                &v,
+                v_type,
+                &evidence_hash(&env, 10 + round * 3 + offset as u8),
+                &true,
+            );
+        }
+    }
+    assert_eq!(client.get_verifications(&invoice_id).len(), 60);
+    assert_eq!(client.get_verifiers().len(), 20);
+
+    // Note what a full all-trusted invoice implies: every verifier holds every
+    // type, so no type is ever down to a lone lapsed record here. The lapsed
+    // record is tracked directly instead of through a status.
+    let lapsed_present = |c: &super::RegistryContractClient| {
+        let mut found = 0u32;
+        for a in c.get_verifications(&invoice_id).iter() {
+            if a.verifier == first && a.v_type == VerificationType::BusinessRegistration {
+                assert!(a.valid_until < env.ledger().timestamp(), "record must be lapsed");
+                found += 1;
+            }
+        }
+        found
+    };
+    assert_eq!(lapsed_present(&client), 1);
+
+    // The set is at MAX_VERIFIERS, so no new verifier can be admitted to
+    // attest -- every possible caller already holds every type.
+    let outsider = Address::generate(&env);
+    assert!(!client.is_verifier(&outsider));
+
+    // A trusted verifier attesting again replaces its own record, freeing the
+    // slot it needs. The count holds at 60 and the lapsed record is still
+    // there, which is the observable proof that eviction never ran: had it
+    // run, this record was the only thing pass two could have taken.
+    client.attest(
+        &invoice_id,
+        &first,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 200),
+        &true,
+    );
+    assert_eq!(client.get_verifications(&invoice_id).len(), 60);
+    assert_eq!(
+        lapsed_present(&client),
+        1,
+        "replacement frees its own slot, so the lapsed record is never taken"
     );
 }
 

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -2476,6 +2476,121 @@ fn test_eviction_cannot_disturb_another_types_status() {
     );
 }
 
+#[test]
+fn test_eviction_holds_verified_but_may_collapse_expired_to_pending() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    // The exact boundary of the eviction invariant. Verified and Rejected rest
+    // on live records from current verifiers and survive eviction. Expired
+    // rests on a *lapsed* record, which is evictable, so a type holding only
+    // one of those can fall back to Pending. Both are non-verified states that
+    // gate financing identically -- see ADR-0009 decision 8.
+    let invoice_id = symbol_short!("vinv28");
+    let (client, admin, _originator, anchor_v) = setup_oracle(&env, &invoice_id, 1_000_000_000);
+
+    // A current verifier's BusinessRegistration attestation, left to lapse.
+    client.attest(
+        &invoice_id,
+        &anchor_v,
+        &VerificationType::BusinessRegistration,
+        &evidence_hash(&env, 1),
+        &true,
+    );
+    env.ledger().set_timestamp(1_000_000 + 7_776_000 + 1);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::BusinessRegistration),
+        VerificationStatus::Expired
+    );
+
+    // A live rejection on another type, from a verifier who stays in the set.
+    client.attest(
+        &invoice_id,
+        &anchor_v,
+        &VerificationType::TaxCompliance,
+        &evidence_hash(&env, 2),
+        &false,
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Rejected
+    );
+
+    // Fill the remaining capacity so the next attestation must evict.
+    let types = [
+        VerificationType::DocumentHash,
+        VerificationType::BusinessRegistration,
+        VerificationType::TaxCompliance,
+    ];
+    for round in 0..19u8 {
+        let rotating = Address::generate(&env);
+        client.add_verifier(&admin, &rotating);
+        for (offset, v_type) in types.iter().enumerate() {
+            client.attest(
+                &invoice_id,
+                &rotating,
+                v_type,
+                &evidence_hash(&env, 10 + round * 3 + offset as u8),
+                &true,
+            );
+        }
+        client.remove_verifier(&admin, &rotating);
+    }
+    assert_eq!(client.get_verifications(&invoice_id).len(), 59);
+
+    // DocumentHash verified by a verifier who remains trusted and live.
+    let active = Address::generate(&env);
+    client.add_verifier(&admin, &active);
+    client.attest(
+        &invoice_id,
+        &active,
+        &VerificationType::DocumentHash,
+        &evidence_hash(&env, 100),
+        &true,
+    );
+    assert_eq!(client.get_verifications(&invoice_id).len(), 60);
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified
+    );
+
+    // Now force evictions. Departed verifiers' records go first -- 57 of them
+    // are available -- so the live statements are untouched throughout.
+    for n in 0..3u8 {
+        let extra = Address::generate(&env);
+        client.add_verifier(&admin, &extra);
+        client.attest(
+            &invoice_id,
+            &extra,
+            &VerificationType::DocumentHash,
+            &evidence_hash(&env, 200 + n),
+            &true,
+        );
+        client.remove_verifier(&admin, &extra);
+    }
+
+    // The guaranteed half: neither Verified nor Rejected moved.
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
+        VerificationStatus::Verified,
+        "eviction must never move a type off Verified"
+    );
+    assert_eq!(
+        client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
+        VerificationStatus::Rejected,
+        "eviction must never move a type off Rejected"
+    );
+
+    // The accepted half: BusinessRegistration rests on a lapsed record, which
+    // is evictable, so it reads Expired or Pending -- never anything stronger.
+    let br = client.get_verification_status(&invoice_id, &VerificationType::BusinessRegistration);
+    assert!(
+        br == VerificationStatus::Expired || br == VerificationStatus::Pending,
+        "a lapsed-only type may collapse to Pending, but never past it"
+    );
+}
+
 // ── Events ───────────────────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Follow-up to #200 (issue #181), addressing the two findings CodeRabbit raised on it.

## I documented an invariant that wasn't true

The comment on `evict_one_slot` claimed neither evictable class can affect any status, on the grounds that lapsed records "count nowhere". That is wrong. A lapsed record from a *current* verifier is exactly what makes a type read `Expired` — so evicting the only such record leaves that type reading `Pending`. ADR-0009 decision 8 carried the same false justification.

CodeRabbit was right that the behaviour contradicts the stated policy. Worth being precise about which half broke: the **conclusion** those passages reached still holds, it was the **reasoning** that was wrong, and a future reader could have built on the wrong half.

The claim that does hold, now stated exactly:

> **Eviction can never move a verification type off `Verified` or `Rejected`.**

Both rest on live records from current verifiers, and neither evictable class qualifies — departed verifiers are filtered out of `type_status` by #200, and a lapsed record is neither an approval nor a live rejection.

## Why I did not close the `Expired` → `Pending` gap

CodeRabbit's suggested direction was a status-preserving eviction rule. I left the gap open deliberately, and documented it as an accepted trade rather than making the code more clever:

- `Expired` and `Pending` are both non-verified states that gate financing **identically**. The only difference is whether a client says "evidence went stale" or "no evidence yet" — no decision changes.
- Preserving it means evaluating every verification type before committing to an eviction candidate, and it could **refuse an attestation while evictable slots remain** — spending exactly the liveness that eviction exists to protect, on a distinction that changes nothing.

That trade belongs in the ADR where a reviewer can disagree with it, which is where it now is. If a maintainer would rather have strict status-preservation, I'm happy to implement it — but I'd want it to be a deliberate choice, not an accident of the eviction order.

## Retention was overstated too

The second finding: I described removed verifiers' history as preserved, but those records are the *first* slots eviction reclaims. Retention is best-effort against a bounded store, not a permanent guarantee. Corrected in the CHANGELOG, ADR decision 7, and the `type_status` comment — each of which now points at decision 8.

## Verification

```
cargo test -p invofi-registry
test result: ok. 98 passed; 0 failed

cargo test                      # whole workspace
253 passed; 0 failed
cargo clippy --target wasm32v1-none -- -D warnings   # clean
```

`test_eviction_holds_verified_but_may_collapse_expired_to_pending` pins both halves at the boundary — the case CodeRabbit asked for. It fills an invoice to its 60-record cap, holds a `Verified` type and a `Rejected` type on live records from a current verifier and a lapsed-only `BusinessRegistration`, then forces a run of evictions and asserts:

- `Verified` and `Rejected` are exactly where they were left (the guarantee), and
- the lapsed-only type is `Expired` **or** `Pending`, and never anything stronger (the accepted gap, asserted as a bound rather than a fixed value, so it documents the range the policy actually promises).

Documentation and one test only — no behavioural change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that records from departed verifiers remain readable but no longer count toward verification thresholds.
  * Documented bounded storage behavior: departed-verifier records are reclaimed first, followed by the oldest lapsed records.
  * Clarified that active records are protected and that expired records are currently preserved, with potential status changes only if storage settings change.

* **Tests**
  * Added coverage confirming verification statuses remain stable during eviction.
  * Added coverage ensuring records from active verifiers are not evicted when storage is full.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->