### PR TITLE
feat(reputation): dispute-aware score adjustment (closes #134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,24 @@ and are enforced by commitlint in CI.
     threshold, fee math and its overflow guard, fee-on-rejection, expiry and
     re-attestation, non-retroactive validity changes, the removed-verifier
     case, and the three events.
+- **Dispute-aware reputation adjustment (issue #134)** — a default that a
+  dispute later overturns no longer keeps punishing the originator.
+  `reputation` gains an admin-only `resolve_dispute(admin, originator,
+  originator_favourable)` mirroring the registry's admin-only
+  `resolve_dispute`: when the resolution is in the originator's favour, one
+  previously-recorded default is **neutralized** (`defaults` decrements by
+  one, floored at 0) so the `-2` penalty stops counting against them. A
+  resolution against the originator leaves the recorded outcome unchanged.
+  - The documented rule lives in ADR-0004 §7. The scoring formula itself is
+    untouched — `get_score` stays `repayments − 2×defaults`, floored at 0,
+    public and read-only, and non-disputed outcomes are unaffected.
+  - The adjustment emits a `ReputationChanged` event (topic `rep_chg`, new
+    to the canonical events table) carrying the corrected score.
+  - The recorder restriction is unchanged: only the repayment contract can
+    record new outcomes; only the admin can adjust them after a dispute.
+  - 6 new tests: favourable neutralization, favourable no-op with no
+    recorded default, unfavourable no-op, non-admin rejection
+    (`E_UNAUTHORIZED`), pause guard, and the emitted event payload.
 
 - **Partial repayment with pro-rata interest (issue #176)** — originators
   can now make partial payments against an invoice, with interest calculated

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ the frontend's portfolio offers a one-click trustline helper.
 | `__constructor(admin)` | Deployer (at deploy) | Sets admin atomically in the deploy operation (ADR-0005) |
 | `set_recorder(admin, recorder)` | Admin | Set the repayment contract as the only writer |
 | `record_outcome(originator, outcome)` | Recorder only | `0` = repaid, `1` = defaulted; updates outcome counts |
+| `resolve_dispute(admin, originator, originator_favourable)` | Admin | Neutralize one recorded default when a dispute resolves in the originator's favour; emits `rep_chg` with the corrected score (ADR-0004 §7, issue #134) |
 | `get_score(originator)` | Anyone | `repayments − 2×defaults`, floored at 0 (ADR-0004) |
 | `get_record(originator)` | Anyone | Raw `{repayments, defaults}` counts — the source of truth |
 
@@ -190,6 +191,7 @@ Every state-mutating function publishes a Soroban contract event. Topics are
 | `pool_pay` | `pay_out` (insurance) | `amount paid` |
 | `pool_yld` | `unstake` (insurance) | `yield paid` — emitted only when yield > 0 |
 | `reputn` | `record_outcome` (reputation) | `outcome` |
+| `rep_chg` | `resolve_dispute` (reputation) | corrected score — emitted when a dispute resolution neutralizes a default |
 
 ---
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -496,7 +496,7 @@ pub fn resolve_token(env: &Env, currency: &Symbol) -> Address {
 ///     transfer_admin.
 ///   - exceptions: pause, unpause, contract_is_paused, getters.
 /// - Reputation:
-///   - state-changing: record_outcome, set_recorder.
+///   - state-changing: record_outcome, resolve_dispute, set_recorder.
 ///   - exceptions: pause, unpause, contract_is_paused, getters.
 pub fn assert_not_paused(env: &Env) {
     let paused: bool = env

--- a/docs/adr/0004-reputation.md
+++ b/docs/adr/0004-reputation.md
@@ -38,6 +38,26 @@ raw counts into a simple, transparent, publicly-readable score.
    new formula. The public `get_record` API makes a future re-scoring safe
    — scores are derived, raw outcomes remain the source of truth.
 
+7. **Dispute-aware adjustment (issue #134):** a default that a dispute
+   later overturns must not keep punishing the originator. Because the
+   reputation contract tracks only aggregate counts — not invoices — the
+   admin (the same key that resolves disputes in the registry) calls
+   `resolve_dispute(admin, originator, originator_favourable)` on the
+   reputation contract after a registry resolution:
+   - `originator_favourable = true` **neutralizes** one previously-recorded
+     default — `defaults` decrements by one, floored at 0 — so the `-2`
+     penalty stops counting against the originator. The scoring formula
+     itself is untouched: the neutralized default simply no longer exists
+     in the count.
+   - `originator_favourable = false` leaves the recorded outcome
+     unchanged; a penalty already applied by `record_outcome(..., 1)`
+     stands. Recording a *fresh* default for a resolution against the
+     originator remains the repayment contract's job, out of scope here.
+   - The adjustment emits a `ReputationChanged` event (topic `rep_chg`,
+     payload = corrected score) so indexers and the marketplace UI can
+     observe the correction. `get_score` / `get_record` stay public and
+     read-only. Admin auth mirrors `resolve_dispute` in the registry.
+
 ## Consequences
 
 - Lenders get a queryable, honest default-risk signal per originator.

--- a/reputation/src/lib.rs
+++ b/reputation/src/lib.rs
@@ -12,6 +12,11 @@
 //! `score = successful_repayments * 1 - defaults * 2`, floored at 0.
 //! A richer weighted model (amount-weighted, recency decay) is tracked as a
 //! follow-up issue; see ADR-0004.
+//!
+//! Disputes (issue #134): a default that is later overturned by a dispute
+//! resolving in the originator's favour is neutralized via the admin-only
+//! `resolve_dispute` — the `-2` penalty stops counting against them. The
+//! rule is documented in ADR-0004 §7.
 
 use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map};
 
@@ -174,6 +179,55 @@ impl ReputationContract {
 
         env.events()
             .publish((symbol_short!("reputn"), originator.clone()), outcome);
+    }
+
+    /// Adjust an originator's recorded outcome after a dispute resolution.
+    /// Admin only — mirrors the admin-only `resolve_dispute` in the
+    /// registry. After the admin resolves a disputed invoice, they call
+    /// this so the resolution is reflected in the originator's score.
+    ///
+    /// Documented rule (ADR-0004 §7): when `originator_favourable` is
+    /// true, one previously-recorded default is neutralized — `defaults`
+    /// decrements by one (floored at 0) — so the `-2` penalty stops
+    /// counting against the originator. When false, the recorded outcome
+    /// stands unchanged: the penalty, if already applied by
+    /// `record_outcome`, remains.
+    ///
+    /// Emits `ReputationChanged` (topic `rep_chg`) with the corrected
+    /// score when a default was neutralized. `get_score` stays public and
+    /// read-only. Returns the originator's corrected score.
+    pub fn resolve_dispute(
+        env: Env,
+        admin: Address,
+        originator: Address,
+        originator_favourable: bool,
+    ) -> i128 {
+        assert_not_paused(&env);
+        admin.require_auth();
+        let current: Address = env
+            .storage()
+            .instance()
+            .get(&symbol_short!("admin"))
+            .unwrap_or_else(|| panic!("Not initialized"));
+        if current != admin {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+
+        let mut records = load_records(&env);
+        let mut record = records.get(originator.clone()).unwrap_or(ReputationRecord {
+            repayments: 0,
+            defaults: 0,
+        });
+        let mut score = (record.repayments as i128 - 2 * record.defaults as i128).max(0);
+        if originator_favourable && record.defaults > 0 {
+            record.defaults -= 1;
+            score = (record.repayments as i128 - 2 * record.defaults as i128).max(0);
+            records.set(originator.clone(), record);
+            save_records(&env, &records);
+            env.events()
+                .publish((symbol_short!("rep_chg"), originator.clone()), score);
+        }
+        score
     }
 
     // ── Query helpers (public, read-only) ───────────────────────────────────

--- a/reputation/src/test.rs
+++ b/reputation/src/test.rs
@@ -2,7 +2,11 @@
 extern crate std;
 
 use super::{ReputationContract, OUTCOME_DEFAULTED, OUTCOME_REPAID};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{
+    symbol_short,
+    testutils::{Address as _, Events as _},
+    Address, Env, Symbol, TryFromVal,
+};
 
 /// Deploy the reputation contract and initialize.
 fn setup<'a>(env: &'a Env, admin: &Address) -> super::ReputationContractClient<'a> {
@@ -140,4 +144,155 @@ fn test_record_outcome_invalid_outcome_panics() {
     client.set_recorder(&admin, &recorder);
 
     client.record_outcome(&originator, &99);
+}
+
+// ─── Dispute-aware adjustment tests (issue #134) ─────────────────────────────
+
+#[test]
+fn test_resolve_dispute_favourable_neutralizes_default() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recorder = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+    client.set_recorder(&admin, &recorder);
+
+    // 2 repayments + 1 default -> 2 - 2 = 0: the default penalty outweighs
+    // the successful repayments.
+    client.record_outcome(&originator, &OUTCOME_REPAID);
+    client.record_outcome(&originator, &OUTCOME_REPAID);
+    client.record_outcome(&originator, &OUTCOME_DEFAULTED);
+    assert_eq!(client.get_score(&originator), 0);
+
+    // Dispute resolves in the originator's favour -> default neutralized.
+    let corrected = client.resolve_dispute(&admin, &originator, &true);
+    assert_eq!(corrected, 2);
+    assert_eq!(client.get_score(&originator), 2);
+
+    let rec = client.get_record(&originator);
+    assert_eq!(rec.repayments, 2);
+    assert_eq!(rec.defaults, 0);
+}
+
+#[test]
+fn test_resolve_dispute_favourable_without_default_is_noop() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+
+    // Fresh originator — nothing to neutralize, score stays 0.
+    let corrected = client.resolve_dispute(&admin, &originator, &true);
+    assert_eq!(corrected, 0);
+    assert_eq!(client.get_score(&originator), 0);
+    assert_eq!(client.get_record(&originator).defaults, 0);
+}
+
+#[test]
+fn test_resolve_dispute_unfavourable_leaves_record_unchanged() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recorder = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+    client.set_recorder(&admin, &recorder);
+
+    client.record_outcome(&originator, &OUTCOME_REPAID);
+    client.record_outcome(&originator, &OUTCOME_DEFAULTED);
+    assert_eq!(client.get_score(&originator), 0);
+
+    // Resolution against the originator: the recorded outcome stands.
+    let corrected = client.resolve_dispute(&admin, &originator, &false);
+    assert_eq!(corrected, 0);
+    assert_eq!(client.get_score(&originator), 0);
+    assert_eq!(client.get_record(&originator).defaults, 1);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_resolve_dispute_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+
+    let impostor = Address::generate(&env);
+    client.resolve_dispute(&impostor, &originator, &true);
+}
+
+#[test]
+fn test_resolve_dispute_paused_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let client = setup(&env, &admin);
+    let originator = Address::generate(&env);
+
+    client.pause(&admin);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        client.resolve_dispute(&admin, &originator, &true);
+    }));
+    assert!(result.is_err(), "resolve_dispute must panic while paused");
+}
+
+/// Count published events whose first topic is `name`.
+fn count_events(env: &Env, name: Symbol) -> u32 {
+    let mut count = 0;
+    for (_contract, topics, _data) in env.events().all().iter() {
+        if let Some(first) = topics.get(0) {
+            if let Ok(topic) = Symbol::try_from_val(env, &first) {
+                if topic == name {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+#[test]
+fn test_resolve_dispute_emits_corrected_score_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recorder = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+    client.set_recorder(&admin, &recorder);
+
+    client.record_outcome(&originator, &OUTCOME_REPAID);
+    client.record_outcome(&originator, &OUTCOME_REPAID);
+    client.record_outcome(&originator, &OUTCOME_DEFAULTED);
+    assert_eq!(count_events(&env, symbol_short!("rep_chg")), 0);
+
+    let corrected = client.resolve_dispute(&admin, &originator, &true);
+    assert_eq!(corrected, 2);
+    assert_eq!(count_events(&env, symbol_short!("rep_chg")), 1);
+
+    // The event payload is the corrected score.
+    let mut found: Option<i128> = None;
+    for (_contract, topics, data) in env.events().all().iter() {
+        if let Some(first) = topics.get(0) {
+            if let Ok(topic) = Symbol::try_from_val(&env, &first) {
+                if topic == symbol_short!("rep_chg") {
+                    found = Some(i128::try_from_val(&env, &data).unwrap());
+                }
+            }
+        }
+    }
+    assert_eq!(found, Some(2));
+
+    // Unfavourable resolution emits nothing — the event window holds only
+    // the most recent invocation, so the count drops back to 0.
+    client.resolve_dispute(&admin, &originator, &false);
+    assert_eq!(count_events(&env, symbol_short!("rep_chg")), 0);
 }


### PR DESCRIPTION
## feat(reputation): dispute-aware score adjustment

Closes #134

---

### Summary

Reputation previously treated outcomes as binary: repay vs default. A default that a dispute later overturns kept punishing the originator permanently, skewing their score. This PR makes the reputation contract dispute-aware: after the admin resolves a dispute in the registry, they call the new admin-only `resolve_dispute(admin, originator, originator_favourable)` on the reputation contract so the resolution is reflected in the score.

**Documented rule (ADR-0004 §7):**

- **Favourable resolution** (`originator_favourable = true`): one previously-recorded default is **neutralized** — `defaults` decrements by one, floored at 0 — so the `-2` penalty stops counting against the originator.
- **Unfavourable resolution** (`originator_favourable = false`): the recorded outcome stands unchanged; a penalty already applied by `record_outcome(..., 1)` remains.

The scoring formula itself is untouched: `get_score` stays `repayments − 2×defaults`, floored at 0, public and read-only, and non-disputed outcomes are unaffected.

---

### Changes

| File | Change |
|---|---|
| `reputation/src/lib.rs` | New `resolve_dispute` entrypoint (admin-only, pause-guarded, mirrors the registry's admin-only dispute resolution); emits `ReputationChanged` (topic `rep_chg`) with the corrected score when a default is neutralized |
| `reputation/src/test.rs` | 6 new tests: favourable neutralization, favourable no-op with no recorded default, unfavourable no-op, non-admin rejection (`E_UNAUTHORIZED`), pause guard, and the emitted event payload |
| `docs/adr/0004-reputation.md` | Decision 7 documents the adjustment rule |
| `README.md` | New `resolve_dispute` row in the reputation function table; `rep_chg` row in the canonical events table |
| `CHANGELOG.md` | `[Unreleased]` entry |
| `common/src/lib.rs` | Auth inventory doc updated to list `resolve_dispute` |

---

### Why an admin entrypoint on the reputation contract?

- The reputation contract tracks only aggregate counts, not invoices, so it cannot derive dispute outcomes itself.
- The registry's `resolve_dispute` is already admin-only; the same trusted key makes the corresponding reputation adjustment, keeping the two resolutions atomic at the operator level without new cross-contract wiring.
- Recording new outcomes stays recorder-only (repayment contract); only *adjusting* previously-recorded outcomes after a dispute is admin-gated.

---

### Acceptance criteria (from #134)

- [x] Originator-favourable dispute resolution stops the default penalty
- [x] Event emitted with the corrected score (`rep_chg`, payload = corrected score)
- [x] Existing scoring formula unchanged for non-disputed cases (`get_score` / `get_record` untouched)

---

### Testing

- `cargo test` — all 258 tests pass (reputation: 11, registry: 97, financing: 74, repayment: 33, insurance: 31, integration: 12)
- `cargo clippy --target wasm32v1-none -- -D warnings` — clean
- `cargo build --target wasm32v1-none --release` — all five contract WASM artifacts build
- New unit tests cover the favourable/unfavourable paths, auth, pause, and events


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin-authorized dispute resolution for reputation records.
  * Originator-favourable resolutions can neutralize one recorded default, without allowing defaults below zero.
  * Unfavourable or already-cleared disputes leave reputation unchanged.
  * Reputation updates emit a corrected change event.

* **Documentation**
  * Documented the new dispute-resolution function, event, and behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->