### PR TITLE
ci: nextest runner + soft coverage baseline

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,13 @@
+# cargo-nextest configuration for InvoFi Contracts.
+# https://nexte.st/docs/configuration/
+
+[profile.default]
+# Parallel by default; CI also sets PROPTEST_CASES for property tests.
+test-threads = "num-cpus"
+
+[profile.ci]
+# Used optionally via: cargo nextest run --profile ci
+# Do not terminate slow property tests — PROPTEST_CASES=2000 can take minutes.
+test-threads = "num-cpus"
+failure-output = "immediate-final"
+slow-timeout = { period = "120s" }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
@@ -19,11 +20,71 @@ jobs:
         with:
           targets: wasm32-unknown-unknown,wasm32v1-none
       - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: nextest
       - name: Run tests
-        # .cargo/config.toml defaults to wasm32v1-none; override to the host
-        # so tests actually compile and execute on the runner.
+        # .cargo/config.toml may pin a WASM target; override to the host so
+        # tests actually compile and execute on the runner. nextest runs the
+        # same assertions as `cargo test`, in parallel.
         run: |
-          PROPTEST_CASES=2000 cargo test --target "$(rustc -vV | sed -n 's/^host: //p')" -- --nocapture
+          HOST="$(rustc -vV | sed -n 's/^host: //p')"
+          PROPTEST_CASES=2000 cargo nextest run --target "$HOST" --no-capture
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+          targets: wasm32-unknown-unknown,wasm32v1-none
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov and nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov,nextest
+      - name: Collect coverage
+        # Soft gate only: regressions on touched crates emit warnings /
+        # PR comments; the job itself stays green (no repo-wide % hard gate).
+        # Emit LCOV in the same invocation as the tests — splitting into
+        # `--no-report` + `report` fails when `--target` is set.
+        run: |
+          HOST="$(rustc -vV | sed -n 's/^host: //p')"
+          PROPTEST_CASES=2000 cargo llvm-cov nextest \
+            --workspace \
+            --target "$HOST" \
+            --lcov \
+            --output-path lcov.info \
+            --summary-only \
+            | tee coverage-summary.txt
+          # JSON summary is optional; LCOV drives the soft regression check.
+          cargo llvm-cov report --json --summary-only --output-path coverage-summary.json \
+            || echo "Note: JSON summary unavailable; continuing with LCOV"
+      - name: Per-crate summary + soft regression check
+        id: coverage_check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-coverage-regression.sh
+      - name: Upload LCOV to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            lcov.info
+            coverage-summary.json
+            coverage-summary.txt
+          retention-days: 30
 
   build:
     name: Build WASM

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,13 @@ target/
 **/test_snapshots/
 **/*.rs.bk
 
+# ── Local coverage output (committed baseline lives in coverage/) ─────────────
+coverage/local/
+coverage-summary.json
+coverage-summary.txt
+coverage-report.md
+lcov.info
+
 # ── Stellar CLI ───────────────────────────────────────────────────────────────
 .soroban/
 .stellar/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and are enforced by commitlint in CI.
 ## [Unreleased]
 
 ### Added
+- **CI: cargo-nextest + line coverage** — the Test job runs the full suite under
+  [nextest](https://nexte.st/) (parallel, same assertions). A Coverage job uses
+  `cargo llvm-cov nextest`, publishes LCOV/Codecov artifacts, and soft-checks
+  touched crates against `coverage/baseline.json` (PR comment + annotations, no
+  hard fail yet). README badge + CONTRIBUTING document local test/coverage flows.
 - **Offer amendment and counter-offer protocol (issue #180)** — financing
   offers are no longer take-it-or-leave-it. A lender can revise their own terms
   with `amend_offer`, an originator can name theirs with `counter_offer`, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,14 +34,42 @@ stellar contract build
 
 ### Test
 
+CI runs the suite with [cargo-nextest](https://nexte.st/) (parallel, same assertions as `cargo test`). Locally you can use either:
+
 ```bash
-cargo test
+# Fast parallel runner (preferred; matches CI)
+cargo nextest run --target "$(rustc -vV | sed -n 's/^host: //p')"
+
+# Classic serial runner
+cargo test --target "$(rustc -vV | sed -n 's/^host: //p')"
 ```
+
+Install nextest once with `cargo install cargo-nextest --locked`, or on Windows grab the [pre-built binary](https://get.nexte.st/).
+
+Property tests use fewer cases locally by default; CI sets `PROPTEST_CASES=2000`. Override locally when needed:
+
+```bash
+PROPTEST_CASES=2000 cargo nextest run --target "$(rustc -vV | sed -n 's/^host: //p')"
+```
+
+### Coverage
+
+We collect line coverage with [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) wrapping nextest (LLVM instrumentation — the modern alternative to tarpaulin/grcov).
+
+```bash
+# One-time: rustup component add llvm-tools-preview
+#           cargo install cargo-llvm-cov cargo-nextest --locked
+bash scripts/coverage.sh
+```
+
+HTML output lands in `coverage/local/html/`. Per-crate floors live in [`coverage/baseline.json`](./coverage/baseline.json) and are shown on the README badge via [`coverage/badge.json`](./coverage/badge.json).
+
+**Soft PR policy:** changing a crate must not reduce that crate’s line coverage vs the baseline. CI posts a comment / `::warning::` annotation on regressions but does **not** fail the job yet, and there is no repo-wide percentage hard gate. See [`coverage/README.md`](./coverage/README.md).
 
 ### Lint
 
 ```bash
-cargo clippy -- -D warnings
+cargo clippy --target wasm32v1-none -- -D warnings
 ```
 
 ### Check contract size

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Soroban smart contracts for the [InvoFi](https://github.com/Stellar-VaultLink/in
 [![CI](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/ci.yml/badge.svg)](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/ci.yml)
 [![Clippy](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/clippy.yml/badge.svg)](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/clippy.yml)
 [![Scout](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/scout-security-analysis.yml/badge.svg)](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/scout-security-analysis.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/Stellar-VaultLink/invofi-contracts/master/coverage/badge.json)](./coverage/README.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 
 ---
@@ -226,8 +227,11 @@ All contracts emit machine-readable `E_*` error codes (see [docs/error-codes.md]
 # Build
 cargo build --target wasm32v1-none --release
 
-# Run tests (110 tests across registry / financing / repayment / insurance / reputation)
-cargo test
+# Run tests (nextest in CI; cargo test also works)
+cargo nextest run --target "$(rustc -vV | sed -n 's/^host: //p')"
+
+# Line coverage (HTML + LCOV under coverage/local/)
+bash scripts/coverage.sh
 
 # Check WASM size stays under 256 KB
 bash scripts/check-size.sh
@@ -235,6 +239,8 @@ bash scripts/check-size.sh
 # Deploy to Testnet (requires stellar-cli)
 bash scripts/deploy.sh
 ```
+
+Per-crate coverage floors and the soft “no regression on touched crates” policy are documented in [`coverage/README.md`](./coverage/README.md).
 
 Or trigger the **[Deploy Contract](https://github.com/Stellar-VaultLink/invofi-contracts/actions/workflows/deploy-contract.yml)** GitHub Actions workflow for a one-click Testnet deploy.
 

--- a/coverage/README.md
+++ b/coverage/README.md
@@ -1,0 +1,36 @@
+# Coverage baseline
+
+Per-crate line-coverage floor used by the soft CI check in `.github/workflows/ci.yml`.
+
+| File | Purpose |
+|---|---|
+| `baseline.json` | Documented floors per crate + workspace figure |
+| `badge.json` | Shields.io endpoint payload rendered on the README |
+
+## Current baseline (2026-08-21)
+
+| Crate | Line coverage |
+|---|---:|
+| `invofi-common` | 81.36% |
+| `invofi-registry` | 98.68% |
+| `invofi-financing` | 96.39% |
+| `invofi-repayment` | 94.86% |
+| `invofi-insurance` | 83.38% |
+| `invofi-reputation` | 88.27% |
+| `invofi-integration` | 100.00% |
+| **workspace (weighted)** | **94.9%** |
+
+## Policy
+
+- **Touched crates only.** A PR that lowers line coverage on a crate it modified gets a warning annotation and a PR comment. Untouched crates are ignored.
+- **Not a hard gate (yet).** The coverage job stays green even when a regression is reported so we can establish signal before flipping the switch.
+- **No repo-wide % gate.** Do not add `--fail-under-lines` until the team agrees on a number.
+
+## Updating the baseline
+
+After you add tests and coverage goes up on `master`:
+
+1. Run `bash scripts/coverage.sh` locally (or copy numbers from the Coverage job summary).
+2. Update `crates.*` values and `workspace_lines_pct` in `baseline.json`.
+3. Update `badge.json` `message` / `color` to match the workspace figure.
+4. Commit with a message like `ci(coverage): raise baseline after <feature>`.

--- a/coverage/badge.json
+++ b/coverage/badge.json
@@ -1,0 +1,6 @@
+{
+  "schemaVersion": 1,
+  "label": "coverage",
+  "message": "94.9%",
+  "color": "brightgreen"
+}

--- a/coverage/baseline.json
+++ b/coverage/baseline.json
@@ -1,0 +1,14 @@
+{
+  "workspace_lines_pct": 94.9,
+  "updated": "2026-08-21",
+  "policy": "Soft gate: PRs must not reduce line coverage on touched crates relative to this baseline. Regressions produce a PR comment and ::warning:: annotations but do not fail CI yet. There is no repo-wide hard percentage gate. Update this file (and coverage/badge.json) when you intentionally raise the bar after adding tests.",
+  "crates": {
+    "invofi-common": 81.36,
+    "invofi-registry": 98.68,
+    "invofi-financing": 96.39,
+    "invofi-repayment": 94.86,
+    "invofi-insurance": 83.38,
+    "invofi-reputation": 88.27,
+    "invofi-integration": 100.0
+  }
+}

--- a/scripts/check-coverage-regression.sh
+++ b/scripts/check-coverage-regression.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# Soft coverage regression check for touched crates.
+#
+# Compares per-crate line coverage from an llvm-cov JSON summary (or LCOV)
+# against coverage/baseline.json. Regressions emit ::warning:: annotations and
+# (on pull_request) a sticky PR comment. Exit code is always 0 — this is not a
+# hard gate yet (see CONTRIBUTING.md).
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export ROOT
+BASELINE="${ROOT}/coverage/baseline.json"
+cd "$ROOT"
+
+if [[ ! -f "$BASELINE" ]]; then
+  echo "::error::Missing ${BASELINE}"
+  exit 1
+fi
+
+python3 - <<'PY'
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+root = Path(os.environ["ROOT"])
+baseline_path = root / "coverage" / "baseline.json"
+summary_json = root / "coverage-summary.json"
+lcov_path = root / "lcov.info"
+report_md = root / "coverage-report.md"
+
+baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+crate_baselines = baseline.get("crates", {})
+workspace_baseline = float(baseline.get("workspace_lines_pct", 0.0))
+
+# Map package name -> directory prefix under the repo root.
+PACKAGE_DIRS = {
+    "invofi-common": "common",
+    "invofi-registry": "registry",
+    "invofi-financing": "financing",
+    "invofi-repayment": "repayment",
+    "invofi-insurance": "insurance",
+    "invofi-reputation": "reputation",
+    "invofi-integration": "integration",
+}
+DIR_TO_PACKAGE = {v: k for k, v in PACKAGE_DIRS.items()}
+
+
+def coverage_from_lcov(path: Path):
+    """Return ({package: line_pct}, workspace_pct) aggregated from LCOV."""
+    covered: dict[str, int] = defaultdict(int)
+    total: dict[str, int] = defaultdict(int)
+    current_pkg = None
+    if not path.is_file():
+        return {}, None
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        if line.startswith("SF:"):
+            sf = line[3:].replace("\\", "/")
+            current_pkg = None
+            for pkg, directory in PACKAGE_DIRS.items():
+                # Match "/registry/src/..." or "registry/src/..."
+                if re.search(rf"(^|/)({re.escape(directory)})/", sf):
+                    current_pkg = pkg
+                    break
+        elif line.startswith("LF:") and current_pkg:
+            total[current_pkg] += int(line[3:])
+        elif line.startswith("LH:") and current_pkg:
+            covered[current_pkg] += int(line[3:])
+        elif line.strip() == "end_of_record":
+            current_pkg = None
+    out = {}
+    for pkg, lf in total.items():
+        if lf == 0:
+            continue
+        out[pkg] = round(100.0 * covered[pkg] / lf, 2)
+    ws_lf = sum(total.values())
+    ws_lh = sum(covered.values())
+    workspace = round(100.0 * ws_lh / ws_lf, 2) if ws_lf else None
+    return out, workspace
+
+
+def coverage_from_json(path: Path) -> tuple[dict[str, float], float | None]:
+    """Best-effort parse of cargo-llvm-cov --json-summary-path output."""
+    if not path.is_file():
+        return {}, None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    per_crate: dict[str, float] = {}
+    workspace = None
+
+    # Format A: {"data":[{"totals":{"lines":{"percent":..}},"files":[...]}]}
+    if isinstance(data, dict) and "data" in data:
+        for entry in data["data"]:
+            totals = entry.get("totals") or {}
+            lines = totals.get("lines") or {}
+            if "percent" in lines and workspace is None:
+                workspace = float(lines["percent"])
+            for f in entry.get("files") or []:
+                filename = (f.get("filename") or "").replace("\\", "/")
+                pkg = None
+                for name, directory in PACKAGE_DIRS.items():
+                    if re.search(rf"(^|/)({re.escape(directory)})/", filename):
+                        pkg = name
+                        break
+                if not pkg:
+                    continue
+                flines = (f.get("summary") or f.get("totals") or {}).get("lines") or {}
+                if "percent" in flines:
+                    # Average later via weighted? Use running sum of covered/count if present.
+                    pass
+                count = int(flines.get("count") or 0)
+                covered = int(flines.get("covered") or 0)
+                if count:
+                    # accumulate in side maps
+                    per_crate.setdefault(pkg, [0, 0])
+                    if isinstance(per_crate[pkg], list):
+                        per_crate[pkg][0] += covered
+                        per_crate[pkg][1] += count
+        resolved = {}
+        for pkg, val in per_crate.items():
+            if isinstance(val, list) and val[1]:
+                resolved[pkg] = round(100.0 * val[0] / val[1], 2)
+        return resolved, workspace
+
+    # Format B: flat {"invofi-registry": {"lines": 90.1}, "total": {...}}
+    if isinstance(data, dict):
+        for key, val in data.items():
+            if key in PACKAGE_DIRS and isinstance(val, dict):
+                pct = val.get("lines") or val.get("line_pct") or val.get("percent")
+                if pct is not None:
+                    per_crate[key] = round(float(pct), 2)
+            if key in ("total", "totals", "workspace") and isinstance(val, dict):
+                pct = val.get("lines") or val.get("line_pct") or val.get("percent")
+                if pct is not None:
+                    workspace = float(pct)
+        if per_crate:
+            return per_crate, workspace
+
+    return {}, workspace
+
+
+per_crate, workspace_pct = coverage_from_json(summary_json)
+if not per_crate:
+    per_crate, workspace_pct = coverage_from_lcov(lcov_path)
+if workspace_pct is None and per_crate:
+    # Unweighted mean as a last-resort display figure.
+    workspace_pct = round(sum(per_crate.values()) / len(per_crate), 2)
+
+# Determine touched packages from the PR/push diff.
+event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+base_ref = os.environ.get("GITHUB_BASE_REF") or "master"
+changed_files: list[str] = []
+try:
+    if event_name == "pull_request":
+        merge_base = subprocess.check_output(
+            ["git", "merge-base", f"origin/{base_ref}", "HEAD"],
+            text=True,
+        ).strip()
+        changed_files = subprocess.check_output(
+            ["git", "diff", "--name-only", merge_base, "HEAD"],
+            text=True,
+        ).splitlines()
+    else:
+        # Push to master: compare against previous commit when available.
+        try:
+            changed_files = subprocess.check_output(
+                ["git", "diff", "--name-only", "HEAD~1", "HEAD"],
+                text=True,
+            ).splitlines()
+        except subprocess.CalledProcessError:
+            changed_files = []
+except subprocess.CalledProcessError:
+    changed_files = []
+
+touched_pkgs: set[str] = set()
+for path in changed_files:
+    top = path.replace("\\", "/").split("/", 1)[0]
+    if top in DIR_TO_PACKAGE:
+        touched_pkgs.add(DIR_TO_PACKAGE[top])
+
+lines = []
+lines.append("## Coverage report")
+lines.append("")
+lines.append(f"Workspace line coverage: **{workspace_pct if workspace_pct is not None else 'n/a'}%** "
+             f"(baseline {workspace_baseline}%)")
+lines.append("")
+lines.append("| Crate | Current | Baseline | Δ | Touched |")
+lines.append("|---|---:|---:|---:|:---:|")
+
+regressions: list[tuple[str, float, float]] = []
+for pkg in sorted(crate_baselines.keys()):
+    base = float(crate_baselines[pkg])
+    cur = per_crate.get(pkg)
+    touched = pkg in touched_pkgs
+    if cur is None:
+        delta = "n/a"
+        cur_s = "n/a"
+    else:
+        d = round(cur - base, 2)
+        delta = f"{d:+.2f}"
+        cur_s = f"{cur:.2f}%"
+        if touched and cur + 1e-9 < base:
+            regressions.append((pkg, cur, base))
+    lines.append(
+        f"| `{pkg}` | {cur_s} | {base:.2f}% | {delta} | {'yes' if touched else ''} |"
+    )
+
+lines.append("")
+lines.append(
+    "_Soft check only: regressions on touched crates are annotated and "
+    "commented, but do not fail CI yet._"
+)
+
+if regressions:
+    lines.append("")
+    lines.append("### Regressions on touched crates")
+    for pkg, cur, base in regressions:
+        msg = f"{pkg} coverage {cur:.2f}% is below baseline {base:.2f}%"
+        lines.append(f"- {msg}")
+        # GitHub Actions annotation (visible on the PR Checks UI).
+        print(f"::warning title=Coverage regression::{msg}")
+else:
+    if touched_pkgs:
+        lines.append("")
+        lines.append(
+            f"No coverage regressions on touched crates: "
+            f"{', '.join(sorted(touched_pkgs))}."
+        )
+    else:
+        lines.append("")
+        lines.append("No contract crates touched in this change set.")
+
+report = "\n".join(lines) + "\n"
+report_md.write_text(report, encoding="utf-8")
+summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+if summary_path:
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write(report)
+
+print(report)
+
+# Optional PR comment (never fails the job).
+if event_name == "pull_request" and os.environ.get("GH_TOKEN"):
+    try:
+        pr = os.environ.get("GITHUB_REF_NAME", "").replace("/merge", "")
+        # Prefer number from event payload when available.
+        event_path = os.environ.get("GITHUB_EVENT_PATH")
+        pr_number = None
+        if event_path and Path(event_path).is_file():
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+            pr_number = (event.get("number")
+                         or (event.get("pull_request") or {}).get("number"))
+        if pr_number:
+            body = (
+                "<!-- invofi-coverage-bot -->\n"
+                + report
+                + "\nSee `coverage/baseline.json` and CONTRIBUTING.md "
+                "for how the baseline is maintained.\n"
+            )
+            # Upsert: delete prior bot comments then post fresh.
+            existing = subprocess.check_output(
+                [
+                    "gh", "api",
+                    f"repos/{os.environ['GITHUB_REPOSITORY']}/issues/{pr_number}/comments",
+                    "--jq",
+                    '.[] | select(.body | contains("invofi-coverage-bot")) | .id',
+                ],
+                text=True,
+            ).splitlines()
+            for cid in existing:
+                cid = cid.strip()
+                if cid:
+                    subprocess.run(
+                        [
+                            "gh", "api", "-X", "DELETE",
+                            f"repos/{os.environ['GITHUB_REPOSITORY']}/issues/comments/{cid}",
+                        ],
+                        check=False,
+                    )
+            subprocess.run(
+                [
+                    "gh", "pr", "comment", str(pr_number),
+                    "--body", body,
+                ],
+                check=False,
+            )
+    except Exception as exc:  # noqa: BLE001 — soft path
+        print(f"Note: could not post PR comment ({exc})", file=sys.stderr)
+
+# Soft gate: always succeed.
+sys.exit(0)
+PY

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run the workspace test suite under cargo-llvm-cov + nextest and print a
+# per-crate summary. Overrides any WASM default target so coverage is collected
+# on the host (same as CI).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+HOST="$(rustc -vV | sed -n 's/^host: //p')"
+OUT_DIR="${ROOT}/coverage/local"
+mkdir -p "$OUT_DIR"
+
+PROPTEST_CASES="${PROPTEST_CASES:-256}"
+export PROPTEST_CASES
+
+echo "==> Collecting coverage on ${HOST} (PROPTEST_CASES=${PROPTEST_CASES})"
+# Emit LCOV in the same invocation that runs tests. Splitting into
+# `--no-report` + `report` fails when `--target` is set (object path mismatch).
+cargo llvm-cov nextest \
+  --workspace \
+  --target "$HOST" \
+  --lcov \
+  --output-path "${OUT_DIR}/lcov.info" \
+  --summary-only \
+  | tee "${OUT_DIR}/summary.txt"
+
+echo
+echo "LCOV: ${OUT_DIR}/lcov.info"
+echo "Text: ${OUT_DIR}/summary.txt"
+echo
+echo "Compare against coverage/baseline.json before opening a PR that touches"
+echo "money-moving crates. Soft CI check warns if touched-crate coverage drops."
+echo "Optional HTML: cargo llvm-cov report --html --output-dir coverage/local/html"
+echo "(only works if you re-run without --target, or from a host-default build)."


### PR DESCRIPTION
## Summary

- Switch the CI **Test** job from serial `cargo test` to **cargo-nextest** (same assertions, parallel).
- Add a **Coverage** job using `cargo llvm-cov nextest` that uploads LCOV, posts a soft regression report for **touched crates only** (PR comment + `::warning::` annotations â€” no hard fail / no repo-wide % gate).
- Document local nextest + coverage flows in `CONTRIBUTING.md`, publish a shields badge via `coverage/badge.json`, and commit a per-crate baseline in `coverage/baseline.json` (workspace **94.9%**).

## Test plan

- [x] `cargo nextest run --workspace` â€” **260/260 passed** (WSL / Linux host target)
- [x] `bash scripts/coverage.sh` â€” LCOV produced; soft check matches baseline per crate
- [ ] CI on this PR: Test (nextest), Coverage, Build WASM, commitlint all green

## Notes

- Soft gate only on crates touched by the PR diff vs `master`.
- Update `coverage/baseline.json` + `coverage/badge.json` when intentionally raising the floor after adding tests.

Closes: #126 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated test coverage collection and reporting for CI.
  * Added coverage artifacts, badges, per-crate baselines, and regression warnings.
  * Added parallel test execution for faster CI runs.

* **Documentation**
  * Updated development and contribution guides with testing and coverage instructions.
  * Added coverage policy and baseline documentation.
  * Documented the changes in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->