### PR TITLE
docs(financing): note that amend_offer already satisfies #131

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and are enforced by commitlint in CI.
     derived expiry at the deadline boundary, an expired counter-offer that can
     no longer be taken, revocation, permissionless post-deadline close, the
     round cap, the pause and authorization guards, and the events.
+  - `amend_offer` also satisfies issue #131 (lender-only amendment of a
+    Pending offer's amount/rate/duration, with bounds re-validated and a
+    clear panic on a non-Pending offer) — #131 was left open when this
+    landed even though #180 listed it as related.
 - **Invoice verification oracle (issue #181)** — `registry` now records
   attestations from a trusted verifier set about off-chain invoice facts:
   document hash, business registration, and tax compliance. Design in


### PR DESCRIPTION
## Summary
No functional change. `amend_offer` — lender-only amendment of a Pending offer's `amount`/`interest_rate`/`duration`, with bounds re-validated and a clear panic on a non-Pending offer — was already delivered by the #180 negotiation protocol (`financing/src/lib.rs`, `amend_offer`, merged in #195/#199). #180 listed #131 as related, but the PR that closed it only referenced `Closes #180`, so #131 was left open even though it's fully satisfied. This PR adds a CHANGELOG note pointing at the existing implementation and tests so #131 can close against real, already-shipped work instead of duplicating it.

## Type of change
- [ ] Bug fix
- [ ] New contract function
- [ ] Data type change
- [ ] Test addition
- [x] Chore / docs

## How #131's acceptance criteria are already met
- **Amending a pending offer updates stored terms and emits an event** — `amend_offer` (`financing/src/lib.rs:710`) writes the new `amount`/`interest_rate`/`duration` onto the offer and emits `off_amd` with `(lender, amount, interest_rate, duration)`. Covered by `test_amend_offer_rewrites_terms_and_opens_negotiation` and `test_negotiation_emits_amend_counter_and_close_events` in `financing/src/test.rs`.
- **Amending a non-pending offer panics with a clear message** — `assert_negotiable` panics with `ContractError::InvalidTransition` when `offer.status != OfferStatus::Pending`. Covered by `test_amend_after_acceptance_panics`.
- **Bounds re-validated (dust, rate cap)** — `assert_terms_valid` re-checks amount, rate (1–10 000 bps) and duration against the same bounds `create_offer` enforces on every amendment. Covered by `test_amend_cannot_reach_terms_create_offer_would_reject`.
- **Auth: lender of the offer only** — `amend_offer` calls `lender.require_auth()` and panics `Unauthorized` if the caller isn't `offer.lender`. Covered by `test_amend_offer_by_non_lender_panics`.
- **Stop: no amendment of invoice reference** — `amend_offer`'s signature has no `invoice_id` parameter; the offer's `invoice_id` field is never touched by this path.
- **Stop: no amendments to accepted/financed offers** — enforced by the same `assert_negotiable` Pending check above.

`amend_offer` additionally takes `expected_round` (optimistic concurrency for the negotiation protocol) and can auto-settle if the terms match the originator's live counter-offer — both out of #131's stated scope, but neither conflicts with it: a caller with no open negotiation passes `expected_round: 0` and gets exactly the amend-only behavior #131 describes.

## Checklist
- [x] `cargo test` passes (no code changed; pre-existing amend_offer tests already cover this)
- [x] `cargo clippy -- -D warnings` passes (CI)
- [x] Soroban Scout security analysis passes (CI)
- [x] `stellar contract build` succeeds (no code changed)
- [x] New functions have corresponding tests (no new functions)
- [x] Breaking changes are documented (none)

## Related issues
Closes #131


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lender-only amendments to pending offer terms are now supported.
  * Updated terms are revalidated against applicable bounds.
  * Clearer errors are provided when attempting to amend non-pending offers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->