### PR TITLE
feat(admin): add multisig admin governance

### DIFF
--- a/.github/workflows/deploy-contract.yml
+++ b/.github/workflows/deploy-contract.yml
@@ -69,6 +69,9 @@ jobs:
           XLM_TOKEN=$(stellar contract id asset --asset native --network ${{ inputs.network }})
           USDC_TOKEN=$(stellar contract id asset --asset USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5 --network ${{ inputs.network }})
 
+          # Constructors still take a single --admin: they only ever bind
+          # single-admin bootstrap mode (ADR-0010). Multisig, if wanted, is
+          # opted into post-deploy via set_signers.
           REGISTRY_ID=$(stellar contract deploy --wasm target/wasm32v1-none/release/invofi_registry.wasm --source invofi-deployer --network ${{ inputs.network }} -- --admin "$ADMIN_PUBLIC")
           FINANCING_ID=$(stellar contract deploy --wasm target/wasm32v1-none/release/invofi_financing.wasm --source invofi-deployer --network ${{ inputs.network }} -- --admin "$ADMIN_PUBLIC" --registry "$REGISTRY_ID" --token "$XLM_TOKEN")
           REPAYMENT_ID=$(stellar contract deploy --wasm target/wasm32v1-none/release/invofi_repayment.wasm --source invofi-deployer --network ${{ inputs.network }} -- --admin "$ADMIN_PUBLIC" --registry "$REGISTRY_ID" --financing "$FINANCING_ID" --token "$XLM_TOKEN")
@@ -114,12 +117,18 @@ jobs:
 
           # No initialize() calls: constructors already bound admin/wiring at
           # deploy. Only the admin-gated cross-contract wiring remains.
+          #
+          # Every admin-gated entry point now takes --signers, a JSON array of
+          # signer addresses (ADR-0010). A freshly deployed contract is in
+          # single-admin bootstrap mode, so a one-element array containing the
+          # constructor's admin is both necessary and sufficient here.
+          SIGNERS="[\"$ADMIN_PUBLIC\"]"
 
-          stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_financing_contract --admin "$ADMIN_PUBLIC" --financing "$FINANCING_ID"
-          stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_repayment_contract --admin "$ADMIN_PUBLIC" --repayment "$REPAYMENT_ID"
-          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_repayment_contract --admin "$ADMIN_PUBLIC" --repayment "$REPAYMENT_ID"
-          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- register_currency --admin "$ADMIN_PUBLIC" --currency XLM --token_addr "$XLM_TOKEN"
-          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- register_currency --admin "$ADMIN_PUBLIC" --currency USDC --token_addr "$USDC_TOKEN"
+          stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_financing_contract --signers "$SIGNERS" --financing "$FINANCING_ID"
+          stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_repayment_contract --signers "$SIGNERS" --repayment "$REPAYMENT_ID"
+          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_repayment_contract --signers "$SIGNERS" --repayment "$REPAYMENT_ID"
+          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- register_currency --signers "$SIGNERS" --currency XLM --token_addr "$XLM_TOKEN"
+          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- register_currency --signers "$SIGNERS" --currency USDC --token_addr "$USDC_TOKEN"
 
           # Position token: POS is deterministic per issuer, so compute its ID and
           # only deploy if missing (a re-run with the same deployer reuses the
@@ -133,14 +142,14 @@ jobs:
           # to an older financing contract, the step fails loudly with a clear
           # message rather than silently minting from the wrong admin.
           stellar contract invoke --id "$POS_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_admin --new_admin "$FINANCING_ID"
-          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_position_token --admin "$ADMIN_PUBLIC" --token "$POS_ID"
+          stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_position_token --signers "$SIGNERS" --token "$POS_ID"
 
           # Insurance payout caller + reputation recorder: repayment is the only
           # authorized caller on both.
-          stellar contract invoke --id "$REPAYMENT_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_insurance --admin "$ADMIN_PUBLIC" --insurance "$INSURANCE_ID"
-          stellar contract invoke --id "$REPAYMENT_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_reputation --admin "$ADMIN_PUBLIC" --reputation "$REPUTATION_ID"
-          stellar contract invoke --id "$INSURANCE_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_payout_caller --admin "$ADMIN_PUBLIC" --payout_caller "$REPAYMENT_ID"
-          stellar contract invoke --id "$REPUTATION_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_recorder --admin "$ADMIN_PUBLIC" --recorder "$REPAYMENT_ID"
+          stellar contract invoke --id "$REPAYMENT_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_insurance --signers "$SIGNERS" --insurance "$INSURANCE_ID"
+          stellar contract invoke --id "$REPAYMENT_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_reputation --signers "$SIGNERS" --reputation "$REPUTATION_ID"
+          stellar contract invoke --id "$INSURANCE_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_payout_caller --signers "$SIGNERS" --payout_caller "$REPAYMENT_ID"
+          stellar contract invoke --id "$REPUTATION_ID" --source invofi-deployer --network ${{ inputs.network }} -- set_recorder --signers "$SIGNERS" --recorder "$REPAYMENT_ID"
 
           echo "position_token_id=$POS_ID" >> "$GITHUB_OUTPUT"
           echo "position_token=$POS_ID" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -227,25 +227,31 @@ jobs:
             --asset USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN \
             --network "$NETWORK")
 
-          stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer \
-            --network "$NETWORK" \
-            -- set_financing_contract --admin "$ADMIN_PUBLIC" --financing "$FINANCING_ID"
+          # Every admin-gated entry point now takes --signers, a JSON array of
+          # signer addresses (ADR-0010). A freshly deployed contract is in
+          # single-admin bootstrap mode, so a one-element array containing the
+          # constructor's admin is both necessary and sufficient here.
+          SIGNERS="[\"$ADMIN_PUBLIC\"]"
 
           stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_repayment_contract --admin "$ADMIN_PUBLIC" --repayment "$REPAYMENT_ID"
+            -- set_financing_contract --signers "$SIGNERS" --financing "$FINANCING_ID"
+
+          stellar contract invoke --id "$REGISTRY_ID" --source invofi-deployer \
+            --network "$NETWORK" \
+            -- set_repayment_contract --signers "$SIGNERS" --repayment "$REPAYMENT_ID"
 
           stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_repayment_contract --admin "$ADMIN_PUBLIC" --repayment "$REPAYMENT_ID"
+            -- set_repayment_contract --signers "$SIGNERS" --repayment "$REPAYMENT_ID"
 
           stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- register_currency --admin "$ADMIN_PUBLIC" --currency XLM --token_addr "$XLM_TOKEN"
+            -- register_currency --signers "$SIGNERS" --currency XLM --token_addr "$XLM_TOKEN"
 
           stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- register_currency --admin "$ADMIN_PUBLIC" --currency USDC --token_addr "$USDC_TOKEN"
+            -- register_currency --signers "$SIGNERS" --currency USDC --token_addr "$USDC_TOKEN"
 
           # Position token (POS): deploy SAC if absent, then hand admin to financing.
           POS_ID=$(stellar contract id asset \
@@ -260,21 +266,21 @@ jobs:
             -- set_admin --new_admin "$FINANCING_ID"
           stellar contract invoke --id "$FINANCING_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_position_token --admin "$ADMIN_PUBLIC" --token "$POS_ID"
+            -- set_position_token --signers "$SIGNERS" --token "$POS_ID"
 
           # Insurance payout caller + reputation recorder
           stellar contract invoke --id "$REPAYMENT_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_insurance --admin "$ADMIN_PUBLIC" --insurance "$INSURANCE_ID"
+            -- set_insurance --signers "$SIGNERS" --insurance "$INSURANCE_ID"
           stellar contract invoke --id "$REPAYMENT_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_reputation --admin "$ADMIN_PUBLIC" --reputation "$REPUTATION_ID"
+            -- set_reputation --signers "$SIGNERS" --reputation "$REPUTATION_ID"
           stellar contract invoke --id "$INSURANCE_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_payout_caller --admin "$ADMIN_PUBLIC" --payout_caller "$REPAYMENT_ID"
+            -- set_payout_caller --signers "$SIGNERS" --payout_caller "$REPAYMENT_ID"
           stellar contract invoke --id "$REPUTATION_ID" --source invofi-deployer \
             --network "$NETWORK" \
-            -- set_recorder --admin "$ADMIN_PUBLIC" --recorder "$REPAYMENT_ID"
+            -- set_recorder --signers "$SIGNERS" --recorder "$REPAYMENT_ID"
 
           echo "position_token_id=$POS_ID" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and are enforced by commitlint in CI.
 ## [Unreleased]
 
 ### Added
+- **M-of-N admin governance / multisig (issue #50)** — every contract's admin
+  surface (`set_*`, `pause`/`unpause`, `resolve_dispute`, `transfer_admin`) is
+  now gated by a threshold over a configurable set of signer addresses
+  (`AdminConfig { signers, threshold }` in `invofi_common`) instead of a
+  single stored `Address`. A call is authorized once `threshold` distinct
+  configured signers each `require_auth` within the same transaction — no
+  on-chain proposal queue, same "same-block" philosophy as the pause
+  mechanism (ADR-0001). Every constructor still takes one `admin: Address`
+  and boots into single-admin mode (`signers: [admin], threshold: 1`), which
+  behaves identically to the old single-admin check; a deployment opts into
+  true M-of-N post-deploy via the new `set_signers`. Design, alternatives,
+  and the redeploy-based migration path for already-deployed instances are in
+  `docs/adr/0010-multisig-admin-governance.md`.
+  - **Breaking ABI change**: every admin-gated function's first argument
+    changes from `admin: Address` to `signers: Vec<Address>`. CLI callers
+    (`deploy-contract.yml`, `scripts/deploy.sh`) pass a one-element JSON array
+    (`--signers '["G..."]'`) for bootstrap-mode deployments.
+  - New per-contract getters: `get_admin_config`, `get_signers`,
+    `get_threshold`. `get_admin` is kept for backward compatibility and now
+    returns the primary signer (`signers[0]`).
 - **CI: cargo-nextest + line coverage** — the Test job runs the full suite under
   [nextest](https://nexte.st/) (parallel, same assertions). A Coverage job uses
   `cargo llvm-cov nextest`, publishes LCOV/Codecov artifacts, and soft-checks

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -9,6 +9,7 @@
 
 use soroban_sdk::{
     contractclient, contracterror, contracttype, symbol_short, Address, BytesN, Env, Map, Symbol,
+    Vec,
 };
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -68,6 +69,11 @@ pub const MAX_VERIFICATION_FEE_BPS: u32 = 500;
 
 /// Maximum size of the trusted verifier set.
 pub const MAX_VERIFIERS: u32 = 20;
+
+/// Maximum number of signers an `AdminConfig` may hold. Every threshold
+/// check walks the signer set, so this bounds that loop the same way
+/// `MAX_VERIFIERS` bounds the verifier one.
+pub const MAX_ADMIN_SIGNERS: u32 = 20;
 
 /// Maximum attestations retained per invoice. One per (verifier, type) keeps
 /// this at `MAX_VERIFIERS x 3` for the current verifier set; the cap also
@@ -516,6 +522,124 @@ pub fn assert_not_paused(env: &Env) {
 
 // ─── Invoice State Machine ────────────────────────────────────────────────────
 
+// ─── Multisig Admin Governance (ADR-0010) ─────────────────────────────────────
+//
+// Every `assert_admin`-style check across the five contracts used to compare
+// the caller against one stored `Address`. This section replaces that with an
+// M-of-N threshold over a configurable set of signer addresses, following the
+// same "same-block, no timelock" philosophy as the pause mechanism
+// (ADR-0001): a call that already carries `threshold` valid signer
+// authorizations executes immediately, in the same transaction, with no
+// on-chain proposal queue to track.
+//
+// `AdminConfig { signers: [admin], threshold: 1 }` — one signer, threshold
+// one — is single-admin bootstrap mode, and is what every constructor sets up
+// by default. Under it, a threshold-gated call takes a one-element
+// `Vec<Address>` and behaves exactly like the legacy single-admin check: the
+// sole signer's authorization is both necessary and sufficient. Moving to a
+// true M-of-N is a post-deploy admin action (`set_signers`, threshold-gated
+// like everything else here), never a redeploy.
+
+/// M-of-N admin governance config: `threshold` distinct, authorized addresses
+/// out of `signers` are required to authorize any admin-gated call.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminConfig {
+    pub signers: Vec<Address>,
+    pub threshold: u32,
+}
+
+/// One-time setup: writes single-admin bootstrap config (`[admin]`,
+/// threshold 1). Called from each contract's constructor in place of the old
+/// `storage().instance().set(&symbol_short!("admin"), &admin)`. Panics if a
+/// config already exists — constructors run at most once (see ADR-0005).
+pub fn init_admin_config(env: &Env, admin: &Address) {
+    if env.storage().instance().has(&symbol_short!("admcfg")) {
+        panic!("Already initialized");
+    }
+    let mut signers = Vec::new(env);
+    signers.push_back(admin.clone());
+    save_admin_config(
+        env,
+        &AdminConfig {
+            signers,
+            threshold: 1,
+        },
+    );
+}
+
+/// Load the current admin config. Panics if the contract was never
+/// initialized (pre-ADR-0010 instances that have not run `migrate_admin` —
+/// see the migration note in `docs/adr/0010-multisig-admin-governance.md`).
+pub fn load_admin_config(env: &Env) -> AdminConfig {
+    env.storage()
+        .instance()
+        .get(&symbol_short!("admcfg"))
+        .unwrap_or_else(|| panic!("Not initialized"))
+}
+
+/// Persist an admin config. `pub` so `set_signers` (and the one-time
+/// `migrate_admin` path) can write it from each contract; every other
+/// mutation goes through `assert_threshold` first.
+pub fn save_admin_config(env: &Env, cfg: &AdminConfig) {
+    env.storage().instance().set(&symbol_short!("admcfg"), cfg);
+}
+
+/// True if `who` is a member of `cfg.signers`.
+pub fn is_signer(cfg: &AdminConfig, who: &Address) -> bool {
+    cfg.signers.iter().any(|s| s == *who)
+}
+
+/// Validates a candidate `(signers, threshold)` pair before it is written by
+/// `set_signers`: non-empty, threshold in `[1, signers.len()]`, no duplicate
+/// address, and bounded by `MAX_ADMIN_SIGNERS`. A threshold above the signer
+/// count would make the config permanently unsatisfiable; a duplicate would
+/// let one key count twice toward it.
+pub fn validate_signers(env: &Env, signers: &Vec<Address>, threshold: u32) {
+    if signers.is_empty() || signers.len() > MAX_ADMIN_SIGNERS {
+        env.panic_with_error(ContractError::InvalidInput);
+    }
+    if threshold == 0 || threshold > signers.len() {
+        env.panic_with_error(ContractError::InvalidInput);
+    }
+    for (i, a) in signers.iter().enumerate() {
+        for (j, b) in signers.iter().enumerate() {
+            if i != j && a == b {
+                env.panic_with_error(ContractError::InvalidInput);
+            }
+        }
+    }
+}
+
+/// The core threshold check. Requires every address in `provided` to be a
+/// distinct member of `cfg.signers` and to authorize this invocation
+/// (`require_auth`), and requires at least `cfg.threshold` of them. Panics
+/// with `Unauthorized` otherwise.
+///
+/// Soroban lets a single transaction carry a separate signed authorization
+/// entry per address, so `provided` being fully authorized means every one
+/// of those signers actually co-signed *this* call, in this same
+/// transaction — there is no separate on-chain approval step to replay or to
+/// front-run.
+pub fn assert_threshold(env: &Env, cfg: &AdminConfig, provided: &Vec<Address>) {
+    let mut counted: Vec<Address> = Vec::new(env);
+    for who in provided.iter() {
+        if !is_signer(cfg, &who) {
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+        if counted.iter().any(|c| c == who) {
+            // Duplicate entry — would otherwise let one signature count
+            // twice toward the threshold.
+            env.panic_with_error(ContractError::Unauthorized);
+        }
+        who.require_auth();
+        counted.push_back(who);
+    }
+    if counted.len() < cfg.threshold {
+        env.panic_with_error(ContractError::Unauthorized);
+    }
+}
+
 // ─── Cross-Contract Interface ────────────────────────────────────────────────
 // Financing calls these methods on the Registry contract.
 
@@ -783,9 +907,7 @@ mod transition_tests {
 
 // ─── State Machine State Validation and Enforcement ──────────────────────────
 
-use soroban_sdk::Vec;
-
-/// Validates and executes an invoice state transition. Emits a structured 
+/// Validates and executes an invoice state transition. Emits a structured
 /// transition event and records the transition in the history log.
 /// 
 /// This is the single point of authority for all invoice status changes across

--- a/docs/adr/0010-multisig-admin-governance.md
+++ b/docs/adr/0010-multisig-admin-governance.md
@@ -1,0 +1,196 @@
+# ADR-0010: M-of-N Admin Governance (Multisig)
+
+- Status: Accepted
+- Date: 2026-08-22
+
+## Context
+
+Every InvoFi contract — registry, financing, repayment, insurance, reputation
+— binds a single admin `Address` at deploy (ADR-0005) and gates every
+`set_*`, `pause`/`unpause`, `resolve_dispute`, and `transfer_admin` call on a
+single `require_auth()` check against that one address. ADR-0001 flagged this
+directly: "Admin is a single deployer key for now. Multisig / DAO admin is
+future scope; when it lands it replaces the `assert_admin` check, not the
+pause mechanism." This is that follow-through, tracked as a roadmap item
+(issue #50).
+
+The risk is concentration: one compromised key can pause the protocol,
+redirect cross-contract wiring (`set_financing_contract`,
+`set_payout_caller`, …), blacklist addresses, change fee/rate/penalty
+parameters, or hand admin to an attacker via `transfer_admin` — all in one
+transaction, with no second signer able to stop it.
+
+## Decision
+
+Replace the single stored admin `Address` with an `AdminConfig { signers:
+Vec<Address>, threshold: u32 }` in `invofi_common`, and change every
+admin-gated entry point's authorization parameter from a single `admin:
+Address` to a `signers: Vec<Address>`. A call is authorized once at least
+`threshold` *distinct* addresses in `signers` are (a) members of the
+configured signer set and (b) each present their own `require_auth()` inside
+that same invocation:
+
+```rust
+pub fn assert_threshold(env: &Env, cfg: &AdminConfig, provided: &Vec<Address>) {
+    let mut counted: Vec<Address> = Vec::new(env);
+    for who in provided.iter() {
+        if !is_signer(cfg, &who) { env.panic_with_error(ContractError::Unauthorized); }
+        if counted.iter().any(|c| c == who) { env.panic_with_error(ContractError::Unauthorized); }
+        who.require_auth();
+        counted.push_back(who);
+    }
+    if counted.len() < cfg.threshold { env.panic_with_error(ContractError::Unauthorized); }
+}
+```
+
+### Same-block, no on-chain proposal queue
+
+This mirrors ADR-0001's "same-block" philosophy rather than introducing a
+timelock or an on-chain propose/approve state machine. Soroban already lets a
+single transaction carry one signed authorization entry per address —
+`Address::require_auth()` verifies each entry independently. So an M-of-N
+call is simply a transaction whose `signers` argument lists `threshold` (or
+more) addresses, each of whom pre-signed their own authorization entry
+off-chain; a coordinator (any one signer, or a relayer) collects those
+entries and submits the combined transaction. There is no separate approval
+transaction to send, no proposal id to track, and nothing pending on-chain
+that a second attacker-controlled key could later push through alone — the
+whole action either has enough valid signatures *in this transaction* or it
+reverts with no state change at all.
+
+An async on-chain proposal queue (open a proposal, have other signers approve
+it in separate transactions over time) was considered and rejected for this
+stage: it adds persistent proposal storage, replay/expiry bookkeeping, and a
+second class of "pending but not yet authorized" state to reason about, for a
+capability (asynchronous, non-atomic approval) the emergency-pause philosophy
+already argues against. It remains a reasonable future extension if
+real-world signer coordination turns out to need it.
+
+### Single-admin bootstrap mode
+
+`AdminConfig { signers: [admin], threshold: 1 }` — one signer, threshold one
+— is **single-admin bootstrap mode**, and it is what every constructor sets
+up by default via `invofi_common::init_admin_config`:
+
+```rust
+pub fn __constructor(env: Env, admin: Address) {
+    invofi_common::init_admin_config(&env, &admin);
+}
+```
+
+Under bootstrap mode, every threshold-gated call takes a one-element
+`Vec<Address>` containing the sole signer and behaves exactly like the old
+single-admin check — same authorization outcome, same events, same storage
+writes. A deployment stays in this mode until an admin deliberately opts into
+true M-of-N.
+
+### Opting into true M-of-N
+
+Each contract exposes `set_signers(signers: Vec<Address>, new_signers:
+Vec<Address>, new_threshold: u32)`, itself threshold-gated by the *current*
+config. This is the only way to add signers or raise the threshold — there is
+no separate "add signer" call that a single key could invoke unilaterally
+once a deployment has moved beyond bootstrap. `invofi_common::validate_signers`
+enforces: non-empty, `1 <= new_threshold <= new_signers.len()`, no duplicate
+address, and a `MAX_ADMIN_SIGNERS` (20) cap so the threshold check's loop
+stays bounded (same reasoning as `MAX_VERIFIERS` — see ADR-0009).
+
+`transfer_admin(signers: Vec<Address>, new_admin: Address)` keeps its
+original meaning as a full handoff / disaster-recovery escape hatch: it
+collapses the *entire* config to a single new signer at threshold 1
+(`AdminConfig { signers: [new_admin], threshold: 1 }`), gated by the outgoing
+config's threshold. Reconfiguring to a different M-of-N set (add/remove
+signers, change the threshold without collapsing to one) goes through
+`set_signers` instead.
+
+### What moved and what didn't
+
+Every function that used to take `admin: Address` and compare it against the
+stored admin now takes `signers: Vec<Address>` and calls `assert_admin`
+(a thin per-contract wrapper around `assert_threshold`):
+
+- **Registry**: `transfer_admin`, `set_signers` (new), `set_financing_contract`,
+  `set_repayment_contract`, `pause`, `unpause`, `set_rate`, `set_fee`,
+  `resolve_dispute`, `blacklist_address`, `unblacklist_address`,
+  `add_verifier`, `remove_verifier`, `set_verifier_threshold`,
+  `set_verification_fee`, `set_attestation_validity`, `register_currency`.
+- **Financing**: `transfer_admin`, `set_signers` (new), `set_repayment_contract`,
+  `register_currency`, `set_position_token`, `pause`, `unpause`,
+  `set_negotiation_window`.
+- **Repayment**: `transfer_admin`, `set_signers` (new), `set_insurance`,
+  `set_reputation`, `set_penalty`, `pause`, `unpause`. (The protocol fee
+  recipient inside `repay_invoice`, previously the raw stored admin address,
+  now resolves to the primary signer — `AdminConfig.signers[0]` — which is
+  identical under bootstrap mode.)
+- **Insurance**: `transfer_admin`, `set_signers` (new), `set_staking_token`,
+  `set_payout_caller`, `set_registry`, `set_yield_rate`, `pause`, `unpause`.
+- **Reputation**: `transfer_admin` (new), `set_signers` (new), `set_recorder`,
+  `pause`, `unpause`, `resolve_dispute`.
+
+What did **not** move, per ADR-0001's own framing ("multisig... replaces the
+`assert_admin` check, not the pause mechanism"):
+
+- `assert_not_paused` and the `paused` flag are untouched — pausing is still
+  same-block and requires no separate unlock.
+- The `paused`/emergency-brake call itself is still one transaction; it is
+  the *authorization* on that transaction that now may require more than one
+  signature, not the mechanism.
+- Every non-admin authorization (originator, lender, verifier, cross-contract
+  implicit-invoker auth) is untouched.
+
+### New read surface
+
+Every contract gains `get_admin_config() -> AdminConfig`, `get_signers() ->
+Vec<Address>`, and `get_threshold() -> u32`. `get_admin() -> Address` is kept
+for backward compatibility and returns the *primary* signer
+(`signers[0]`) — safe to keep because no contract in this codebase calls
+`get_admin()` cross-contract for authorization (verified: it is a
+query-only, human/tooling-facing getter everywhere it is used); it is not a
+source of authority by itself under true M-of-N.
+
+## Migration path
+
+Soroban contracts here have no upgrade entrypoint (`update_current_contract_wasm`
+is not wired into any of the five contracts), so an already-deployed instance
+cannot gain this admin model in place — the same constraint ADR-0005 recorded
+for its own change ("Live instances deployed before this ADR remain
+admin-bound to the deployer"). The migration is:
+
+1. **Fresh deployments** build in single-admin bootstrap mode automatically —
+   the constructor is unchanged (`--admin <address>`), so `deploy-contract.yml`
+   and `scripts/deploy.sh` need no constructor changes.
+2. **Every admin-gated CLI invocation changes shape**: the `--admin <address>`
+   invoke argument becomes `--signers '["<address>"]'` (a JSON array). This
+   repo's deploy workflow (`.github/workflows/deploy-contract.yml`) is
+   updated accordingly as part of this change.
+3. **Existing testnet/mainnet instances deployed before this ADR** keep their
+   old single-`Address` admin storage layout and old function signatures —
+   this migration does not (and cannot, without an upgrade path) touch them.
+   Moving one to the new model means deploying a fresh instance with the
+   updated WASM and re-running the post-deploy wiring steps
+   (`set_financing_contract`, `set_repayment_contract`, `set_insurance`, …)
+   against the new instance, exactly as any other WASM upgrade in this
+   protocol would require today.
+4. **Opting into real M-of-N** on a freshly deployed (bootstrap-mode)
+   instance is a single post-deploy call: `set_signers(["<admin>"], [<n
+   addresses>], <threshold>)`, signed by the sole bootstrap admin.
+
+## Consequences
+
+- No compromised single key can unilaterally pause, reconfigure, or drain the
+  protocol on any deployment that has opted into `threshold > 1` — an
+  attacker needs `threshold` signer keys, not one.
+- Bootstrap deployments (the default, and every deployment until an operator
+  explicitly runs `set_signers`) are behaviourally identical to before this
+  ADR — same one-call UX, same events, same storage semantics — so this is
+  additive, not a functional regression for anyone who never configures
+  multisig.
+- Every admin-gated call site's argument list changed shape (`Address` →
+  `Vec<Address>`), which is a breaking ABI change for any off-chain caller
+  (CLI scripts, indexer, frontend) invoking those functions directly. This is
+  intentional and unavoidable for a real multisig — the whole point is that
+  more than one address may need to authorize a call — and is called out
+  explicitly rather than hidden behind an unchanged signature.
+- `MAX_ADMIN_SIGNERS` (20) bounds the threshold-check loop and the
+  `set_signers` validation loop, the same way `MAX_VERIFIERS` bounds the
+  verification oracle (ADR-0009).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ get the next number; append, never rewrite (status updates go in the file).
 | 0007 | [Overdue penalty interest](./0007-overdue-penalty-interest.md) | Proposed |
 | 0008 | [Offer amendment and counter-offer](./0008-offer-negotiation.md) | Proposed |
 | 0009 | [Invoice verification oracle](./0009-verification-oracle.md) | Proposed |
+| 0010 | [M-of-N admin governance (multisig)](./0010-multisig-admin-governance.md) | Accepted |
 
 App-layer decisions (wallet allowlist, indexer, SDK) live in the monorepo:
 [invofi/docs/adr](https://github.com/Stellar-VaultLink/invofi/tree/main/docs/adr).

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -6,13 +6,19 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, resolve_token, ContractError, FinancingOffer, Invoice, InvoiceStatus,
-    LenderStats, NegotiationParty, NegotiationRecord, NegotiationStatus, OfferStatus,
-    ProtocolStats, RegistryClient, RepaymentSchedule, ScheduleFrequency,
+    assert_not_paused, resolve_token, AdminConfig, ContractError, FinancingOffer, Invoice,
+    InvoiceStatus, LenderStats, NegotiationParty, NegotiationRecord, NegotiationStatus,
+    OfferStatus, ProtocolStats, RegistryClient, RepaymentSchedule, ScheduleFrequency,
     DEFAULT_NEGOTIATION_WINDOW_SECS, MAX_INTEREST_BPS, MAX_NEGOTIATION_ROUNDS,
     MAX_NEGOTIATION_WINDOW_SECS, MAX_OFFER_DURATION_SECS, MIN_NEGOTIATION_WINDOW_SECS,
     MIN_OFFER_DURATION_SECS,
 };
+
+/// Threshold-gated admin check (ADR-0010). See `invofi_common::assert_threshold`.
+fn assert_admin(env: &Env, signers: &Vec<Address>) {
+    let cfg = invofi_common::load_admin_config(env);
+    invofi_common::assert_threshold(env, &cfg, signers);
+}
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
 
@@ -182,12 +188,7 @@ impl FinancingContract {
     /// fresh deployment can never be hijacked by a third party setting
     /// themselves as admin.
     pub fn __constructor(env: Env, admin: Address, registry: Address, token: Address) {
-        if env.storage().instance().has(&symbol_short!("admin")) {
-            panic!("Already initialized");
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &admin);
+        invofi_common::init_admin_config(&env, &admin);
         env.storage()
             .instance()
             .set(&symbol_short!("registry"), &registry);
@@ -199,27 +200,56 @@ impl FinancingContract {
     /// Register the repayment contract address. Only admin.
     /// The repayment contract is the only caller authorized to invoke
     /// callback methods (update_offer_status, update_offer_amount_repaid, etc.).
-    pub fn set_repayment_contract(env: Env, admin: Address, repayment: Address) {
+    pub fn set_repayment_contract(env: Env, signers: Vec<Address>, repayment: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("repayment"), &repayment);
     }
 
+    /// Returns the primary admin address (the first configured signer). See
+    /// `RegistryContract::get_admin` for the same caveat under true M-of-N.
     pub fn get_admin(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("admin"))
+        invofi_common::load_admin_config(&env)
+            .signers
+            .get(0)
             .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// The full M-of-N admin governance config. See ADR-0010.
+    pub fn get_admin_config(env: Env) -> AdminConfig {
+        invofi_common::load_admin_config(&env)
+    }
+
+    /// The current signer set.
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        invofi_common::load_admin_config(&env).signers
+    }
+
+    /// The current approval threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        invofi_common::load_admin_config(&env).threshold
+    }
+
+    /// Reconfigure the admin signer set and threshold. See
+    /// `RegistryContract::set_signers`.
+    pub fn set_signers(
+        env: Env,
+        signers: Vec<Address>,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        invofi_common::validate_signers(&env, &new_signers, new_threshold);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: new_threshold,
+            },
+        );
     }
 
     pub fn get_registry(env: Env) -> Address {
@@ -229,37 +259,33 @@ impl FinancingContract {
             .unwrap_or_else(|| panic!("Not initialized"))
     }
 
-    /// Transfers admin rights. Only current admin.
-    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
+    /// Transfers admin rights, collapsing the config back to a single new
+    /// admin. See `RegistryContract::transfer_admin`.
+    pub fn transfer_admin(env: Env, signers: Vec<Address>, new_admin: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &new_admin);
+        assert_admin(&env, &signers);
+        let mut new_signers = Vec::new(&env);
+        new_signers.push_back(new_admin);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: 1,
+            },
+        );
     }
 
     // ── Currency registry ────────────────────────────────────────────────────
 
     /// Register a currency → token mapping. Admin only.
-    pub fn register_currency(env: Env, admin: Address, currency: Symbol, token_addr: Address) {
+    pub fn register_currency(
+        env: Env,
+        signers: Vec<Address>,
+        currency: Symbol,
+        token_addr: Address,
+    ) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         invofi_common::register_currency(&env, &currency, &token_addr);
     }
 
@@ -276,17 +302,9 @@ impl FinancingContract {
     /// its admin, so accept_offer can mint claim tokens on the lender's
     /// behalf (the token's admin.require_auth() resolves via implicit
     /// contract-invoker auth — see ADR-0002).
-    pub fn set_position_token(env: Env, admin: Address, token: Address) {
+    pub fn set_position_token(env: Env, signers: Vec<Address>, token: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("postok"), &token);
@@ -299,31 +317,15 @@ impl FinancingContract {
 
     // ── Pause / unpause ──────────────────────────────────────────────────────
 
-    pub fn pause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn pause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &true);
     }
 
-    pub fn unpause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn unpause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &false);
@@ -664,17 +666,9 @@ impl FinancingContract {
     ///
     /// Changing the window does not move the deadline of a negotiation that
     /// is already open: each deadline is frozen when its negotiation opens.
-    pub fn set_negotiation_window(env: Env, admin: Address, window_secs: u64) {
+    pub fn set_negotiation_window(env: Env, signers: Vec<Address>, window_secs: u64) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         if !(MIN_NEGOTIATION_WINDOW_SECS..=MAX_NEGOTIATION_WINDOW_SECS).contains(&window_secs) {
             env.panic_with_error(ContractError::InvalidInput);
         }

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -10,6 +10,15 @@ use soroban_sdk::{
     token, Address, Env, Symbol, TryFromVal,
 };
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 /// Deploy the registry + financing contracts and return both clients.
 /// The registry is initialized with `admin`; financing is wired to the
 /// registry address and the SEP-41 `token`.
@@ -30,7 +39,7 @@ fn setup_contracts<'a>(
 
     // Register financing as a trusted caller on the registry so its
     // cross-contract status transition (Pending -> Financed) is allowed.
-    registry_client.set_financing_contract(admin, &financing_id);
+    registry_client.set_financing_contract(&one(env, admin), &financing_id);
 
     (registry_client, financing_client)
 }
@@ -308,7 +317,7 @@ fn test_blacklisted_cannot_create_offer() {
         &3_000_000u64,
     );
     // Blacklist on registry, then try to create offer on financing
-    reg.blacklist_address(&admin, &lender);
+    reg.blacklist_address(&one(&env, &admin), &lender);
     fin.create_offer(
         &symbol_short!("off_bl2"),
         &symbol_short!("bl2"),
@@ -345,7 +354,7 @@ fn test_accept_offer() {
     );
     let fin = super::FinancingContractClient::new(&env, &financing_id);
 
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
 
     reg.register_invoice(
@@ -782,7 +791,7 @@ fn test_update_offer_status_and_amount_repaid() {
             Address::generate(&env),
         ),
     );
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Simulate repayment callback
     fin.update_offer_status(&symbol_short!("off_cr"), &OfferStatus::Financed);
@@ -834,7 +843,7 @@ fn test_update_lender_stats_repaid() {
             Address::generate(&env),
         ),
     );
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     fin.update_lender_stats_repaid(&lender, &true);
 
@@ -864,7 +873,7 @@ fn test_update_stats_repaid_and_get_fee_bps() {
             Address::generate(&env),
         ),
     );
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Simulate stats update
     fin.update_stats_repaid(&1_000_000i128, &50_000i128);
@@ -909,6 +918,53 @@ fn test_get_offer_duration_limits() {
     assert_eq!(max, invofi_common::MAX_OFFER_DURATION_SECS);
 }
 
+// ─── Multisig admin governance tests (ADR-0010) ─────────────────────────────
+
+#[test]
+fn test_financing_bootstrap_admin_config_defaults() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), Address::generate(&env), Address::generate(&env)),
+    );
+    let fin = super::FinancingContractClient::new(&env, &financing_id);
+
+    let cfg = fin.get_admin_config();
+    assert_eq!(cfg.signers.len(), 1);
+    assert_eq!(cfg.signers.get(0).unwrap(), admin);
+    assert_eq!(cfg.threshold, 1);
+}
+
+#[test]
+fn test_financing_set_signers_requires_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), Address::generate(&env), Address::generate(&env)),
+    );
+    let fin = super::FinancingContractClient::new(&env, &financing_id);
+
+    let b = Address::generate(&env);
+    let mut two_signers = soroban_sdk::Vec::new(&env);
+    two_signers.push_back(admin.clone());
+    two_signers.push_back(b.clone());
+    fin.set_signers(&one(&env, &admin), &two_signers, &2u32);
+
+    // A single signer is no longer sufficient once threshold is 2.
+    let result = fin.try_pause(&one(&env, &admin));
+    assert!(result.is_err());
+
+    let mut both = soroban_sdk::Vec::new(&env);
+    both.push_back(admin.clone());
+    both.push_back(b.clone());
+    fin.pause(&both);
+    assert!(fin.contract_is_paused());
+}
+
 // ─── Task 4A: emergency pause / circuit breaker ──────────────────────────────
 
 #[test]
@@ -933,7 +989,7 @@ fn test_pause_blocks_create_offer() {
         &3_000_000u64,
     );
 
-    fin.pause(&admin);
+    fin.pause(&one(&env, &admin));
     fin.create_offer(
         &symbol_short!("offp1"),
         &invoice_id,
@@ -958,7 +1014,7 @@ fn test_pause_blocks_all_financing_state_changes() {
     let repayment = Address::generate(&env);
     let pos_token = Address::generate(&env);
 
-    fin.pause(&admin);
+    fin.pause(&one(&env, &admin));
 
     fn assert_paused<F: FnOnce()>(f: F) {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
@@ -986,16 +1042,16 @@ fn test_pause_blocks_all_financing_state_changes() {
         fin.reject_offer(&symbol_short!("offx4"), &originator);
     });
     assert_paused(|| {
-        fin.set_repayment_contract(&admin, &repayment);
+        fin.set_repayment_contract(&one(&env, &admin), &repayment);
     });
     assert_paused(|| {
-        fin.transfer_admin(&admin, &new_admin);
+        fin.transfer_admin(&one(&env, &admin), &new_admin);
     });
     assert_paused(|| {
-        fin.register_currency(&admin, &symbol_short!("EUR"), &Address::generate(&env));
+        fin.register_currency(&one(&env, &admin), &symbol_short!("EUR"), &Address::generate(&env));
     });
     assert_paused(|| {
-        fin.set_position_token(&admin, &pos_token);
+        fin.set_position_token(&one(&env, &admin), &pos_token);
     });
     assert_paused(|| {
         fin.update_offer_status(&symbol_short!("offx5"), &OfferStatus::Rejected);
@@ -1045,9 +1101,9 @@ fn test_accept_offer_mints_position_token() {
     let pos_token_id = pos_sac.address();
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     assert!(fin.get_position_token().is_none());
-    fin.set_position_token(&admin, &pos_token_id);
+    fin.set_position_token(&one(&env, &admin), &pos_token_id);
     assert_eq!(fin.get_position_token(), Some(pos_token_id.clone()));
 
     reg.register_invoice(
@@ -1103,7 +1159,7 @@ fn test_accept_offer_without_position_token_still_works() {
     );
     let fin = super::FinancingContractClient::new(&env, &financing_id);
 
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
     assert!(fin.get_position_token().is_none());
 
@@ -1264,7 +1320,7 @@ fn test_off_schedule_repayment_does_not_corrupt_state() {
             Address::generate(&env),
         ),
     );
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Simulate an ad-hoc off-schedule partial repayment (42M — not a multiple
     // of installment_amount = 105M). State should remain readable and correct.
@@ -1416,7 +1472,7 @@ fn test_get_installment_due_zero_when_all_paid() {
             Address::generate(&env),
         ),
     );
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Simulate full coverage: 4 installments × installment_amount.
     fin.update_offer_amount_repaid(&symbol_short!("off_sc1"), &full_paid);
@@ -1541,7 +1597,7 @@ fn test_daily_frequency_period() {
             Address::generate(&env),
         ),
     );
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Mark installment 1 as paid.
     fin.update_offer_amount_repaid(&symbol_short!("off_sc1"), &sched.installment_amount);
@@ -1587,7 +1643,7 @@ fn setup_negotiation<'a>(
     );
     let fin = super::FinancingContractClient::new(env, &financing_id);
 
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     // The lender's standing allowance to the financing contract is their
     // pre-commitment: it is what makes auto-accept executable without a second
     // signature from them at match time.
@@ -2389,7 +2445,7 @@ fn test_amend_offer_is_pause_guarded() {
     let (_reg, fin, admin, _originator, lender, _token) =
         setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
 
-    fin.pause(&admin);
+    fin.pause(&one(&env, &admin));
     fin.amend_offer(
         &offer_id,
         &lender,
@@ -2412,7 +2468,7 @@ fn test_counter_offer_is_pause_guarded() {
     let (_reg, fin, admin, originator, _lender, _token) =
         setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
 
-    fin.pause(&admin);
+    fin.pause(&one(&env, &admin));
     fin.counter_offer(
         &offer_id,
         &originator,
@@ -2438,7 +2494,7 @@ fn test_negotiation_window_is_configurable_and_deadlines_are_frozen() {
 
     assert_eq!(fin.get_negotiation_window(), 259_200);
 
-    fin.set_negotiation_window(&admin, &7_200u64);
+    fin.set_negotiation_window(&one(&env, &admin), &7_200u64);
     assert_eq!(fin.get_negotiation_window(), 7_200);
 
     fin.amend_offer(
@@ -2453,7 +2509,7 @@ fn test_negotiation_window_is_configurable_and_deadlines_are_frozen() {
 
     // Widening the window afterwards must not resurrect a negotiation that is
     // already running against a frozen deadline.
-    fin.set_negotiation_window(&admin, &2_592_000u64);
+    fin.set_negotiation_window(&one(&env, &admin), &2_592_000u64);
     assert_eq!(fin.get_negotiation_deadline(&offer_id), 1_007_200);
     env.ledger().set_timestamp(1_007_201);
     assert_eq!(
@@ -2474,7 +2530,7 @@ fn test_set_negotiation_window_is_admin_only() {
     let (_reg, fin, _admin, _originator, lender, _token) =
         setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
 
-    fin.set_negotiation_window(&lender, &7_200u64);
+    fin.set_negotiation_window(&one(&env, &lender), &7_200u64);
 }
 
 #[test]
@@ -2489,7 +2545,7 @@ fn test_negotiation_window_below_minimum_panics() {
     let (_reg, fin, admin, _originator, _lender, _token) =
         setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
 
-    fin.set_negotiation_window(&admin, &3_599u64);
+    fin.set_negotiation_window(&one(&env, &admin), &3_599u64);
 }
 
 #[test]
@@ -2504,7 +2560,7 @@ fn test_negotiation_window_above_maximum_panics() {
     let (_reg, fin, admin, _originator, _lender, _token) =
         setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
 
-    fin.set_negotiation_window(&admin, &2_592_001u64);
+    fin.set_negotiation_window(&one(&env, &admin), &2_592_001u64);
 }
 
 // ── Events ───────────────────────────────────────────────────────────────────

--- a/insurance/src/lib.rs
+++ b/insurance/src/lib.rs
@@ -38,7 +38,13 @@
 
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Map, Symbol, Vec};
 
-use invofi_common::{assert_not_paused, ContractError, InvoiceStatus, RegistryClient};
+use invofi_common::{assert_not_paused, AdminConfig, ContractError, InvoiceStatus, RegistryClient};
+
+/// Threshold-gated admin check (ADR-0010). See `invofi_common::assert_threshold`.
+fn assert_admin(env: &Env, signers: &Vec<Address>) {
+    let cfg = invofi_common::load_admin_config(env);
+    invofi_common::assert_threshold(env, &cfg, signers);
+}
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -266,54 +272,77 @@ impl InsuranceContract {
     /// of the deploy operation, which only the deployer can authorize. There
     /// is therefore no separate initialize() call to front-run (issue #75).
     pub fn __constructor(env: Env, admin: Address, token: Address) {
-        if env.storage().instance().has(&symbol_short!("admin")) {
-            panic!("Already initialized");
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &admin);
+        invofi_common::init_admin_config(&env, &admin);
         env.storage()
             .instance()
             .set(&symbol_short!("token"), &token);
     }
 
+    /// Returns the primary admin address (the first configured signer). See
+    /// `RegistryContract::get_admin` for the same caveat under true M-of-N.
     pub fn get_admin(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("admin"))
+        invofi_common::load_admin_config(&env)
+            .signers
+            .get(0)
             .unwrap_or_else(|| panic!("Not initialized"))
     }
 
-    /// Transfers admin rights. Only current admin.
-    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
+    /// The full M-of-N admin governance config. See ADR-0010.
+    pub fn get_admin_config(env: Env) -> AdminConfig {
+        invofi_common::load_admin_config(&env)
+    }
+
+    /// The current signer set.
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        invofi_common::load_admin_config(&env).signers
+    }
+
+    /// The current approval threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        invofi_common::load_admin_config(&env).threshold
+    }
+
+    /// Reconfigure the admin signer set and threshold. See
+    /// `RegistryContract::set_signers`.
+    pub fn set_signers(
+        env: Env,
+        signers: Vec<Address>,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &new_admin);
+        assert_admin(&env, &signers);
+        invofi_common::validate_signers(&env, &new_signers, new_threshold);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: new_threshold,
+            },
+        );
+    }
+
+    /// Transfers admin rights, collapsing the config back to a single new
+    /// admin. See `RegistryContract::transfer_admin`.
+    pub fn transfer_admin(env: Env, signers: Vec<Address>, new_admin: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        let mut new_signers = Vec::new(&env);
+        new_signers.push_back(new_admin);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: 1,
+            },
+        );
     }
 
     /// Swap the staking token. Admin only. Existing stakes are not migrated —
     /// set this before opening the pool to stakers.
-    pub fn set_staking_token(env: Env, admin: Address, token: Address) {
+    pub fn set_staking_token(env: Env, signers: Vec<Address>, token: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("token"), &token);
@@ -326,17 +355,9 @@ impl InsuranceContract {
     /// Configure the address allowed to trigger payouts — this is the
     /// repayment contract. Admin only. Payouts are disabled until a caller
     /// is configured (fail-closed).
-    pub fn set_payout_caller(env: Env, admin: Address, payout_caller: Address) {
+    pub fn set_payout_caller(env: Env, signers: Vec<Address>, payout_caller: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paycall"), &payout_caller);
@@ -350,16 +371,8 @@ impl InsuranceContract {
     /// `pay_out`. Admin only. Payouts on Defaulted invoices are rejected
     /// with a clear error if the registry is not configured or if the
     /// invoice is not in the Defaulted state (fail-closed).
-    pub fn set_registry(env: Env, admin: Address, registry: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn set_registry(env: Env, signers: Vec<Address>, registry: Address) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("registry"), &registry);
@@ -381,17 +394,9 @@ impl InsuranceContract {
     /// yield accrued at the new rate since this call.
     ///
     /// Admin only. Rate may be set to 0 to disable yield entirely.
-    pub fn set_yield_rate(env: Env, admin: Address, rate_bps: u32) {
+    pub fn set_yield_rate(env: Env, signers: Vec<Address>, rate_bps: u32) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
 
         // Bank outstanding yield for every staker at the current rate before
         // the new rate takes effect. This is the key invariant: rate changes
@@ -417,31 +422,15 @@ impl InsuranceContract {
 
     // ── Pause / unpause (Task 4A circuit breaker) ───────────────────────────
 
-    pub fn pause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn pause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &true);
     }
 
-    pub fn unpause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn unpause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &false);

--- a/insurance/src/test.rs
+++ b/insurance/src/test.rs
@@ -5,6 +5,15 @@ extern crate std;
 use super::InsuranceContract;
 use soroban_sdk::{symbol_short, testutils::{Address as _, Ledger}, token, Address, Env};
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 /// Deploy the insurance contract + a staking token, and initialize.
 fn setup<'a>(
     env: &'a Env,
@@ -177,6 +186,31 @@ fn test_unstake_zero_panics() {
     client.unstake(&staker, &0);
 }
 
+// ─── Multisig admin governance tests (ADR-0010) ─────────────────────────────
+
+#[test]
+fn test_insurance_set_signers_requires_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let (_token_id, _insurance_id, client) = setup(&env, &admin);
+
+    let b = Address::generate(&env);
+    let mut two_signers = soroban_sdk::Vec::new(&env);
+    two_signers.push_back(admin.clone());
+    two_signers.push_back(b.clone());
+    client.set_signers(&one(&env, &admin), &two_signers, &2u32);
+
+    let result = client.try_pause(&one(&env, &admin));
+    assert!(result.is_err(), "one of two required signatures must not pause");
+
+    let mut both = soroban_sdk::Vec::new(&env);
+    both.push_back(admin.clone());
+    both.push_back(b.clone());
+    client.pause(&both);
+    assert!(client.contract_is_paused());
+}
+
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
 fn test_paused_blocks_stake() {
@@ -189,7 +223,7 @@ fn test_paused_blocks_stake() {
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     assert!(client.contract_is_paused());
     client.stake(&staker, &1_000_000);
 }
@@ -206,7 +240,7 @@ fn test_pause_blocks_all_insurance_state_changes() {
     let payout_caller = Address::generate(&env);
     let new_token = Address::generate(&env);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     fn assert_paused<F: FnOnce()>(f: F) {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
         assert!(result.is_err(), "state-changing function should panic while paused");
@@ -222,13 +256,13 @@ fn test_pause_blocks_all_insurance_state_changes() {
         client.pay_out(&soroban_sdk::symbol_short!("inv_x"), &beneficiary, &1_000i128);
     });
     assert_paused(|| {
-        client.transfer_admin(&admin, &new_admin);
+        client.transfer_admin(&one(&env, &admin), &new_admin);
     });
     assert_paused(|| {
-        client.set_staking_token(&admin, &new_token);
+        client.set_staking_token(&one(&env, &admin), &new_token);
     });
     assert_paused(|| {
-        client.set_payout_caller(&admin, &payout_caller);
+        client.set_payout_caller(&one(&env, &admin), &payout_caller);
     });
 
     assert_eq!(client.get_pool_total(), 0);
@@ -248,7 +282,7 @@ fn test_paused_blocks_unstake() {
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     client.stake(&staker, &1_000_000);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     client.unstake(&staker, &100_000);
 }
 
@@ -275,7 +309,7 @@ fn test_set_staking_token_admin_only() {
     let (_, _, client) = setup(&env, &admin);
 
     let new_token = Address::generate(&env);
-    client.set_staking_token(&admin, &new_token);
+    client.set_staking_token(&one(&env, &admin), &new_token);
     assert_eq!(client.get_staking_token(), new_token);
 }
 
@@ -304,11 +338,11 @@ fn setup_with_defaulted_invoice<'a>(
     // Deploy a registry, wire it to the insurance contract.
     let registry_id = env.register(RegistryContract, (admin.clone(),));
     let reg = invofi_registry::RegistryContractClient::new(env, &registry_id);
-    client.set_registry(admin, &registry_id);
+    client.set_registry(&one(env, admin), &registry_id);
 
     // Use the payout_caller as the authorised repayment contract on the
     // registry — mock_all_auths covers its auth so we can drive status.
-    reg.set_repayment_contract(admin, payout_caller);
+    reg.set_repayment_contract(&one(env, admin), payout_caller);
 
     // Register a minimal invoice and drive it to Defaulted.
     let originator = Address::generate(env);
@@ -323,7 +357,7 @@ fn setup_with_defaulted_invoice<'a>(
         &due_date,
     );
     // Pending -> Financed (registry needs a financing contract configured).
-    reg.set_financing_contract(admin, payout_caller);
+    reg.set_financing_contract(&one(env, admin), payout_caller);
     reg.financing_marks_invoice_financed(&invoice_id);
     // Advance ledger past due_date so mark_invoice_overdue passes.
     env.ledger().set_timestamp(due_date + 1);
@@ -351,7 +385,7 @@ fn test_payout_after_default_covers_claim() {
     client.stake(&staker, &1_000_000);
 
     // Configure payout caller and registry with a Defaulted invoice.
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
     assert_eq!(client.get_payout_caller(), Some(payout_caller.clone()));
     let (_reg, invoice_id) =
         setup_with_defaulted_invoice(&env, &admin, &payout_caller, &client);
@@ -381,7 +415,7 @@ fn test_payout_pool_depleted_pays_whats_left() {
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 100_000);
     client.stake(&staker, &100_000);
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
     let (_reg, invoice_id) =
         setup_with_defaulted_invoice(&env, &admin, &payout_caller, &client);
 
@@ -418,7 +452,7 @@ fn test_payout_pro_rata_multiple_stakers_exact() {
     mint_and_approve(&env, &token_id, &insurance_id, &staker_b, 3_000_000);
     client.stake(&staker_a, &1_000_000);
     client.stake(&staker_b, &3_000_000);
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
     let (_reg, invoice_id) =
         setup_with_defaulted_invoice(&env, &admin, &payout_caller, &client);
 
@@ -456,14 +490,14 @@ fn test_payout_rejected_when_invoice_overdue_not_defaulted() {
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     client.stake(&staker, &1_000_000);
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
 
     // Deploy registry, wire it — but only advance invoice to Overdue, NOT Defaulted.
     let registry_id = env.register(RegistryContract, (admin.clone(),));
     let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
-    client.set_registry(&admin, &registry_id);
-    reg.set_repayment_contract(&admin, &payout_caller);
-    reg.set_financing_contract(&admin, &payout_caller);
+    client.set_registry(&one(&env, &admin), &registry_id);
+    reg.set_repayment_contract(&one(&env, &admin), &payout_caller);
+    reg.set_financing_contract(&one(&env, &admin), &payout_caller);
 
     let originator = Address::generate(&env);
     let invoice_id = symbol_short!("inv_ovd");
@@ -504,11 +538,11 @@ fn test_payout_rejected_when_invoice_pending() {
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     client.stake(&staker, &1_000_000);
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
 
     let registry_id = env.register(RegistryContract, (admin.clone(),));
     let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
-    client.set_registry(&admin, &registry_id);
+    client.set_registry(&one(&env, &admin), &registry_id);
 
     let originator = Address::generate(&env);
     let invoice_id = symbol_short!("inv_pnd");
@@ -553,7 +587,7 @@ fn test_payout_zero_amount_panics() {
     let payout_caller = Address::generate(&env);
     let beneficiary = Address::generate(&env);
     let (_, _, client) = setup(&env, &admin);
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
     let invoice_id = symbol_short!("inv_x");
 
     client.pay_out(&invoice_id, &beneficiary, &0);
@@ -571,8 +605,8 @@ fn test_paused_blocks_payout() {
     let payout_caller = Address::generate(&env);
     let beneficiary = Address::generate(&env);
     let (_, _, client) = setup(&env, &admin);
-    client.set_payout_caller(&admin, &payout_caller);
-    client.pause(&admin);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
+    client.pause(&one(&env, &admin));
     let invoice_id = symbol_short!("inv_x");
 
     client.pay_out(&invoice_id, &beneficiary, &1_000);
@@ -597,7 +631,7 @@ fn test_payout_without_registry_panics() {
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     client.stake(&staker, &1_000_000);
     // Payout caller configured, but NO registry wired — must fail-closed.
-    client.set_payout_caller(&admin, &payout_caller);
+    client.set_payout_caller(&one(&env, &admin), &payout_caller);
     let invoice_id = symbol_short!("inv_x");
 
     client.pay_out(&invoice_id, &beneficiary, &500_000);
@@ -668,7 +702,7 @@ fn test_yield_math_one_year_500_bps() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &500); // 5 % annual
+    client.set_yield_rate(&one(&env, &admin), &500); // 5 % annual
     assert_eq!(client.get_yield_rate(), 500);
 
     let staker = Address::generate(&env);
@@ -701,7 +735,7 @@ fn test_yield_math_half_year_1000_bps() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &1_000); // 10 % annual
+    client.set_yield_rate(&one(&env, &admin), &1_000); // 10 % annual
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 2_000_000);
     fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
@@ -731,7 +765,7 @@ fn test_partial_unstake_pays_full_yield_then_resets() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &500); // 5 % annual
+    client.set_yield_rate(&one(&env, &admin), &500); // 5 % annual
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 2_000_000);
     fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
@@ -777,7 +811,7 @@ fn test_rate_change_prospective_only() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &500); // 5 % annual
+    client.set_yield_rate(&one(&env, &admin), &500); // 5 % annual
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     fund_yield_reserve(&env, &token_id, &insurance_id, 300_000);
@@ -790,7 +824,7 @@ fn test_rate_change_prospective_only() {
     assert_eq!(client.accrued_yield(&staker), 50_000);
 
     // Admin changes rate to 1000 bps. This banks the 50_000 for all stakers.
-    client.set_yield_rate(&admin, &1_000);
+    client.set_yield_rate(&one(&env, &admin), &1_000);
 
     // Immediately after rate change, accrued_yield should still show 50_000
     // (the banked amount; no new accrual yet because elapsed since bank = 0).
@@ -816,7 +850,7 @@ fn test_rate_decrease_preserves_accrued_yield() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &1_000); // 10 % annual
+    client.set_yield_rate(&one(&env, &admin), &1_000); // 10 % annual
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 1_000_000);
     fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
@@ -829,7 +863,7 @@ fn test_rate_decrease_preserves_accrued_yield() {
     assert_eq!(client.accrued_yield(&staker), 100_000);
 
     // Admin drops rate to 0. The 100_000 must be banked.
-    client.set_yield_rate(&admin, &0);
+    client.set_yield_rate(&one(&env, &admin), &0);
     assert_eq!(client.accrued_yield(&staker), 100_000); // banked amount unchanged
 
     // No further accrual at 0 bps.
@@ -853,7 +887,7 @@ fn test_topup_banks_yield_and_resets_clock() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &500); // 5 % annual
+    client.set_yield_rate(&one(&env, &admin), &500); // 5 % annual
     let staker = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker, 3_000_000);
     fund_yield_reserve(&env, &token_id, &insurance_id, 200_000);
@@ -894,7 +928,7 @@ fn test_multiple_stakers_independent_yield() {
     let admin = Address::generate(&env);
     let (token_id, insurance_id, client) = setup(&env, &admin);
 
-    client.set_yield_rate(&admin, &500); // 5 % annual
+    client.set_yield_rate(&one(&env, &admin), &500); // 5 % annual
     let staker_a = Address::generate(&env);
     let staker_b = Address::generate(&env);
     mint_and_approve(&env, &token_id, &insurance_id, &staker_a, 1_000_000);
@@ -940,7 +974,7 @@ fn test_set_yield_rate_non_admin_panics() {
     // Calling with an address that is not the admin — must panic Unauthorized.
     // mock_all_auths satisfies the require_auth; the explicit admin-equality
     // check rejects the call.
-    client.set_yield_rate(&impostor, &500);
+    client.set_yield_rate(&one(&env, &impostor), &500);
 }
 
 // ── accrued_yield for non-staker returns 0 ───────────────────────────────────
@@ -952,7 +986,7 @@ fn test_accrued_yield_non_staker_returns_zero() {
 
     let admin = Address::generate(&env);
     let (_, _, client) = setup(&env, &admin);
-    client.set_yield_rate(&admin, &500);
+    client.set_yield_rate(&one(&env, &admin), &500);
 
     let stranger = Address::generate(&env);
     set_ts(&env, 31_536_000);

--- a/integration/src/test.rs
+++ b/integration/src/test.rs
@@ -17,6 +17,15 @@ use soroban_sdk::{
 // Shared Test Helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 /// Deploy a fresh SEP-41 token and return its contract address.
 fn create_token(env: &Env) -> Address {
     let token_admin = Address::generate(env);
@@ -104,22 +113,22 @@ fn deploy_protocol(env: &Env) -> Protocol {
 
     // ── Wire cross-contract trust ──────────────────────────────────────────
     // Registry trusts financing and repayment for system status transitions.
-    reg.set_financing_contract(&admin, &financing_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Financing trusts repayment for callback methods.
-    fin.set_repayment_contract(&admin, &repayment_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
 
     // Repayment trusts insurance and reputation for default hooks.
-    rep.set_insurance(&admin, &insurance_id);
-    rep.set_reputation(&admin, &reputation_id);
+    rep.set_insurance(&one(&env, &admin), &insurance_id);
+    rep.set_reputation(&one(&env, &admin), &reputation_id);
 
     // Insurance: payout caller = repayment, registry for Defaulted check.
-    ins.set_payout_caller(&admin, &repayment_id);
-    ins.set_registry(&admin, &registry_id);
+    ins.set_payout_caller(&one(&env, &admin), &repayment_id);
+    ins.set_registry(&one(&env, &admin), &registry_id);
 
     // Reputation: recorder = repayment.
-    repu.set_recorder(&admin, &repayment_id);
+    repu.set_recorder(&one(&env, &admin), &repayment_id);
 
     Protocol {
         admin,

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -5,11 +5,11 @@ use soroban_sdk::{
 };
 
 use invofi_common::{
-    assert_not_paused, assert_transition, get_transition_history, Attestation, ContractError,
-    Invoice, InvoiceStatus, ProtocolStats, RiskTier, TransitionRecord, VerificationStatus,
-    VerificationType, DEFAULT_ATTESTATION_VALIDITY_SECS, MAX_ATTESTATIONS_PER_INVOICE,
-    MAX_ATTESTATION_VALIDITY_SECS, MAX_VERIFICATION_FEE_BPS, MAX_VERIFIERS,
-    MIN_ATTESTATION_VALIDITY_SECS, MIN_INVOICE_AMOUNT, VERIFICATION_TYPES,
+    assert_not_paused, assert_transition, get_transition_history, AdminConfig, Attestation,
+    ContractError, Invoice, InvoiceStatus, ProtocolStats, RiskTier, TransitionRecord,
+    VerificationStatus, VerificationType, DEFAULT_ATTESTATION_VALIDITY_SECS,
+    MAX_ATTESTATIONS_PER_INVOICE, MAX_ATTESTATION_VALIDITY_SECS, MAX_VERIFICATION_FEE_BPS,
+    MAX_VERIFIERS, MIN_ATTESTATION_VALIDITY_SECS, MIN_INVOICE_AMOUNT, VERIFICATION_TYPES,
 };
 
 // ─── Storage Helpers ─────────────────────────────────────────────────────────
@@ -257,16 +257,13 @@ fn assert_not_blacklisted(env: &Env, address: &Address) {
     }
 }
 
-fn assert_admin(env: &Env, caller: &Address) {
-    caller.require_auth();
-    let current: Address = env
-        .storage()
-        .instance()
-        .get(&symbol_short!("admin"))
-        .unwrap_or_else(|| panic!("Not initialized"));
-    if current != *caller {
-        env.panic_with_error(ContractError::Unauthorized);
-    }
+/// Threshold-gated admin check (ADR-0010). `signers` must contain at least
+/// `threshold` distinct, authorized addresses from the contract's
+/// `AdminConfig`. In single-admin bootstrap mode (the default at deploy)
+/// this is one address behaving exactly like the legacy admin check.
+fn assert_admin(env: &Env, signers: &Vec<Address>) {
+    let cfg = invofi_common::load_admin_config(env);
+    invofi_common::assert_threshold(env, &cfg, signers);
 }
 
 // ─── Contract ────────────────────────────────────────────────────────────────
@@ -286,38 +283,83 @@ impl RegistryContract {
     /// deployment can never be hijacked by a third party setting themselves
     /// as admin (issue #75).
     pub fn __constructor(env: Env, admin: Address) {
-        if env.storage().instance().has(&symbol_short!("admin")) {
-            panic!("Already initialized");
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &admin);
+        invofi_common::init_admin_config(&env, &admin);
     }
 
-    /// Returns the admin address. Panics if not yet initialized.
+    /// Returns the primary admin address (the first configured signer).
+    /// Panics if not yet initialized. In single-admin bootstrap mode this is
+    /// the only signer; under true M-of-N it is a convenience for tooling
+    /// that only needs *an* admin-controlled address, not a source of
+    /// authorization by itself — use `get_signers`/`get_threshold` for that.
     pub fn get_admin(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("admin"))
+        invofi_common::load_admin_config(&env)
+            .signers
+            .get(0)
             .unwrap_or_else(|| panic!("Not initialized"))
     }
 
-    /// Transfers admin rights to a new address. Only the current admin can
-    /// call this.
-    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
+    /// The full M-of-N admin governance config. See ADR-0010.
+    pub fn get_admin_config(env: Env) -> AdminConfig {
+        invofi_common::load_admin_config(&env)
+    }
+
+    /// The current signer set.
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        invofi_common::load_admin_config(&env).signers
+    }
+
+    /// The current approval threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        invofi_common::load_admin_config(&env).threshold
+    }
+
+    /// Reconfigure the admin signer set and threshold. Threshold-gated by the
+    /// *current* config, so raising the bar (e.g. moving from single-admin
+    /// bootstrap to true M-of-N) requires the outgoing config's own
+    /// authorization — this is the mechanism ADR-0010 describes for opting
+    /// into multisig after deploy.
+    pub fn set_signers(
+        env: Env,
+        signers: Vec<Address>,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &new_admin);
+        assert_admin(&env, &signers);
+        invofi_common::validate_signers(&env, &new_signers, new_threshold);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: new_threshold,
+            },
+        );
+    }
+
+    /// Hands control to a single new admin, collapsing the config back to
+    /// single-admin bootstrap mode (threshold 1). Requires the *current*
+    /// threshold's worth of signer authorizations. For reconfiguring to a
+    /// true M-of-N set instead, use `set_signers`.
+    pub fn transfer_admin(env: Env, signers: Vec<Address>, new_admin: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        let mut new_signers = Vec::new(&env);
+        new_signers.push_back(new_admin);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: 1,
+            },
+        );
     }
 
     /// Register the financing contract address. Admin only. The financing
     /// contract is the only caller allowed to transition a Pending invoice to
     /// Financed via `transition_invoice_status`.
-    pub fn set_financing_contract(env: Env, admin: Address, financing: Address) {
+    pub fn set_financing_contract(env: Env, signers: Vec<Address>, financing: Address) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("financing"), &financing);
@@ -326,9 +368,9 @@ impl RegistryContract {
     /// Register the repayment contract address. Admin only. The repayment
     /// contract is the only caller allowed to transition a Financed invoice
     /// to Financed (partial) or Repaid (full) via `transition_invoice_status`.
-    pub fn set_repayment_contract(env: Env, admin: Address, repayment: Address) {
+    pub fn set_repayment_contract(env: Env, signers: Vec<Address>, repayment: Address) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("repayment"), &repayment);
@@ -337,16 +379,16 @@ impl RegistryContract {
     // ── Pause / unpause ──────────────────────────────────────────────────────
 
     /// Halt all state-mutating operations. Admin only.
-    pub fn pause(env: Env, admin: Address) {
-        assert_admin(&env, &admin);
+    pub fn pause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &true);
     }
 
     /// Resume operations after a pause. Admin only.
-    pub fn unpause(env: Env, admin: Address) {
-        assert_admin(&env, &admin);
+    pub fn unpause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &false);
@@ -364,9 +406,9 @@ impl RegistryContract {
 
     /// Sets the yield rate (in basis points, 0-10000) for a risk tier.
     /// Admin only.
-    pub fn set_rate(env: Env, admin: Address, tier: RiskTier, rate_bps: u32) {
+    pub fn set_rate(env: Env, signers: Vec<Address>, tier: RiskTier, rate_bps: u32) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         if rate_bps > 10_000 {
             env.panic_with_error(ContractError::InvalidInput);
         }
@@ -386,9 +428,9 @@ impl RegistryContract {
     // ── Protocol fee ─────────────────────────────────────────────────────────
 
     /// Set the protocol fee in basis points (max 500 = 5%). Admin only.
-    pub fn set_fee(env: Env, admin: Address, fee_bps: u32) {
+    pub fn set_fee(env: Env, signers: Vec<Address>, fee_bps: u32) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         if fee_bps > 500 {
             env.panic_with_error(ContractError::InvalidInput);
         }
@@ -739,12 +781,12 @@ impl RegistryContract {
     /// Allowed targets: Financed, Repaid, Cancelled, Defaulted.
     pub fn resolve_dispute(
         env: Env,
-        admin: Address,
+        signers: Vec<Address>,
         invoice_id: Symbol,
         target_status: InvoiceStatus,
     ) -> Invoice {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         let mut invoices = load_invoices(&env);
         let mut invoice = invoices
             .get(invoice_id.clone())
@@ -752,9 +794,10 @@ impl RegistryContract {
         if target_status == InvoiceStatus::Disputed {
             env.panic_with_error(ContractError::InvalidInput);
         }
-        
+
         let old_status = invoice.status;
-        assert_transition(&env, invoice_id.clone(), old_status, target_status, admin.clone());
+        let actor = signers.get(0).unwrap_or_else(|| env.panic_with_error(ContractError::Unauthorized));
+        assert_transition(&env, invoice_id.clone(), old_status, target_status, actor);
         
         invoice.status = target_status;
         invoices.set(invoice_id, invoice.clone());
@@ -860,9 +903,9 @@ impl RegistryContract {
 
     // ── Blacklist management ─────────────────────────────────────────────────
 
-    pub fn blacklist_address(env: Env, admin: Address, target: Address) {
+    pub fn blacklist_address(env: Env, signers: Vec<Address>, target: Address) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         let mut list = load_blacklist(&env);
         for entry in list.iter() {
             if entry == target {
@@ -873,9 +916,9 @@ impl RegistryContract {
         save_blacklist(&env, &list);
     }
 
-    pub fn unblacklist_address(env: Env, admin: Address, target: Address) {
+    pub fn unblacklist_address(env: Env, signers: Vec<Address>, target: Address) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         let list = load_blacklist(&env);
         let mut new_list: Vec<Address> = Vec::new(&env);
         for entry in list.iter() {
@@ -915,9 +958,9 @@ impl RegistryContract {
     // bounded by verifier honesty and by the m-of-n threshold, not eliminated.
 
     /// Add an address to the trusted verifier set. Admin only. Idempotent.
-    pub fn add_verifier(env: Env, admin: Address, verifier: Address) {
+    pub fn add_verifier(env: Env, signers: Vec<Address>, verifier: Address) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         let mut verifiers = load_verifiers(&env);
         for existing in verifiers.iter() {
             if existing == verifier {
@@ -938,9 +981,9 @@ impl RegistryContract {
     /// still count until they expire; an admin who needs a compromised
     /// verifier's statements discounted immediately raises the threshold, per
     /// the key-compromise runbook (#145).
-    pub fn remove_verifier(env: Env, admin: Address, verifier: Address) {
+    pub fn remove_verifier(env: Env, signers: Vec<Address>, verifier: Address) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         let verifiers = load_verifiers(&env);
         let mut remaining: Vec<Address> = Vec::new(&env);
         for existing in verifiers.iter() {
@@ -971,9 +1014,9 @@ impl RegistryContract {
     /// admin may deliberately set it above the set while adding verifiers, and
     /// a removal must not silently weaken it. A threshold no live verifier set
     /// can reach simply means nothing verifies, which is the safe direction.
-    pub fn set_verifier_threshold(env: Env, admin: Address, threshold: u32) {
+    pub fn set_verifier_threshold(env: Env, signers: Vec<Address>, threshold: u32) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         if threshold == 0 || threshold > MAX_VERIFIERS {
             env.panic_with_error(ContractError::InvalidInput);
         }
@@ -993,9 +1036,9 @@ impl RegistryContract {
     /// Set the verification fee in basis points of invoice value. Admin only.
     /// Capped at `MAX_VERIFICATION_FEE_BPS` (5%). Defaults to 0, which
     /// disables fee settlement entirely.
-    pub fn set_verification_fee(env: Env, admin: Address, fee_bps: u32) {
+    pub fn set_verification_fee(env: Env, signers: Vec<Address>, fee_bps: u32) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         if fee_bps > MAX_VERIFICATION_FEE_BPS {
             env.panic_with_error(ContractError::InvalidInput);
         }
@@ -1018,9 +1061,9 @@ impl RegistryContract {
     ///
     /// Changing this does not move the `valid_until` of attestations already
     /// submitted — each one carries its own, fixed at submission.
-    pub fn set_attestation_validity(env: Env, admin: Address, validity_secs: u64) {
+    pub fn set_attestation_validity(env: Env, signers: Vec<Address>, validity_secs: u64) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         if !(MIN_ATTESTATION_VALIDITY_SECS..=MAX_ATTESTATION_VALIDITY_SECS)
             .contains(&validity_secs)
         {
@@ -1046,9 +1089,14 @@ impl RegistryContract {
     /// multi-currency deployment registers each currency once here — the same
     /// pattern the financing contract uses, sharing the `invofi_common`
     /// registry rather than growing a per-currency branch.
-    pub fn register_currency(env: Env, admin: Address, currency: Symbol, token_addr: Address) {
+    pub fn register_currency(
+        env: Env,
+        signers: Vec<Address>,
+        currency: Symbol,
+        token_addr: Address,
+    ) {
         assert_not_paused(&env);
-        assert_admin(&env, &admin);
+        assert_admin(&env, &signers);
         invofi_common::register_currency(&env, &currency, &token_addr);
     }
 

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -9,6 +9,15 @@ use soroban_sdk::{
     token, Address, BytesN, Env, IntoVal, Symbol, TryFromVal,
 };
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 // ─── Invoice CRUD tests ──────────────────────────────────────────────────────
 
 #[test]
@@ -611,7 +620,7 @@ fn test_transfer_admin() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
     let new_admin = Address::generate(&env);
 
-    client.transfer_admin(&admin, &new_admin);
+    client.transfer_admin(&one(&env, &admin), &new_admin);
     assert_eq!(client.get_admin(), new_admin);
 }
 
@@ -626,7 +635,208 @@ fn test_transfer_admin_unauthorized_panics() {
     let not_admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
 
-    client.transfer_admin(&not_admin, &new_admin);
+    client.transfer_admin(&one(&env, &not_admin), &new_admin);
+}
+
+// ─── Multisig admin governance tests (ADR-0010) ─────────────────────────────
+
+#[test]
+fn test_bootstrap_admin_config_defaults() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    // Every constructor boots into single-admin bootstrap mode: one signer,
+    // threshold one.
+    let cfg = client.get_admin_config();
+    assert_eq!(cfg.signers.len(), 1);
+    assert_eq!(cfg.signers.get(0).unwrap(), admin);
+    assert_eq!(cfg.threshold, 1);
+    assert_eq!(client.get_signers(), cfg.signers);
+    assert_eq!(client.get_threshold(), 1);
+}
+
+#[test]
+fn test_set_signers_upgrades_to_true_multisig() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut new_signers = soroban_sdk::Vec::new(&env);
+    new_signers.push_back(admin.clone());
+    new_signers.push_back(b.clone());
+    new_signers.push_back(c.clone());
+
+    // Bootstrap mode's sole signer can authorize the upgrade alone.
+    client.set_signers(&one(&env, &admin), &new_signers, &2u32);
+
+    let cfg = client.get_admin_config();
+    assert_eq!(cfg.threshold, 2);
+    assert_eq!(cfg.signers, new_signers);
+}
+
+#[test]
+fn test_multisig_requires_threshold_distinct_signatures() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut signers_3 = soroban_sdk::Vec::new(&env);
+    signers_3.push_back(admin.clone());
+    signers_3.push_back(b.clone());
+    signers_3.push_back(c.clone());
+    client.set_signers(&one(&env, &admin), &signers_3, &2u32);
+
+    // A single signer is no longer enough once threshold is 2.
+    let result = client.try_pause(&one(&env, &admin));
+    assert!(result.is_err(), "one of two required signatures must not pause");
+    assert!(!client.contract_is_paused());
+
+    // Two distinct configured signers together clear the threshold.
+    let mut two = soroban_sdk::Vec::new(&env);
+    two.push_back(admin.clone());
+    two.push_back(b.clone());
+    client.pause(&two);
+    assert!(client.contract_is_paused());
+}
+
+#[test]
+fn test_multisig_rejects_non_signer_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let outsider = Address::generate(&env);
+    let mut signers_2 = soroban_sdk::Vec::new(&env);
+    signers_2.push_back(admin.clone());
+    signers_2.push_back(b.clone());
+    client.set_signers(&one(&env, &admin), &signers_2, &2u32);
+
+    // One real signer plus one address outside the configured set must not
+    // satisfy the threshold, even though the vec has two entries.
+    let mut bad = soroban_sdk::Vec::new(&env);
+    bad.push_back(admin.clone());
+    bad.push_back(outsider);
+    let result = client.try_pause(&bad);
+    assert!(result.is_err(), "a non-signer address must not count toward the threshold");
+}
+
+#[test]
+fn test_multisig_rejects_duplicate_signer_in_same_call() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let mut signers_2 = soroban_sdk::Vec::new(&env);
+    signers_2.push_back(admin.clone());
+    signers_2.push_back(b.clone());
+    client.set_signers(&one(&env, &admin), &signers_2, &2u32);
+
+    // The same signer listed twice must not count as two approvals.
+    let mut dup = soroban_sdk::Vec::new(&env);
+    dup.push_back(admin.clone());
+    dup.push_back(admin.clone());
+    let result = client.try_pause(&dup);
+    assert!(result.is_err(), "a duplicated signer must not satisfy a threshold of two");
+}
+
+#[test]
+fn test_set_signers_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+    let outsider = Address::generate(&env);
+    let new_signers = one(&env, &Address::generate(&env));
+
+    let result = client.try_set_signers(&one(&env, &outsider), &new_signers, &1u32);
+    assert!(result.is_err(), "a non-signer must not be able to reconfigure the admin set");
+}
+
+#[test]
+fn test_set_signers_rejects_invalid_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+    let b = Address::generate(&env);
+    let mut two_signers = soroban_sdk::Vec::new(&env);
+    two_signers.push_back(admin.clone());
+    two_signers.push_back(b.clone());
+
+    // threshold 0 is never satisfiable and is rejected outright.
+    let result = client.try_set_signers(&one(&env, &admin), &two_signers, &0u32);
+    assert!(result.is_err());
+
+    // threshold above the signer count could never be met.
+    let result = client.try_set_signers(&one(&env, &admin), &two_signers, &3u32);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_set_signers_rejects_empty_and_duplicate_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let empty: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    let result = client.try_set_signers(&one(&env, &admin), &empty, &1u32);
+    assert!(result.is_err(), "an empty signer set is never satisfiable");
+
+    let mut dup_signers = soroban_sdk::Vec::new(&env);
+    dup_signers.push_back(admin.clone());
+    dup_signers.push_back(admin.clone());
+    let result = client.try_set_signers(&one(&env, &admin), &dup_signers, &2u32);
+    assert!(result.is_err(), "a duplicate address would let one key count twice");
+}
+
+#[test]
+fn test_transfer_admin_collapses_multisig_back_to_single_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let mut two_signers = soroban_sdk::Vec::new(&env);
+    two_signers.push_back(admin.clone());
+    two_signers.push_back(b.clone());
+    client.set_signers(&one(&env, &admin), &two_signers, &2u32);
+
+    let new_admin = Address::generate(&env);
+    let mut both = soroban_sdk::Vec::new(&env);
+    both.push_back(admin.clone());
+    both.push_back(b.clone());
+    client.transfer_admin(&both, &new_admin);
+
+    let cfg = client.get_admin_config();
+    assert_eq!(cfg.signers.len(), 1);
+    assert_eq!(cfg.signers.get(0).unwrap(), new_admin);
+    assert_eq!(cfg.threshold, 1);
+    // Single-admin bootstrap behavior is restored: one signature suffices.
+    client.pause(&one(&env, &new_admin));
+    assert!(client.contract_is_paused());
 }
 
 // ─── Pause tests ──────────────────────────────────────────────────────────────
@@ -641,9 +851,9 @@ fn test_pause_and_unpause() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
 
     assert!(!client.contract_is_paused());
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     assert!(client.contract_is_paused());
-    client.unpause(&admin);
+    client.unpause(&one(&env, &admin));
     assert!(!client.contract_is_paused());
 }
 
@@ -658,7 +868,7 @@ fn test_register_invoice_while_paused_panics() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
     let originator = Address::generate(&env);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     client.register_invoice(
         &symbol_short!("inv_p1"),
         &originator,
@@ -678,7 +888,7 @@ fn test_pause_unauthorized_panics() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
     let not_admin = Address::generate(&env);
 
-    client.pause(&not_admin);
+    client.pause(&one(&env, &not_admin));
 }
 
 #[test]
@@ -691,8 +901,8 @@ fn test_pause_blocks_transfer_admin() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
     let new_admin = Address::generate(&env);
 
-    client.pause(&admin);
-    client.transfer_admin(&admin, &new_admin);
+    client.pause(&one(&env, &admin));
+    client.transfer_admin(&one(&env, &admin), &new_admin);
 }
 
 #[test]
@@ -703,7 +913,7 @@ fn test_pause_blocks_all_registry_state_changes() {
     let contract_id = env.register(RegistryContract, (admin.clone(),));
     let client = super::RegistryContractClient::new(&env, &contract_id);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     let originator = Address::generate(&env);
     let other = Address::generate(&env);
     let financing = Address::generate(&env);
@@ -757,28 +967,28 @@ fn test_pause_blocks_all_registry_state_changes() {
         client.raise_dispute(&invoice_id, &originator);
     });
     assert_paused(|| {
-        client.resolve_dispute(&admin, &invoice_id, &invofi_common::InvoiceStatus::Cancelled);
+        client.resolve_dispute(&one(&env, &admin), &invoice_id, &invofi_common::InvoiceStatus::Cancelled);
     });
     assert_paused(|| {
-        client.blacklist_address(&admin, &other);
+        client.blacklist_address(&one(&env, &admin), &other);
     });
     assert_paused(|| {
-        client.unblacklist_address(&admin, &other);
+        client.unblacklist_address(&one(&env, &admin), &other);
     });
     assert_paused(|| {
-        client.transfer_admin(&admin, &new_admin);
+        client.transfer_admin(&one(&env, &admin), &new_admin);
     });
     assert_paused(|| {
-        client.set_financing_contract(&admin, &financing);
+        client.set_financing_contract(&one(&env, &admin), &financing);
     });
     assert_paused(|| {
-        client.set_repayment_contract(&admin, &repayment);
+        client.set_repayment_contract(&one(&env, &admin), &repayment);
     });
     assert_paused(|| {
-        client.set_rate(&admin, &invofi_common::RiskTier::A, &500u32);
+        client.set_rate(&one(&env, &admin), &invofi_common::RiskTier::A, &500u32);
     });
     assert_paused(|| {
-        client.set_fee(&admin, &50u32);
+        client.set_fee(&one(&env, &admin), &50u32);
     });
 
     assert_eq!(client.get_fee(), 0);
@@ -795,9 +1005,9 @@ fn test_set_and_get_rate() {
     let contract_id = env.register(RegistryContract, (admin.clone(),));
     let client = super::RegistryContractClient::new(&env, &contract_id);
 
-    client.set_rate(&admin, &RiskTier::A, &500u32);
-    client.set_rate(&admin, &RiskTier::B, &800u32);
-    client.set_rate(&admin, &RiskTier::C, &1200u32);
+    client.set_rate(&one(&env, &admin), &RiskTier::A, &500u32);
+    client.set_rate(&one(&env, &admin), &RiskTier::B, &800u32);
+    client.set_rate(&one(&env, &admin), &RiskTier::C, &1200u32);
 
     assert_eq!(client.get_rate(&RiskTier::A), 500);
     assert_eq!(client.get_rate(&RiskTier::B), 800);
@@ -813,7 +1023,7 @@ fn test_set_rate_out_of_range_panics() {
     let contract_id = env.register(RegistryContract, (admin.clone(),));
     let client = super::RegistryContractClient::new(&env, &contract_id);
 
-    client.set_rate(&admin, &RiskTier::A, &10_001u32);
+    client.set_rate(&one(&env, &admin), &RiskTier::A, &10_001u32);
 }
 
 #[test]
@@ -826,7 +1036,7 @@ fn test_set_rate_unauthorized_panics() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
     let not_admin = Address::generate(&env);
 
-    client.set_rate(&not_admin, &RiskTier::A, &500u32);
+    client.set_rate(&one(&env, &not_admin), &RiskTier::A, &500u32);
 }
 
 #[test]
@@ -852,7 +1062,7 @@ fn test_set_and_get_fee() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
 
     assert_eq!(client.get_fee(), 0);
-    client.set_fee(&admin, &200u32);
+    client.set_fee(&one(&env, &admin), &200u32);
     assert_eq!(client.get_fee(), 200);
 }
 
@@ -865,7 +1075,7 @@ fn test_set_fee_too_high_panics() {
     let contract_id = env.register(RegistryContract, (admin.clone(),));
     let client = super::RegistryContractClient::new(&env, &contract_id);
 
-    client.set_fee(&admin, &600u32);
+    client.set_fee(&one(&env, &admin), &600u32);
 }
 
 // ─── Blacklist tests ───────────────────────────────────────────────────────────
@@ -882,15 +1092,15 @@ fn test_blacklist_and_unblacklist() {
 
     assert!(!client.is_blacklisted(&bad_actor));
 
-    client.blacklist_address(&admin, &bad_actor);
+    client.blacklist_address(&one(&env, &admin), &bad_actor);
     assert!(client.is_blacklisted(&bad_actor));
     assert_eq!(client.get_blacklist().len(), 1);
 
     // Idempotent
-    client.blacklist_address(&admin, &bad_actor);
+    client.blacklist_address(&one(&env, &admin), &bad_actor);
     assert_eq!(client.get_blacklist().len(), 1);
 
-    client.unblacklist_address(&admin, &bad_actor);
+    client.unblacklist_address(&one(&env, &admin), &bad_actor);
     assert!(!client.is_blacklisted(&bad_actor));
     assert_eq!(client.get_blacklist().len(), 0);
 }
@@ -906,7 +1116,7 @@ fn test_blacklisted_cannot_register_invoice() {
     let client = super::RegistryContractClient::new(&env, &contract_id);
     let bad_actor = Address::generate(&env);
 
-    client.blacklist_address(&admin, &bad_actor);
+    client.blacklist_address(&one(&env, &admin), &bad_actor);
     client.register_invoice(
         &symbol_short!("bl1"),
         &bad_actor,
@@ -927,7 +1137,7 @@ fn test_blacklist_non_admin_panics() {
     let non_admin = Address::generate(&env);
     let victim = Address::generate(&env);
 
-    client.blacklist_address(&non_admin, &victim);
+    client.blacklist_address(&one(&env, &non_admin), &victim);
 }
 
 // ─── Stats tests ───────────────────────────────────────────────────────────────
@@ -1133,7 +1343,7 @@ fn test_repayment_marks_defaulted_transition() {
     let invoice_id = symbol_short!("inv_df1");
     let due_date: u64 = 1_735_689_600;
 
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     client.register_invoice(
         &invoice_id,
@@ -1172,7 +1382,7 @@ fn test_repayment_marks_defaulted_requires_overdue() {
     let invoice_id = symbol_short!("inv_df2");
     let due_date: u64 = 1_735_689_600;
 
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     client.register_invoice(
         &invoice_id,
@@ -1199,8 +1409,8 @@ fn test_state_machine_valid_transitions() {
     let financing = Address::generate(&env);
     let repayment = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_financing_contract(&one(&env, &admin), &financing);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     let invoice_id = symbol_short!("sm001");
     let due_date: u64 = 1_735_689_600;
@@ -1261,7 +1471,7 @@ fn test_state_machine_financed_to_overdue() {
     let originator = Address::generate(&env);
     let financing = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
+    client.set_financing_contract(&one(&env, &admin), &financing);
 
     let invoice_id = symbol_short!("sm003");
     let due_date: u64 = 100; // Past ledger timestamp
@@ -1292,7 +1502,7 @@ fn test_state_machine_financed_to_disputed_to_resolved() {
     let originator = Address::generate(&env);
     let financing = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
+    client.set_financing_contract(&one(&env, &admin), &financing);
 
     let invoice_id = symbol_short!("sm004");
     client.register_invoice(
@@ -1311,14 +1521,14 @@ fn test_state_machine_financed_to_disputed_to_resolved() {
     assert_eq!(disputed.status, InvoiceStatus::Disputed);
 
     // Disputed -> Financed (admin resolution)
-    let resolved = client.resolve_dispute(&admin, &invoice_id, &InvoiceStatus::Financed);
+    let resolved = client.resolve_dispute(&one(&env, &admin), &invoice_id, &InvoiceStatus::Financed);
     assert_eq!(resolved.status, InvoiceStatus::Financed);
 
     // Financed -> Disputed (again)
     client.raise_dispute(&invoice_id, &originator);
 
     // Disputed -> Cancelled (admin resolution)
-    let resolved2 = client.resolve_dispute(&admin, &invoice_id, &InvoiceStatus::Cancelled);
+    let resolved2 = client.resolve_dispute(&one(&env, &admin), &invoice_id, &InvoiceStatus::Cancelled);
     assert_eq!(resolved2.status, InvoiceStatus::Cancelled);
 }
 
@@ -1333,7 +1543,7 @@ fn test_state_machine_invalid_repaid_from_pending() {
     let originator = Address::generate(&env);
     let repayment = Address::generate(&env);
 
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     let invoice_id = symbol_short!("sm_bad1");
     client.register_invoice(
@@ -1360,8 +1570,8 @@ fn test_state_machine_invalid_financed_from_repaid() {
     let financing = Address::generate(&env);
     let repayment = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_financing_contract(&one(&env, &admin), &financing);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     let invoice_id = symbol_short!("sm_bad2");
     client.register_invoice(
@@ -1392,8 +1602,8 @@ fn test_state_machine_invalid_overdue_from_repaid() {
     let financing = Address::generate(&env);
     let repayment = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_financing_contract(&one(&env, &admin), &financing);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     let invoice_id = symbol_short!("sm_bad3");
     client.register_invoice(
@@ -1444,7 +1654,7 @@ fn test_transition_history_recorded() {
     let originator = Address::generate(&env);
     let financing = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
+    client.set_financing_contract(&one(&env, &admin), &financing);
 
     let invoice_id = symbol_short!("sm_hist");
     client.register_invoice(
@@ -1481,8 +1691,8 @@ fn test_transition_history_multiple_transitions() {
     let financing = Address::generate(&env);
     let repayment = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
-    client.set_repayment_contract(&admin, &repayment);
+    client.set_financing_contract(&one(&env, &admin), &financing);
+    client.set_repayment_contract(&one(&env, &admin), &repayment);
 
     let invoice_id = symbol_short!("sm_multi");
     client.register_invoice(
@@ -1561,7 +1771,7 @@ fn test_transition_events_emitted() {
     let originator = Address::generate(&env);
     let financing = Address::generate(&env);
 
-    client.set_financing_contract(&admin, &financing);
+    client.set_financing_contract(&one(&env, &admin), &financing);
 
     let invoice_id = symbol_short!("sm_evt");
     client.register_invoice(
@@ -1625,7 +1835,7 @@ fn setup_oracle<'a>(
         &symbol_short!("USDC"),
         &(9_000_000u64),
     );
-    client.add_verifier(&admin, &verifier);
+    client.add_verifier(&one(&env, &admin), &verifier);
 
     (client, admin, originator, verifier)
 }
@@ -1644,14 +1854,14 @@ fn test_verifier_set_management() {
 
     // add_verifier is idempotent — re-adding must not double-count a verifier
     // towards an m-of-n threshold.
-    client.add_verifier(&admin, &verifier);
+    client.add_verifier(&one(&env, &admin), &verifier);
     assert_eq!(client.get_verifiers().len(), 1);
 
     let second = Address::generate(&env);
-    client.add_verifier(&admin, &second);
+    client.add_verifier(&one(&env, &admin), &second);
     assert_eq!(client.get_verifiers().len(), 2);
 
-    client.remove_verifier(&admin, &verifier);
+    client.remove_verifier(&one(&env, &admin), &verifier);
     assert!(!client.is_verifier(&verifier));
     assert!(client.is_verifier(&second));
 }
@@ -1666,7 +1876,7 @@ fn test_add_verifier_is_admin_only() {
     let invoice_id = symbol_short!("vinv02");
     let (client, _admin, originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.add_verifier(&originator, &Address::generate(&env));
+    client.add_verifier(&one(&env, &originator), &Address::generate(&env));
 }
 
 #[test]
@@ -1788,7 +1998,7 @@ fn test_rejection_outranks_approvals() {
     let invoice_id = symbol_short!("vinv06");
     let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
     let second = Address::generate(&env);
-    client.add_verifier(&admin, &second);
+    client.add_verifier(&one(&env, &admin), &second);
 
     client.attest(
         &invoice_id,
@@ -1826,8 +2036,8 @@ fn test_threshold_requires_distinct_verifiers() {
     let invoice_id = symbol_short!("vinv07");
     let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
     let second = Address::generate(&env);
-    client.add_verifier(&admin, &second);
-    client.set_verifier_threshold(&admin, &2u32);
+    client.add_verifier(&one(&env, &admin), &second);
+    client.set_verifier_threshold(&one(&env, &admin), &2u32);
     assert_eq!(client.get_verifier_threshold(), 2);
 
     client.attest(
@@ -1881,7 +2091,7 @@ fn test_zero_verifier_threshold_panics() {
     let invoice_id = symbol_short!("vinv08");
     let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.set_verifier_threshold(&admin, &0u32);
+    client.set_verifier_threshold(&one(&env, &admin), &0u32);
 }
 
 // ── Fees ─────────────────────────────────────────────────────────────────────
@@ -1900,8 +2110,8 @@ fn test_verification_fee_is_charged_to_the_originator() {
     let token_admin = Address::generate(&env);
     let sac = env.register_stellar_asset_contract_v2(token_admin);
     let token_id = sac.address();
-    client.register_currency(&admin, &symbol_short!("USDC"), &token_id);
-    client.set_verification_fee(&admin, &50u32);
+    client.register_currency(&one(&env, &admin), &symbol_short!("USDC"), &token_id);
+    client.set_verification_fee(&one(&env, &admin), &50u32);
     assert_eq!(client.calculate_verification_fee(&invoice_id), 5_000_000);
 
     token::StellarAssetClient::new(&env, &token_id).mint(&originator, &amount);
@@ -1940,8 +2150,8 @@ fn test_fee_is_charged_on_rejection_too() {
     let token_admin = Address::generate(&env);
     let sac = env.register_stellar_asset_contract_v2(token_admin);
     let token_id = sac.address();
-    client.register_currency(&admin, &symbol_short!("USDC"), &token_id);
-    client.set_verification_fee(&admin, &100u32);
+    client.register_currency(&one(&env, &admin), &symbol_short!("USDC"), &token_id);
+    client.set_verification_fee(&one(&env, &admin), &100u32);
 
     token::StellarAssetClient::new(&env, &token_id).mint(&originator, &amount);
     token::TokenClient::new(&env, &token_id).approve(
@@ -2006,7 +2216,7 @@ fn test_nonzero_fee_without_a_registered_token_panics() {
     let invoice_id = symbol_short!("vinv12");
     let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.set_verification_fee(&admin, &50u32);
+    client.set_verification_fee(&one(&env, &admin), &50u32);
     client.attest(
         &invoice_id,
         &verifier,
@@ -2026,7 +2236,7 @@ fn test_verification_fee_above_ceiling_panics() {
     let invoice_id = symbol_short!("vinv13");
     let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.set_verification_fee(&admin, &501u32);
+    client.set_verification_fee(&one(&env, &admin), &501u32);
 }
 
 #[test]
@@ -2039,11 +2249,11 @@ fn test_fee_math_rounds_down_and_does_not_overflow() {
     // 1 bps of 19 999 999 stroops is 1 999.9999 -> 1 999: the division
     // happens last and truncates in the payer's favour.
     let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 19_999_999);
-    client.set_verification_fee(&admin, &1u32);
+    client.set_verification_fee(&one(&env, &admin), &1u32);
     assert_eq!(client.calculate_verification_fee(&invoice_id), 1_999);
 
     // 500 bps of the same is 999 999.95 -> 999 999, truncated the same way.
-    client.set_verification_fee(&admin, &500u32);
+    client.set_verification_fee(&one(&env, &admin), &500u32);
     assert_eq!(client.calculate_verification_fee(&invoice_id), 999_999);
 }
 
@@ -2059,7 +2269,7 @@ fn test_fee_math_overflow_reverts_instead_of_wrapping() {
     // small (or negative) fee.
     let invoice_id = symbol_short!("vinv15");
     let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, i128::MAX);
-    client.set_verification_fee(&admin, &500u32);
+    client.set_verification_fee(&one(&env, &admin), &500u32);
     client.calculate_verification_fee(&invoice_id);
 }
 
@@ -2186,7 +2396,7 @@ fn test_attestation_validity_is_configurable_and_not_retroactive() {
     let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
     assert_eq!(client.get_attestation_validity(), 7_776_000);
-    client.set_attestation_validity(&admin, &86_400u64);
+    client.set_attestation_validity(&one(&env, &admin), &86_400u64);
 
     let first = client.attest(
         &invoice_id,
@@ -2198,7 +2408,7 @@ fn test_attestation_validity_is_configurable_and_not_retroactive() {
     assert_eq!(first.valid_until, 1_000_000 + 86_400);
 
     // Widening the setting must not extend an attestation already submitted.
-    client.set_attestation_validity(&admin, &31_536_000u64);
+    client.set_attestation_validity(&one(&env, &admin), &31_536_000u64);
     let stored = client.get_verifications(&invoice_id).get(0).unwrap();
     assert_eq!(stored.valid_until, 1_000_000 + 86_400);
     env.ledger().set_timestamp(1_000_000 + 86_401);
@@ -2218,7 +2428,7 @@ fn test_attestation_validity_below_minimum_panics() {
     let invoice_id = symbol_short!("vinv19");
     let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.set_attestation_validity(&admin, &86_399u64);
+    client.set_attestation_validity(&one(&env, &admin), &86_399u64);
 }
 
 #[test]
@@ -2231,7 +2441,7 @@ fn test_attestation_validity_above_maximum_panics() {
     let invoice_id = symbol_short!("vinv20");
     let (client, admin, _originator, _verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.set_attestation_validity(&admin, &31_536_001u64);
+    client.set_attestation_validity(&one(&env, &admin), &31_536_001u64);
 }
 
 // ── Guards ───────────────────────────────────────────────────────────────────
@@ -2285,7 +2495,7 @@ fn test_attest_is_pause_guarded() {
     let invoice_id = symbol_short!("vinv23");
     let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     client.attest(
         &invoice_id,
         &verifier,
@@ -2324,7 +2534,7 @@ fn test_removed_verifier_cannot_attest_but_keeps_its_history() {
         &evidence_hash(&env, 1),
         &true,
     );
-    client.remove_verifier(&admin, &verifier);
+    client.remove_verifier(&one(&env, &admin), &verifier);
 
     // The record of what they said survives removal — that is the point of
     // storing it.
@@ -2350,8 +2560,8 @@ fn test_removal_revokes_a_contributing_approval_and_a_rejection() {
     let invoice_id = symbol_short!("vinv26");
     let (client, admin, _originator, first) = setup_oracle(&env, &invoice_id, 1_000_000_000);
     let second = Address::generate(&env);
-    client.add_verifier(&admin, &second);
-    client.set_verifier_threshold(&admin, &2u32);
+    client.add_verifier(&one(&env, &admin), &second);
+    client.set_verifier_threshold(&one(&env, &admin), &2u32);
 
     // Two approvals clear the threshold.
     client.attest(
@@ -2374,7 +2584,7 @@ fn test_removal_revokes_a_contributing_approval_and_a_rejection() {
     );
 
     // Removing one of them drops the live approval count below the threshold.
-    client.remove_verifier(&admin, &second);
+    client.remove_verifier(&one(&env, &admin), &second);
     assert_eq!(
         client.get_verification_status(&invoice_id, &VerificationType::DocumentHash),
         VerificationStatus::Pending,
@@ -2394,7 +2604,7 @@ fn test_removal_revokes_a_contributing_approval_and_a_rejection() {
         client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
         VerificationStatus::Rejected
     );
-    client.remove_verifier(&admin, &first);
+    client.remove_verifier(&one(&env, &admin), &first);
     assert_eq!(
         client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
         VerificationStatus::Pending,
@@ -2426,7 +2636,7 @@ fn test_eviction_cannot_disturb_another_types_status() {
     // Fill the invoice to its cap with departed verifiers.
     for round in 0..20u8 {
         let rotating = Address::generate(&env);
-        client.add_verifier(&admin, &rotating);
+        client.add_verifier(&one(&env, &admin), &rotating);
         for (offset, v_type) in types.iter().enumerate() {
             client.attest(
                 &invoice_id,
@@ -2436,13 +2646,13 @@ fn test_eviction_cannot_disturb_another_types_status() {
                 &true,
             );
         }
-        client.remove_verifier(&admin, &rotating);
+        client.remove_verifier(&one(&env, &admin), &rotating);
     }
     assert_eq!(client.get_verifications(&invoice_id).len(), 60);
 
     // An active verifier vouches for one type, then another, forcing evictions.
     let active = Address::generate(&env);
-    client.add_verifier(&admin, &active);
+    client.add_verifier(&one(&env, &admin), &active);
     client.attest(
         &invoice_id,
         &active,
@@ -2525,7 +2735,7 @@ fn test_eviction_preserves_every_status_it_can_reach() {
     ];
     for round in 0..19u8 {
         let rotating = Address::generate(&env);
-        client.add_verifier(&admin, &rotating);
+        client.add_verifier(&one(&env, &admin), &rotating);
         for (offset, v_type) in types.iter().enumerate() {
             client.attest(
                 &invoice_id,
@@ -2535,13 +2745,13 @@ fn test_eviction_preserves_every_status_it_can_reach() {
                 &true,
             );
         }
-        client.remove_verifier(&admin, &rotating);
+        client.remove_verifier(&one(&env, &admin), &rotating);
     }
     assert_eq!(client.get_verifications(&invoice_id).len(), 59);
 
     // DocumentHash verified by a verifier who remains trusted and live.
     let active = Address::generate(&env);
-    client.add_verifier(&admin, &active);
+    client.add_verifier(&one(&env, &admin), &active);
     client.attest(
         &invoice_id,
         &active,
@@ -2559,7 +2769,7 @@ fn test_eviction_preserves_every_status_it_can_reach() {
     // are available -- so the live statements are untouched throughout.
     for n in 0..3u8 {
         let extra = Address::generate(&env);
-        client.add_verifier(&admin, &extra);
+        client.add_verifier(&one(&env, &admin), &extra);
         client.attest(
             &invoice_id,
             &extra,
@@ -2567,7 +2777,7 @@ fn test_eviction_preserves_every_status_it_can_reach() {
             &evidence_hash(&env, 200 + n),
             &true,
         );
-        client.remove_verifier(&admin, &extra);
+        client.remove_verifier(&one(&env, &admin), &extra);
     }
 
     // The guaranteed half: neither Verified nor Rejected moved.
@@ -2635,7 +2845,7 @@ fn test_eviction_cannot_fire_without_a_departed_record_to_take() {
     }
     for round in 0..19u8 {
         let v = Address::generate(&env);
-        client.add_verifier(&admin, &v);
+        client.add_verifier(&one(&env, &admin), &v);
         for (offset, v_type) in types.iter().enumerate() {
             client.attest(
                 &invoice_id,
@@ -2727,7 +2937,7 @@ fn test_verification_completed_is_emitted_once_per_status_change() {
     let invoice_id = symbol_short!("vinv27");
     let (client, admin, _originator, verifier) = setup_oracle(&env, &invoice_id, 1_000_000_000);
     let second = Address::generate(&env);
-    client.add_verifier(&admin, &second);
+    client.add_verifier(&one(&env, &admin), &second);
 
     // The test harness exposes the events of the most recent invocation, so
     // each attestation is checked as it lands.
@@ -2783,8 +2993,8 @@ fn test_live_approval_below_threshold_reads_pending_not_expired() {
     let invoice_id = symbol_short!("vinv20");
     let (client, admin, _originator, first) = setup_oracle(&env, &invoice_id, 1_000_000_000);
     let second = Address::generate(&env);
-    client.add_verifier(&admin, &second);
-    client.set_verifier_threshold(&admin, &2u32);
+    client.add_verifier(&one(&env, &admin), &second);
+    client.set_verifier_threshold(&one(&env, &admin), &2u32);
 
     // Verifier one attests, then lets its attestation lapse.
     client.attest(
@@ -2818,7 +3028,7 @@ fn test_live_approval_below_threshold_reads_pending_not_expired() {
 
     // And once the threshold is met it flips to Verified.
     let third = Address::generate(&env);
-    client.add_verifier(&admin, &third);
+    client.add_verifier(&one(&env, &admin), &third);
     client.attest(
         &invoice_id,
         &third,
@@ -2876,7 +3086,7 @@ fn test_rotated_out_verifiers_cannot_lock_an_invoice() {
     ];
     for round in 0..20u8 {
         let rotating = Address::generate(&env);
-        client.add_verifier(&admin, &rotating);
+        client.add_verifier(&one(&env, &admin), &rotating);
         for (offset, v_type) in types.iter().enumerate() {
             client.attest(
                 &invoice_id,
@@ -2886,7 +3096,7 @@ fn test_rotated_out_verifiers_cannot_lock_an_invoice() {
                 &true,
             );
         }
-        client.remove_verifier(&admin, &rotating);
+        client.remove_verifier(&one(&env, &admin), &rotating);
     }
     assert_eq!(client.get_verifications(&invoice_id).len(), 60);
 
@@ -2894,7 +3104,7 @@ fn test_rotated_out_verifiers_cannot_lock_an_invoice() {
     // eviction policy this reverted, and the invoice could never be verified
     // again by anyone.
     let fresh = Address::generate(&env);
-    client.add_verifier(&admin, &fresh);
+    client.add_verifier(&one(&env, &admin), &fresh);
     client.attest(
         &invoice_id,
         &fresh,

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -3,10 +3,17 @@
 use soroban_sdk::{contract, contractimpl, symbol_short, token, Address, Env, Symbol, Vec};
 
 use invofi_common::{
-    assert_not_paused, resolve_token, ContractError, FinancingClient, FinancingOffer,
-    InsuranceClient, Invoice, InvoiceStatus, OfferStatus, PaymentRecord, RegistryClient,
-    ReputationClient, GRACE_PERIOD_SECS, MAX_OFFER_DURATION_SECS, MIN_OFFER_DURATION_SECS,
+    assert_not_paused, resolve_token, AdminConfig, ContractError, FinancingClient,
+    FinancingOffer, InsuranceClient, Invoice, InvoiceStatus, OfferStatus, PaymentRecord,
+    RegistryClient, ReputationClient, GRACE_PERIOD_SECS, MAX_OFFER_DURATION_SECS,
+    MIN_OFFER_DURATION_SECS,
 };
+
+/// Threshold-gated admin check (ADR-0010). See `invofi_common::assert_threshold`.
+fn assert_admin(env: &Env, signers: &Vec<Address>) {
+    let cfg = invofi_common::load_admin_config(env);
+    invofi_common::assert_threshold(env, &cfg, signers);
+}
 
 // ─── Overdue penalty (ADR-0007) ──────────────────────────────────────────────
 
@@ -175,12 +182,7 @@ impl RepaymentContract {
         financing: Address,
         token: Address,
     ) {
-        if env.storage().instance().has(&symbol_short!("admin")) {
-            panic!("Already initialized");
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &admin);
+        invofi_common::init_admin_config(&env, &admin);
         env.storage()
             .instance()
             .set(&symbol_short!("registry"), &registry);
@@ -192,27 +194,56 @@ impl RepaymentContract {
             .set(&symbol_short!("token"), &token);
     }
 
+    /// Returns the primary admin address (the first configured signer). See
+    /// `RegistryContract::get_admin` for the same caveat under true M-of-N.
     pub fn get_admin(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("admin"))
+        invofi_common::load_admin_config(&env)
+            .signers
+            .get(0)
             .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// The full M-of-N admin governance config. See ADR-0010.
+    pub fn get_admin_config(env: Env) -> AdminConfig {
+        invofi_common::load_admin_config(&env)
+    }
+
+    /// The current signer set.
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        invofi_common::load_admin_config(&env).signers
+    }
+
+    /// The current approval threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        invofi_common::load_admin_config(&env).threshold
+    }
+
+    /// Reconfigure the admin signer set and threshold. See
+    /// `RegistryContract::set_signers`.
+    pub fn set_signers(
+        env: Env,
+        signers: Vec<Address>,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        invofi_common::validate_signers(&env, &new_signers, new_threshold);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: new_threshold,
+            },
+        );
     }
 
     /// Register the insurance contract address. Admin only. When configured,
     /// reclaim (default) triggers a pool payout to the lender from the
     /// insurance pool (Task 10).
-    pub fn set_insurance(env: Env, admin: Address, insurance: Address) {
+    pub fn set_insurance(env: Env, signers: Vec<Address>, insurance: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("insadd"), &insurance);
@@ -225,17 +256,9 @@ impl RepaymentContract {
     /// Register the reputation contract address. Admin only. When configured,
     /// full repayments and defaults update the originator's reputation score
     /// (Task 11).
-    pub fn set_reputation(env: Env, admin: Address, reputation: Address) {
+    pub fn set_reputation(env: Env, signers: Vec<Address>, reputation: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("repadd"), &reputation);
@@ -252,17 +275,9 @@ impl RepaymentContract {
     /// fraction of that same base. Both default to 0, which disables accrual
     /// entirely — a freshly deployed contract behaves exactly as before until
     /// an admin calls this.
-    pub fn set_penalty(env: Env, admin: Address, penalty_bps: u32, cap_bps: u32) {
+    pub fn set_penalty(env: Env, signers: Vec<Address>, penalty_bps: u32, cap_bps: u32) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         if penalty_bps > MAX_PENALTY_BPS {
             env.panic_with_error(ContractError::InvalidInput);
         }
@@ -287,50 +302,33 @@ impl RepaymentContract {
         load_penalty_config(&env).1
     }
 
-    /// Transfers admin rights. Only current admin.
-    pub fn transfer_admin(env: Env, admin: Address, new_admin: Address) {
+    /// Transfers admin rights, collapsing the config back to a single new
+    /// admin. See `RegistryContract::transfer_admin`.
+    pub fn transfer_admin(env: Env, signers: Vec<Address>, new_admin: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &new_admin);
+        assert_admin(&env, &signers);
+        let mut new_signers = Vec::new(&env);
+        new_signers.push_back(new_admin);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: 1,
+            },
+        );
     }
 
     // ── Pause / unpause ──────────────────────────────────────────────────────
 
-    pub fn pause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn pause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &true);
     }
 
-    pub fn unpause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn unpause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &false);
@@ -445,10 +443,12 @@ impl RepaymentContract {
         // CEI: External interaction. Safe because this contract has no local state to protect.
         token_client.transfer(&repayer, &offer.lender, &lender_amount);
         if fee_amount > 0 {
-            let admin: Address = env
-                .storage()
-                .instance()
-                .get(&symbol_short!("admin"))
+            // Fees settle to the primary signer (the first configured admin
+            // address) — the same recipient as before under single-admin
+            // bootstrap mode; see ADR-0010.
+            let admin: Address = invofi_common::load_admin_config(&env)
+                .signers
+                .get(0)
                 .unwrap_or_else(|| panic!("Not initialized"));
             // CEI: External interaction. Safe because this contract has no local state to protect.
             token_client.transfer(&repayer, &admin, &fee_amount);

--- a/repayment/src/proptest.rs
+++ b/repayment/src/proptest.rs
@@ -12,6 +12,15 @@ use soroban_sdk::{
     token, Address, Env,
 };
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(2000))]
 
@@ -66,12 +75,12 @@ proptest! {
         );
         let rep = crate::RepaymentContractClient::new(&env, &repayment_id);
 
-        fin.set_repayment_contract(&admin, &repayment_id);
-        reg.set_repayment_contract(&admin, &repayment_id);
-        reg.set_financing_contract(&admin, &financing_id);
+        fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+        reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+        reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
         // Set fee
-        reg.set_fee(&admin, &fee_bps);
+        reg.set_fee(&one(&env, &admin), &fee_bps);
 
         // Register invoice
         reg.register_invoice(

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -13,6 +13,15 @@ use soroban_sdk::{
     token, Address, Env,
 };
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 /// Deploy all three contracts (registry, financing, repayment) and return
 /// their clients. All share the same admin and token.
 fn setup_contracts<'a>(
@@ -46,12 +55,12 @@ fn setup_contracts<'a>(
     let rep = super::RepaymentContractClient::new(env, &repayment_id);
 
     // Register repayment contract with financing (for authorized callbacks)
-    fin.set_repayment_contract(admin, &repayment_id);
+    fin.set_repayment_contract(&one(env, admin), &repayment_id);
 
     // Register both contracts as trusted callers on the registry so the
     // cross-contract status transitions (accept + repay) are allowed.
-    reg.set_repayment_contract(admin, &repayment_id);
-    reg.set_financing_contract(admin, &financing_id);
+    reg.set_repayment_contract(&one(env, admin), &repayment_id);
+    reg.set_financing_contract(&one(env, admin), &financing_id);
 
     (reg, fin, rep)
 }
@@ -119,9 +128,9 @@ fn test_repay_invoice_partial_then_full() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     // Register invoice
     reg.register_invoice(
@@ -235,9 +244,9 @@ fn test_repay_invoice_overpayment_panics() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &symbol_short!("inv_op"),
@@ -340,9 +349,9 @@ fn test_repay_zero_amount_panics() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &symbol_short!("inv_za"),
@@ -408,9 +417,9 @@ fn test_reclaim_invoice_after_grace_period() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &invoice_id,
@@ -482,9 +491,9 @@ fn test_reclaim_before_grace_period_panics() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &invoice_id,
@@ -545,9 +554,9 @@ fn test_reclaim_on_non_overdue_panics() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &symbol_short!("inv_nr"),
@@ -605,9 +614,9 @@ fn test_calculate_total_due() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, 10_000i128);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &symbol_short!("inv_td"),
@@ -669,9 +678,9 @@ fn test_calculate_total_due_after_partial() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &symbol_short!("inv_tp"),
@@ -753,6 +762,32 @@ fn test_get_duration_limits() {
     assert_eq!(max, invofi_common::MAX_OFFER_DURATION_SECS);
 }
 
+// ─── Multisig admin governance tests (ADR-0010) ─────────────────────────────
+
+#[test]
+fn test_repayment_set_signers_requires_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let token = create_token(&env);
+    let (_reg, _fin, rep) = setup_contracts(&env, &admin, &token);
+
+    let b = Address::generate(&env);
+    let mut two_signers = soroban_sdk::Vec::new(&env);
+    two_signers.push_back(admin.clone());
+    two_signers.push_back(b.clone());
+    rep.set_signers(&one(&env, &admin), &two_signers, &2u32);
+
+    let result = rep.try_pause(&one(&env, &admin));
+    assert!(result.is_err(), "one of two required signatures must not pause");
+
+    let mut both = soroban_sdk::Vec::new(&env);
+    both.push_back(admin.clone());
+    both.push_back(b.clone());
+    rep.pause(&both);
+    assert!(rep.contract_is_paused());
+}
+
 // ─── Task 4A: emergency pause / circuit breaker ──────────────────────────────
 
 #[test]
@@ -791,9 +826,9 @@ fn test_pause_blocks_repay_invoice() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &invoice_id,
@@ -813,7 +848,7 @@ fn test_pause_blocks_repay_invoice() {
     );
     fin.accept_offer(&offer_id, &originator);
 
-    rep.pause(&admin);
+    rep.pause(&one(&env, &admin));
     rep.repay_invoice(&invoice_id, &offer_id, &originator, &amount);
 }
 
@@ -828,7 +863,7 @@ fn test_pause_blocks_all_repayment_state_changes() {
     let reputation = Address::generate(&env);
     let new_admin = Address::generate(&env);
 
-    rep.pause(&admin);
+    rep.pause(&one(&env, &admin));
     fn assert_paused<F: FnOnce()>(f: F) {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
         assert!(result.is_err(), "state-changing function should panic while paused");
@@ -853,13 +888,13 @@ fn test_pause_blocks_all_repayment_state_changes() {
         );
     });
     assert_paused(|| {
-        rep.set_insurance(&admin, &insurance);
+        rep.set_insurance(&one(&env, &admin), &insurance);
     });
     assert_paused(|| {
-        rep.set_reputation(&admin, &reputation);
+        rep.set_reputation(&one(&env, &admin), &reputation);
     });
     assert_paused(|| {
-        rep.transfer_admin(&admin, &new_admin);
+        rep.transfer_admin(&one(&env, &admin), &new_admin);
     });
 
     assert_eq!(rep.get_duration_limits().0, invofi_common::MIN_OFFER_DURATION_SECS);
@@ -904,9 +939,9 @@ fn test_reclaim_triggers_defaulted_payout_and_reputation() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     // Insurance pool, funded by a third-party staker with the same token
     // the loan settles in (300M coverage against a 1.05B obligation).
@@ -922,19 +957,19 @@ fn test_reclaim_triggers_defaulted_payout_and_reputation() {
         &(env.ledger().sequence() + 1000),
     );
     ins.stake(&staker, &300_000_000);
-    ins.set_payout_caller(&admin, &repayment_id);
+    ins.set_payout_caller(&one(&env, &admin), &repayment_id);
     // Wire the registry into the insurance contract so pay_out can verify
     // the invoice is Defaulted on-chain before moving staked funds.
-    ins.set_registry(&admin, &registry_id);
+    ins.set_registry(&one(&env, &admin), &registry_id);
 
     // Reputation contract, recorder = repayment.
     let reputation_id = env.register(ReputationContract, (admin.clone(),));
     let repu = invofi_reputation::ReputationContractClient::new(&env, &reputation_id);
-    repu.set_recorder(&admin, &repayment_id);
+    repu.set_recorder(&one(&env, &admin), &repayment_id);
 
     // Wire repayment -> insurance + reputation.
-    rep.set_insurance(&admin, &insurance_id);
-    rep.set_reputation(&admin, &reputation_id);
+    rep.set_insurance(&one(&env, &admin), &insurance_id);
+    rep.set_reputation(&one(&env, &admin), &reputation_id);
 
     reg.register_invoice(
         &invoice_id,
@@ -1022,14 +1057,14 @@ fn test_full_repay_records_reputation_success() {
     let rep = super::RepaymentContractClient::new(&env, &repayment_id);
 
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     let reputation_id = env.register(ReputationContract, (admin.clone(),));
     let repu = invofi_reputation::ReputationContractClient::new(&env, &reputation_id);
-    repu.set_recorder(&admin, &repayment_id);
-    rep.set_reputation(&admin, &reputation_id);
+    repu.set_recorder(&one(&env, &admin), &repayment_id);
+    rep.set_reputation(&one(&env, &admin), &reputation_id);
 
     reg.register_invoice(
         &invoice_id,
@@ -1258,9 +1293,9 @@ fn setup_penalty_case<'a>(env: &'a Env) -> PenCase<'a> {
     let rep = super::RepaymentContractClient::new(env, &repayment_id);
 
     mint_and_approve(env, &token_id, &financing_id, &lender, PEN_AMOUNT);
-    fin.set_repayment_contract(&admin, &repayment_id);
-    reg.set_repayment_contract(&admin, &repayment_id);
-    reg.set_financing_contract(&admin, &financing_id);
+    fin.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_repayment_contract(&one(&env, &admin), &repayment_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
     reg.register_invoice(
         &symbol_short!("inv_pen"),
@@ -1334,7 +1369,7 @@ fn test_penalty_zero_cap_disables_accrual() {
 
     // A rate with a zero ceiling accrues nothing — the cap is a hard bound,
     // so a zero cap is a hard zero.
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &0u32);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &0u32);
     at_days_overdue(&env, 10);
     assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
 }
@@ -1345,7 +1380,7 @@ fn test_penalty_accrues_in_whole_days() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     at_days_overdue(&env, 1);
     assert_eq!(
@@ -1374,7 +1409,7 @@ fn test_penalty_truncates_partial_day_toward_borrower() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     // One second short of day 5: the day in progress is not charged, so the
     // borrower is billed for 4 days. ADR-0007 decision 3 — rounding runs in
@@ -1399,7 +1434,7 @@ fn test_penalty_not_accrued_before_or_at_due_date() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     env.ledger().set_timestamp(PEN_DUE_DATE - 1);
     assert_eq!(c.rep.calculate_penalty(&symbol_short!("off_pen")), 0);
@@ -1419,7 +1454,7 @@ fn test_penalty_stops_at_hard_cap() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     // Day 299: still below the ceiling, accruing linearly.
     at_days_overdue(&env, 299);
@@ -1446,7 +1481,7 @@ fn test_penalty_base_frozen_across_partial_repayment() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     at_days_overdue(&env, 5);
     let before = c.rep.calculate_penalty(&symbol_short!("off_pen"));
@@ -1489,7 +1524,7 @@ fn test_penalty_must_be_settled_for_full_repayment() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     at_days_overdue(&env, 5);
     let _penalty = 5 * PEN_PER_DAY;
@@ -1540,7 +1575,7 @@ fn test_penalty_overpayment_beyond_accrued_total_panics() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     at_days_overdue(&env, 5);
     // Total owed = principal + pro-rata interest + penalty.
@@ -1561,7 +1596,7 @@ fn test_penalty_accrues_while_invoice_marked_overdue() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     // Accrual is anchored on due_date, not on the status transition, so
     // flipping the invoice to Overdue neither starts nor resets the meter.
@@ -1587,7 +1622,7 @@ fn test_penalty_excluded_from_insurance_payout() {
     env.mock_all_auths();
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 
     // A pool deliberately deep enough to cover the full claim, so the
     // assertion below distinguishes "penalty excluded" from "pool exhausted".
@@ -1604,11 +1639,11 @@ fn test_penalty_excluded_from_insurance_payout() {
         &(env.ledger().sequence() + 1000),
     );
     ins.stake(&staker, &3_000_000_000);
-    ins.set_payout_caller(&c.admin, &c.repayment_id);
+    ins.set_payout_caller(&one(&env, &c.admin), &c.repayment_id);
     // pay_out verifies on-chain that the invoice is Defaulted before moving
     // staked funds, so the pool needs the registry wired or it fails closed.
-    ins.set_registry(&c.admin, &c.registry_id);
-    c.rep.set_insurance(&c.admin, &insurance_id);
+    ins.set_registry(&one(&env, &c.admin), &c.registry_id);
+    c.rep.set_insurance(&one(&env, &c.admin), &insurance_id);
 
     // Past due plus the grace period, then default.
     env.ledger()
@@ -1643,7 +1678,7 @@ fn test_set_penalty_admin_only() {
     let c = setup_penalty_case(&env);
 
     let stranger = Address::generate(&env);
-    c.rep.set_penalty(&stranger, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &stranger), &PEN_BPS, &PEN_CAP_BPS);
 }
 
 #[test]
@@ -1654,7 +1689,7 @@ fn test_set_penalty_rejects_excessive_rate() {
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
 
-    c.rep.set_penalty(&c.admin, &501u32, &PEN_CAP_BPS);
+    c.rep.set_penalty(&one(&env, &c.admin), &501u32, &PEN_CAP_BPS);
 }
 
 #[test]
@@ -1665,7 +1700,7 @@ fn test_set_penalty_rejects_excessive_cap() {
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
 
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &10_001u32);
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &10_001u32);
 }
 
 #[test]
@@ -1676,6 +1711,6 @@ fn test_set_penalty_blocked_while_paused() {
     env.ledger().set_timestamp(PEN_DUE_DATE - 2_592_000);
     let c = setup_penalty_case(&env);
 
-    c.rep.pause(&c.admin);
-    c.rep.set_penalty(&c.admin, &PEN_BPS, &PEN_CAP_BPS);
+    c.rep.pause(&one(&env, &c.admin));
+    c.rep.set_penalty(&one(&env, &c.admin), &PEN_BPS, &PEN_CAP_BPS);
 }

--- a/reputation/src/lib.rs
+++ b/reputation/src/lib.rs
@@ -18,9 +18,15 @@
 //! `resolve_dispute` — the `-2` penalty stops counting against them. The
 //! rule is documented in ADR-0004 §7.
 
-use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map};
+use soroban_sdk::{contract, contractimpl, contracttype, symbol_short, Address, Env, Map, Vec};
 
-use invofi_common::{assert_not_paused, ContractError};
+use invofi_common::{assert_not_paused, AdminConfig, ContractError};
+
+/// Threshold-gated admin check (ADR-0010). See `invofi_common::assert_threshold`.
+fn assert_admin(env: &Env, signers: &Vec<Address>) {
+    let cfg = invofi_common::load_admin_config(env);
+    invofi_common::assert_threshold(env, &cfg, signers);
+}
 
 /// Outcome discriminant for a successful full repayment.
 pub const OUTCOME_REPAID: u32 = 0;
@@ -65,35 +71,75 @@ impl ReputationContract {
     /// of the deploy operation, which only the deployer can authorize. There
     /// is therefore no separate initialize() call to front-run (issue #75).
     pub fn __constructor(env: Env, admin: Address) {
-        if env.storage().instance().has(&symbol_short!("admin")) {
-            panic!("Already initialized");
-        }
-        env.storage()
-            .instance()
-            .set(&symbol_short!("admin"), &admin);
+        invofi_common::init_admin_config(&env, &admin);
     }
 
+    /// Returns the primary admin address (the first configured signer). See
+    /// `RegistryContract::get_admin` for the same caveat under true M-of-N.
     pub fn get_admin(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&symbol_short!("admin"))
+        invofi_common::load_admin_config(&env)
+            .signers
+            .get(0)
             .unwrap_or_else(|| panic!("Not initialized"))
+    }
+
+    /// The full M-of-N admin governance config. See ADR-0010.
+    pub fn get_admin_config(env: Env) -> AdminConfig {
+        invofi_common::load_admin_config(&env)
+    }
+
+    /// The current signer set.
+    pub fn get_signers(env: Env) -> Vec<Address> {
+        invofi_common::load_admin_config(&env).signers
+    }
+
+    /// The current approval threshold.
+    pub fn get_threshold(env: Env) -> u32 {
+        invofi_common::load_admin_config(&env).threshold
+    }
+
+    /// Reconfigure the admin signer set and threshold. See
+    /// `RegistryContract::set_signers`.
+    pub fn set_signers(
+        env: Env,
+        signers: Vec<Address>,
+        new_signers: Vec<Address>,
+        new_threshold: u32,
+    ) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        invofi_common::validate_signers(&env, &new_signers, new_threshold);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: new_threshold,
+            },
+        );
+    }
+
+    /// Transfers admin rights, collapsing the config back to a single new
+    /// admin. See `RegistryContract::transfer_admin`.
+    pub fn transfer_admin(env: Env, signers: Vec<Address>, new_admin: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        let mut new_signers = Vec::new(&env);
+        new_signers.push_back(new_admin);
+        invofi_common::save_admin_config(
+            &env,
+            &AdminConfig {
+                signers: new_signers,
+                threshold: 1,
+            },
+        );
     }
 
     /// Configure the address allowed to record outcomes — this is the
     /// repayment contract. Admin only. Recording is disabled until a
     /// recorder is configured (fail-closed).
-    pub fn set_recorder(env: Env, admin: Address, recorder: Address) {
+    pub fn set_recorder(env: Env, signers: Vec<Address>, recorder: Address) {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("recorder"), &recorder);
@@ -105,31 +151,15 @@ impl ReputationContract {
 
     // ── Pause / unpause (Task 4A circuit breaker) ───────────────────────────
 
-    pub fn pause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn pause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &true);
     }
 
-    pub fn unpause(env: Env, admin: Address) {
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+    pub fn unpause(env: Env, signers: Vec<Address>) {
+        assert_admin(&env, &signers);
         env.storage()
             .instance()
             .set(&symbol_short!("paused"), &false);
@@ -198,20 +228,12 @@ impl ReputationContract {
     /// read-only. Returns the originator's corrected score.
     pub fn resolve_dispute(
         env: Env,
-        admin: Address,
+        signers: Vec<Address>,
         originator: Address,
         originator_favourable: bool,
     ) -> i128 {
         assert_not_paused(&env);
-        admin.require_auth();
-        let current: Address = env
-            .storage()
-            .instance()
-            .get(&symbol_short!("admin"))
-            .unwrap_or_else(|| panic!("Not initialized"));
-        if current != admin {
-            env.panic_with_error(ContractError::Unauthorized);
-        }
+        assert_admin(&env, &signers);
 
         let mut records = load_records(&env);
         let mut record = records.get(originator.clone()).unwrap_or(ReputationRecord {

--- a/reputation/src/test.rs
+++ b/reputation/src/test.rs
@@ -8,11 +8,57 @@ use soroban_sdk::{
     Address, Env, Symbol, TryFromVal,
 };
 
+/// Wrap a single signer in the one-element `Vec<Address>` the threshold-gated
+/// admin API expects (ADR-0010). Single-admin/bootstrap deployments pass
+/// exactly this.
+fn one(env: &Env, signer: &Address) -> soroban_sdk::Vec<Address> {
+    let mut v = soroban_sdk::Vec::new(env);
+    v.push_back(signer.clone());
+    v
+}
+
 /// Deploy the reputation contract and initialize.
 fn setup<'a>(env: &'a Env, admin: &Address) -> super::ReputationContractClient<'a> {
     let rep_id = env.register(ReputationContract, (admin.clone(),));
     let client = super::ReputationContractClient::new(env, &rep_id);
     client
+}
+
+// ─── Multisig admin governance tests (ADR-0010) ─────────────────────────────
+
+#[test]
+fn test_reputation_set_signers_requires_threshold() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let client = setup(&env, &admin);
+
+    let b = Address::generate(&env);
+    let mut two_signers = soroban_sdk::Vec::new(&env);
+    two_signers.push_back(admin.clone());
+    two_signers.push_back(b.clone());
+    client.set_signers(&one(&env, &admin), &two_signers, &2u32);
+
+    let result = client.try_pause(&one(&env, &admin));
+    assert!(result.is_err(), "one of two required signatures must not pause");
+
+    let mut both = soroban_sdk::Vec::new(&env);
+    both.push_back(admin.clone());
+    both.push_back(b.clone());
+    client.pause(&both);
+    assert!(client.contract_is_paused());
+}
+
+#[test]
+fn test_reputation_transfer_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let client = setup(&env, &admin);
+    let new_admin = Address::generate(&env);
+
+    client.transfer_admin(&one(&env, &admin), &new_admin);
+    assert_eq!(client.get_admin(), new_admin);
 }
 
 // ─── Scoring tests ───────────────────────────────────────────────────────────
@@ -31,7 +77,7 @@ fn test_score_after_sequence_of_outcomes() {
     assert_eq!(client.get_score(&originator), 0);
 
     // No recorder configured yet — recording is disabled.
-    client.set_recorder(&admin, &recorder);
+    client.set_recorder(&one(&env, &admin), &recorder);
     assert_eq!(client.get_recorder(), Some(recorder.clone()));
 
     // 1 repayment -> score 1.
@@ -114,7 +160,7 @@ fn test_pause_blocks_all_reputation_state_changes() {
     let originator = Address::generate(&env);
     let recorder = Address::generate(&env);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     fn assert_paused<F: FnOnce()>(f: F) {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
         assert!(result.is_err(), "state-changing function should panic while paused");
@@ -124,7 +170,7 @@ fn test_pause_blocks_all_reputation_state_changes() {
         client.record_outcome(&originator, &OUTCOME_REPAID);
     });
     assert_paused(|| {
-        client.set_recorder(&admin, &recorder);
+        client.set_recorder(&one(&env, &admin), &recorder);
     });
 
     assert_eq!(client.get_score(&originator), 0);
@@ -141,7 +187,7 @@ fn test_record_outcome_invalid_outcome_panics() {
     let recorder = Address::generate(&env);
     let originator = Address::generate(&env);
     let client = setup(&env, &admin);
-    client.set_recorder(&admin, &recorder);
+    client.set_recorder(&one(&env, &admin), &recorder);
 
     client.record_outcome(&originator, &99);
 }
@@ -157,7 +203,7 @@ fn test_resolve_dispute_favourable_neutralizes_default() {
     let recorder = Address::generate(&env);
     let originator = Address::generate(&env);
     let client = setup(&env, &admin);
-    client.set_recorder(&admin, &recorder);
+    client.set_recorder(&one(&env, &admin), &recorder);
 
     // 2 repayments + 1 default -> 2 - 2 = 0: the default penalty outweighs
     // the successful repayments.
@@ -167,7 +213,7 @@ fn test_resolve_dispute_favourable_neutralizes_default() {
     assert_eq!(client.get_score(&originator), 0);
 
     // Dispute resolves in the originator's favour -> default neutralized.
-    let corrected = client.resolve_dispute(&admin, &originator, &true);
+    let corrected = client.resolve_dispute(&one(&env, &admin), &originator, &true);
     assert_eq!(corrected, 2);
     assert_eq!(client.get_score(&originator), 2);
 
@@ -186,7 +232,7 @@ fn test_resolve_dispute_favourable_without_default_is_noop() {
     let client = setup(&env, &admin);
 
     // Fresh originator — nothing to neutralize, score stays 0.
-    let corrected = client.resolve_dispute(&admin, &originator, &true);
+    let corrected = client.resolve_dispute(&one(&env, &admin), &originator, &true);
     assert_eq!(corrected, 0);
     assert_eq!(client.get_score(&originator), 0);
     assert_eq!(client.get_record(&originator).defaults, 0);
@@ -201,14 +247,14 @@ fn test_resolve_dispute_unfavourable_leaves_record_unchanged() {
     let recorder = Address::generate(&env);
     let originator = Address::generate(&env);
     let client = setup(&env, &admin);
-    client.set_recorder(&admin, &recorder);
+    client.set_recorder(&one(&env, &admin), &recorder);
 
     client.record_outcome(&originator, &OUTCOME_REPAID);
     client.record_outcome(&originator, &OUTCOME_DEFAULTED);
     assert_eq!(client.get_score(&originator), 0);
 
     // Resolution against the originator: the recorded outcome stands.
-    let corrected = client.resolve_dispute(&admin, &originator, &false);
+    let corrected = client.resolve_dispute(&one(&env, &admin), &originator, &false);
     assert_eq!(corrected, 0);
     assert_eq!(client.get_score(&originator), 0);
     assert_eq!(client.get_record(&originator).defaults, 1);
@@ -225,7 +271,7 @@ fn test_resolve_dispute_non_admin_panics() {
     let client = setup(&env, &admin);
 
     let impostor = Address::generate(&env);
-    client.resolve_dispute(&impostor, &originator, &true);
+    client.resolve_dispute(&one(&env, &impostor), &originator, &true);
 }
 
 #[test]
@@ -236,9 +282,9 @@ fn test_resolve_dispute_paused_panics() {
     let client = setup(&env, &admin);
     let originator = Address::generate(&env);
 
-    client.pause(&admin);
+    client.pause(&one(&env, &admin));
     let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        client.resolve_dispute(&admin, &originator, &true);
+        client.resolve_dispute(&one(&env, &admin), &originator, &true);
     }));
     assert!(result.is_err(), "resolve_dispute must panic while paused");
 }
@@ -267,14 +313,14 @@ fn test_resolve_dispute_emits_corrected_score_event() {
     let recorder = Address::generate(&env);
     let originator = Address::generate(&env);
     let client = setup(&env, &admin);
-    client.set_recorder(&admin, &recorder);
+    client.set_recorder(&one(&env, &admin), &recorder);
 
     client.record_outcome(&originator, &OUTCOME_REPAID);
     client.record_outcome(&originator, &OUTCOME_REPAID);
     client.record_outcome(&originator, &OUTCOME_DEFAULTED);
     assert_eq!(count_events(&env, symbol_short!("rep_chg")), 0);
 
-    let corrected = client.resolve_dispute(&admin, &originator, &true);
+    let corrected = client.resolve_dispute(&one(&env, &admin), &originator, &true);
     assert_eq!(corrected, 2);
     assert_eq!(count_events(&env, symbol_short!("rep_chg")), 1);
 
@@ -293,6 +339,6 @@ fn test_resolve_dispute_emits_corrected_score_event() {
 
     // Unfavourable resolution emits nothing — the event window holds only
     // the most recent invocation, so the count drops back to 0.
-    client.resolve_dispute(&admin, &originator, &false);
+    client.resolve_dispute(&one(&env, &admin), &originator, &false);
     assert_eq!(count_events(&env, symbol_short!("rep_chg")), 0);
 }


### PR DESCRIPTION
Closes #50

## Summary

Every InvoFi contract (registry, financing, repayment, insurance, reputation) bound a single admin `Address` at deploy and gated every `set_*` / `pause` / `unpause` / `resolve_dispute` / `transfer_admin` call on one `require_auth()` check against it — a single compromised key could pause or reconfigure the whole protocol. This PR replaces that with an M-of-N threshold admin model (`AdminConfig { signers, threshold }` in `invofi_common`), keeps single-admin as the deploy-time bootstrap default, and migrates every admin-gated entry point across all five contracts.

Design, alternatives considered, and the migration path are written up in `docs/adr/0010-multisig-admin-governance.md`.

## How it works

- `AdminConfig { signers: Vec<Address>, threshold: u32 }` replaces the single stored admin `Address`.
- `invofi_common::assert_threshold(env, cfg, provided)` requires each address in `provided` to be a distinct, configured signer and to `require_auth()` **within the same transaction** — no on-chain proposal queue. Soroban already lets one transaction carry a separate signed authorization entry per address, so an M-of-N call is just a transaction whose signer list has `threshold` (or more) pre-signed entries, collected off-chain and submitted together. This mirrors ADR-0001's "same-block, no timelock" pause philosophy rather than introducing async on-chain approvals.
- Every constructor is unchanged (`admin: Address`) and boots into **single-admin bootstrap mode** (`signers: [admin], threshold: 1`) via `invofi_common::init_admin_config`. Under bootstrap mode every threshold-gated call takes a one-element `Vec<Address>` and behaves exactly like the old single-admin check.
- A new `set_signers(signers, new_signers, new_threshold)` on every contract is the only way to reconfigure the signer set / threshold, itself gated by the *current* threshold. `transfer_admin` keeps its original meaning as a full handoff that collapses the config to one new signer at threshold 1.
- `invofi_common::validate_signers` enforces non-empty, `1 <= threshold <= signers.len()`, no duplicate address, and a new `MAX_ADMIN_SIGNERS` (20) cap.

## What changed

### New files
- `docs/adr/0010-multisig-admin-governance.md` — the ADR: context, decision, alternatives considered (rejected an on-chain proposal queue), and the migration path for already-deployed instances.

### Modified — production code
- `common/src/lib.rs` — adds `AdminConfig`, `MAX_ADMIN_SIGNERS`, `init_admin_config`, `load_admin_config`, `save_admin_config`, `is_signer`, `validate_signers`, `assert_threshold`.
- `registry/src/lib.rs`, `financing/src/lib.rs`, `repayment/src/lib.rs`, `insurance/src/lib.rs`, `reputation/src/lib.rs` — every admin-gated function's first argument changes from `admin: Address` to `signers: Vec<Address>`; each contract gets a thin `assert_admin` wrapper around `invofi_common::assert_threshold`, plus new `get_admin_config`, `get_signers`, `get_threshold`, and `set_signers`. `get_admin()` is kept for backward compatibility and now returns the primary signer. `reputation` additionally gains `transfer_admin` (it didn't have one before, for consistency with the other four contracts). Repayment's protocol-fee recipient (previously the raw stored admin) now resolves to the primary signer.
- `.github/workflows/deploy-contract.yml`, `.github/workflows/deploy-mainnet.yml` — the post-deploy wiring `stellar contract invoke` calls pass `--signers '["<address>"]'` (a JSON array) instead of `--admin <address>` for every migrated function; constructor deploy calls are unchanged (`--admin` still binds the bootstrap admin).
- `CHANGELOG.md`, `docs/adr/README.md` — new entries.

### Test files
- `registry/src/test.rs` — 9 new tests covering bootstrap defaults, `set_signers` upgrading to true M-of-N, threshold enforcement (one-of-two rejected, two-of-two accepted), rejection of a non-configured address padding out the signer count, rejection of a duplicated signer double-counting, `set_signers` authorization and input validation (bad threshold, empty/duplicate signer set), and `transfer_admin` collapsing a multisig config back to single-admin. All ~90 pre-existing admin/pause/set_* call sites updated to the new `Vec<Address>` signature via a small `one(env, addr)` test helper that wraps a single signer — this is what keeps bootstrap-mode test behavior identical to before.
- `financing/src/test.rs`, `repayment/src/test.rs`, `insurance/src/test.rs`, `reputation/src/test.rs`, `repayment/src/proptest.rs` — same `one()` helper + call-site migration, plus one threshold-enforcement test per contract (`set_signers` to 2-of-N, confirm one signature is rejected and two succeed).
- `integration/src/test.rs` — call-site migration only (no new tests; cross-contract wiring already exercised by the per-crate tests above).

## Testing

- `cargo build --workspace --tests` — clean.
- `cargo test --workspace` — all tests pass (`cargo nextest run` also works, per CONTRIBUTING).
- `cargo clippy --target wasm32v1-none -- -D warnings` — clean.

### How to test locally

```bash
cargo test --workspace
# or, matching CI:
cargo nextest run --target "$(rustc -vV | sed -n 's/^host: //p')"
```

To see the threshold behavior directly, the new tests named `test_multisig_*` and `*_set_signers_requires_threshold` in each contract's `test.rs` are the ones to read first — they deploy a contract, call `set_signers` to move from bootstrap (1-of-1) to 2-of-3 (or 2-of-2), and assert that a call authorized by only one signer is rejected while a call authorized by two succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added M-of-N multisignature administration across protocol contracts.
  * Administrators can configure signer sets and approval thresholds.
  * Added visibility into configured signers, thresholds, and full admin settings.
  * Admin transfers can reset governance to a single signer.
* **Breaking Changes**
  * Administrative actions now require signer lists instead of a single admin address.
  * Deployment and contract-wiring commands use the new signer authorization format.
* **Validation**
  * Offer interest rates above 100% are now rejected.
* **Documentation**
  * Added ADR-0010 and changelog coverage for multisig governance and migration considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->