### PR TITLE
feat(registry): batch invoice registration for business onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and are enforced by commitlint in CI.
 ## [Unreleased]
 
 ### Added
+- **Multisig threshold boundary tests (issue #128)** — six new tests covering
+  the exact N, N-1, N+1 threshold boundaries for M-of-N admin governance
+  (ADR-0010). Tests verify: 2-of-3 (N-1 fails, N succeeds, N+1 succeeds),
+  1-of-1 (N-1 fails, N succeeds), 3-of-3 (N-1 fails, N succeeds), and
+  threshold enforcement on non-pause admin ops (`set_rate`, `set_signers`)
+  to confirm the check is applied uniformly.
 - **M-of-N admin governance / multisig (issue #50)** — every contract's admin
   surface (`set_*`, `pause`/`unpause`, `resolve_dispute`, `transfer_admin`) is
   now gated by a threshold over a configurable set of signer addresses

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -765,12 +765,7 @@ pub trait InsuranceInterface {
     /// Claim a partial payout from the insurance pool for a specific offer.
     /// The claim amount is bounded by the reserved amount for this offer and
     /// the pool's available balance. Returns (paid, remaining_reserved).
-    fn claim_payout(
-        env: Env,
-        offer_id: Symbol,
-        lender: Address,
-        amount: i128,
-    ) -> (i128, i128);
+    fn claim_payout(env: Env, offer_id: Symbol, lender: Address, amount: i128) -> (i128, i128);
 }
 
 // ─── Reputation Cross-Contract Interface ─────────────────────────────────────
@@ -820,24 +815,72 @@ mod transition_tests {
     }
 
     // Pending exits
-    legal!(pending_to_financed,  InvoiceStatus::Pending,  InvoiceStatus::Financed);
-    legal!(pending_to_cancelled, InvoiceStatus::Pending,  InvoiceStatus::Cancelled);
+    legal!(
+        pending_to_financed,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Financed
+    );
+    legal!(
+        pending_to_cancelled,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Cancelled
+    );
 
     // Financed exits
-    legal!(financed_to_financed, InvoiceStatus::Financed, InvoiceStatus::Financed); // partial repayment
-    legal!(financed_to_repaid,   InvoiceStatus::Financed, InvoiceStatus::Repaid);
-    legal!(financed_to_overdue,  InvoiceStatus::Financed, InvoiceStatus::Overdue);
-    legal!(financed_to_disputed, InvoiceStatus::Financed, InvoiceStatus::Disputed);
+    legal!(
+        financed_to_financed,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Financed
+    ); // partial repayment
+    legal!(
+        financed_to_repaid,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Repaid
+    );
+    legal!(
+        financed_to_overdue,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Overdue
+    );
+    legal!(
+        financed_to_disputed,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Disputed
+    );
 
     // Overdue exits
-    legal!(overdue_to_defaulted, InvoiceStatus::Overdue,  InvoiceStatus::Defaulted);
+    legal!(
+        overdue_to_defaulted,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Defaulted
+    );
 
     // Disputed exits (resolve_dispute)
-    legal!(disputed_to_pending,   InvoiceStatus::Disputed, InvoiceStatus::Pending);
-    legal!(disputed_to_financed,  InvoiceStatus::Disputed, InvoiceStatus::Financed);
-    legal!(disputed_to_repaid,    InvoiceStatus::Disputed, InvoiceStatus::Repaid);
-    legal!(disputed_to_cancelled, InvoiceStatus::Disputed, InvoiceStatus::Cancelled);
-    legal!(disputed_to_defaulted, InvoiceStatus::Disputed, InvoiceStatus::Defaulted);
+    legal!(
+        disputed_to_pending,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Pending
+    );
+    legal!(
+        disputed_to_financed,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Financed
+    );
+    legal!(
+        disputed_to_repaid,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Repaid
+    );
+    legal!(
+        disputed_to_cancelled,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Cancelled
+    );
+    legal!(
+        disputed_to_defaulted,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Defaulted
+    );
 
     // ── Illegal transitions ───────────────────────────────────────────────────
     //
@@ -856,64 +899,212 @@ mod transition_tests {
     }
 
     // Pending — illegal targets
-    illegal!(pending_to_pending,   InvoiceStatus::Pending, InvoiceStatus::Pending);
-    illegal!(pending_to_repaid,    InvoiceStatus::Pending, InvoiceStatus::Repaid);   // the motivating example
-    illegal!(pending_to_overdue,   InvoiceStatus::Pending, InvoiceStatus::Overdue);
-    illegal!(pending_to_disputed,  InvoiceStatus::Pending, InvoiceStatus::Disputed);
-    illegal!(pending_to_defaulted, InvoiceStatus::Pending, InvoiceStatus::Defaulted);
+    illegal!(
+        pending_to_pending,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Pending
+    );
+    illegal!(
+        pending_to_repaid,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Repaid
+    ); // the motivating example
+    illegal!(
+        pending_to_overdue,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Overdue
+    );
+    illegal!(
+        pending_to_disputed,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Disputed
+    );
+    illegal!(
+        pending_to_defaulted,
+        InvoiceStatus::Pending,
+        InvoiceStatus::Defaulted
+    );
 
     // Financed — illegal targets
-    illegal!(financed_to_pending,    InvoiceStatus::Financed, InvoiceStatus::Pending);
-    illegal!(financed_to_cancelled,  InvoiceStatus::Financed, InvoiceStatus::Cancelled);
-    illegal!(financed_to_defaulted,  InvoiceStatus::Financed, InvoiceStatus::Defaulted);
+    illegal!(
+        financed_to_pending,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Pending
+    );
+    illegal!(
+        financed_to_cancelled,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Cancelled
+    );
+    illegal!(
+        financed_to_defaulted,
+        InvoiceStatus::Financed,
+        InvoiceStatus::Defaulted
+    );
 
     // Overdue — illegal targets
-    illegal!(overdue_to_pending,   InvoiceStatus::Overdue, InvoiceStatus::Pending);
-    illegal!(overdue_to_financed,  InvoiceStatus::Overdue, InvoiceStatus::Financed);
-    illegal!(overdue_to_repaid,    InvoiceStatus::Overdue, InvoiceStatus::Repaid);
-    illegal!(overdue_to_overdue,   InvoiceStatus::Overdue, InvoiceStatus::Overdue);
-    illegal!(overdue_to_cancelled, InvoiceStatus::Overdue, InvoiceStatus::Cancelled);
-    illegal!(overdue_to_disputed,  InvoiceStatus::Overdue, InvoiceStatus::Disputed);
+    illegal!(
+        overdue_to_pending,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Pending
+    );
+    illegal!(
+        overdue_to_financed,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Financed
+    );
+    illegal!(
+        overdue_to_repaid,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Repaid
+    );
+    illegal!(
+        overdue_to_overdue,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Overdue
+    );
+    illegal!(
+        overdue_to_cancelled,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Cancelled
+    );
+    illegal!(
+        overdue_to_disputed,
+        InvoiceStatus::Overdue,
+        InvoiceStatus::Disputed
+    );
 
     // Disputed — illegal targets (anything not in the five allowed)
-    illegal!(disputed_to_overdue,  InvoiceStatus::Disputed, InvoiceStatus::Overdue);
-    illegal!(disputed_to_disputed, InvoiceStatus::Disputed, InvoiceStatus::Disputed);
+    illegal!(
+        disputed_to_overdue,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Overdue
+    );
+    illegal!(
+        disputed_to_disputed,
+        InvoiceStatus::Disputed,
+        InvoiceStatus::Disputed
+    );
 
     // Terminal states — nothing may leave them
-    illegal!(repaid_to_pending,    InvoiceStatus::Repaid,    InvoiceStatus::Pending);
-    illegal!(repaid_to_financed,   InvoiceStatus::Repaid,    InvoiceStatus::Financed);
-    illegal!(repaid_to_repaid,     InvoiceStatus::Repaid,    InvoiceStatus::Repaid);
-    illegal!(repaid_to_overdue,    InvoiceStatus::Repaid,    InvoiceStatus::Overdue);
-    illegal!(repaid_to_cancelled,  InvoiceStatus::Repaid,    InvoiceStatus::Cancelled);
-    illegal!(repaid_to_disputed,   InvoiceStatus::Repaid,    InvoiceStatus::Disputed);
-    illegal!(repaid_to_defaulted,  InvoiceStatus::Repaid,    InvoiceStatus::Defaulted);
+    illegal!(
+        repaid_to_pending,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Pending
+    );
+    illegal!(
+        repaid_to_financed,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Financed
+    );
+    illegal!(
+        repaid_to_repaid,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Repaid
+    );
+    illegal!(
+        repaid_to_overdue,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Overdue
+    );
+    illegal!(
+        repaid_to_cancelled,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Cancelled
+    );
+    illegal!(
+        repaid_to_disputed,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Disputed
+    );
+    illegal!(
+        repaid_to_defaulted,
+        InvoiceStatus::Repaid,
+        InvoiceStatus::Defaulted
+    );
 
-    illegal!(cancelled_to_pending,   InvoiceStatus::Cancelled, InvoiceStatus::Pending);
-    illegal!(cancelled_to_financed,  InvoiceStatus::Cancelled, InvoiceStatus::Financed);
-    illegal!(cancelled_to_repaid,    InvoiceStatus::Cancelled, InvoiceStatus::Repaid);
-    illegal!(cancelled_to_overdue,   InvoiceStatus::Cancelled, InvoiceStatus::Overdue);
-    illegal!(cancelled_to_cancelled, InvoiceStatus::Cancelled, InvoiceStatus::Cancelled);
-    illegal!(cancelled_to_disputed,  InvoiceStatus::Cancelled, InvoiceStatus::Disputed);
-    illegal!(cancelled_to_defaulted, InvoiceStatus::Cancelled, InvoiceStatus::Defaulted);
+    illegal!(
+        cancelled_to_pending,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Pending
+    );
+    illegal!(
+        cancelled_to_financed,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Financed
+    );
+    illegal!(
+        cancelled_to_repaid,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Repaid
+    );
+    illegal!(
+        cancelled_to_overdue,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Overdue
+    );
+    illegal!(
+        cancelled_to_cancelled,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Cancelled
+    );
+    illegal!(
+        cancelled_to_disputed,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Disputed
+    );
+    illegal!(
+        cancelled_to_defaulted,
+        InvoiceStatus::Cancelled,
+        InvoiceStatus::Defaulted
+    );
 
-    illegal!(defaulted_to_pending,   InvoiceStatus::Defaulted, InvoiceStatus::Pending);
-    illegal!(defaulted_to_financed,  InvoiceStatus::Defaulted, InvoiceStatus::Financed);
-    illegal!(defaulted_to_repaid,    InvoiceStatus::Defaulted, InvoiceStatus::Repaid);
-    illegal!(defaulted_to_overdue,   InvoiceStatus::Defaulted, InvoiceStatus::Overdue);
-    illegal!(defaulted_to_cancelled, InvoiceStatus::Defaulted, InvoiceStatus::Cancelled);
-    illegal!(defaulted_to_disputed,  InvoiceStatus::Defaulted, InvoiceStatus::Disputed);
-    illegal!(defaulted_to_defaulted, InvoiceStatus::Defaulted, InvoiceStatus::Defaulted);
+    illegal!(
+        defaulted_to_pending,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Pending
+    );
+    illegal!(
+        defaulted_to_financed,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Financed
+    );
+    illegal!(
+        defaulted_to_repaid,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Repaid
+    );
+    illegal!(
+        defaulted_to_overdue,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Overdue
+    );
+    illegal!(
+        defaulted_to_cancelled,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Cancelled
+    );
+    illegal!(
+        defaulted_to_disputed,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Disputed
+    );
+    illegal!(
+        defaulted_to_defaulted,
+        InvoiceStatus::Defaulted,
+        InvoiceStatus::Defaulted
+    );
 } // end mod transition_tests
 
 // ─── State Machine State Validation and Enforcement ──────────────────────────
 
 /// Validates and executes an invoice state transition. Emits a structured
 /// transition event and records the transition in the history log.
-/// 
+///
 /// This is the single point of authority for all invoice status changes across
 /// the protocol. All entry points (registry, financing, repayment) must route
 /// through this function.
-/// 
+///
 /// # Panics
 /// - If the transition is invalid for the current state
 /// - If the transition would violate business rules (e.g., due_date check for Overdue)
@@ -938,7 +1129,7 @@ pub fn assert_transition(
 }
 
 /// Validates that a transition from `from_status` to `to_status` is allowed.
-/// 
+///
 /// Valid transitions:
 /// - Pending -> Cancelled (originator cancellation)
 /// - Pending -> Financed (offer acceptance)

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -522,7 +522,7 @@ impl RegistryContract {
         }
         let old_status = invoice.status;
         assert_transition(&env, id.clone(), old_status, new_status, originator.clone());
-        
+
         invoice.status = new_status;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -554,10 +554,8 @@ impl RegistryContract {
         invoice.amount = new_amount;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
-        env.events().publish(
-            (symbol_short!("inv_amt"), invoice.id.clone()),
-            new_amount,
-        );
+        env.events()
+            .publish((symbol_short!("inv_amt"), invoice.id.clone()), new_amount);
         invoice
     }
 
@@ -572,10 +570,16 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        
+
         let old_status = invoice.status;
-        assert_transition(&env, invoice_id.clone(), old_status, InvoiceStatus::Cancelled, originator.clone());
-        
+        assert_transition(
+            &env,
+            invoice_id.clone(),
+            old_status,
+            InvoiceStatus::Cancelled,
+            originator.clone(),
+        );
+
         invoice.status = InvoiceStatus::Cancelled;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -602,21 +606,23 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        
+
         let new_status = if fully_repaid {
             InvoiceStatus::Repaid
         } else {
             InvoiceStatus::Financed
         };
-        
+
         let old_status = invoice.status;
         assert_transition(&env, id.clone(), old_status, new_status, repayer.clone());
-        
+
         invoice.status = new_status;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
-        env.events()
-            .publish((symbol_short!("inv_sts"), invoice.id.clone()), invoice.status);
+        env.events().publish(
+            (symbol_short!("inv_sts"), invoice.id.clone()),
+            invoice.status,
+        );
         invoice
     }
 
@@ -638,10 +644,16 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        
+
         let old_status = invoice.status;
-        assert_transition(&env, id.clone(), old_status, InvoiceStatus::Financed, financing.clone());
-        
+        assert_transition(
+            &env,
+            id.clone(),
+            old_status,
+            InvoiceStatus::Financed,
+            financing.clone(),
+        );
+
         invoice.status = InvoiceStatus::Financed;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -668,21 +680,23 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        
+
         let new_status = if fully_repaid {
             InvoiceStatus::Repaid
         } else {
             InvoiceStatus::Financed
         };
-        
+
         let old_status = invoice.status;
         assert_transition(&env, id.clone(), old_status, new_status, repayment.clone());
-        
+
         invoice.status = new_status;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
-        env.events()
-            .publish((symbol_short!("inv_sts"), invoice.id.clone()), invoice.status);
+        env.events().publish(
+            (symbol_short!("inv_sts"), invoice.id.clone()),
+            invoice.status,
+        );
         invoice
     }
 
@@ -706,10 +720,16 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        
+
         let old_status = invoice.status;
-        assert_transition(&env, id.clone(), old_status, InvoiceStatus::Defaulted, repayment.clone());
-        
+        assert_transition(
+            &env,
+            id.clone(),
+            old_status,
+            InvoiceStatus::Defaulted,
+            repayment.clone(),
+        );
+
         invoice.status = InvoiceStatus::Defaulted;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -729,17 +749,23 @@ impl RegistryContract {
         let mut invoice = invoices
             .get(id.clone())
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
-        
+
         // Validate time-based precondition before state transition
         if env.ledger().timestamp() <= invoice.due_date {
             env.panic_with_error(ContractError::InvalidTransition);
         }
-        
+
         let old_status = invoice.status;
         // For overdue, we use a dummy actor since it's permissionless
         let dummy_actor = env.current_contract_address();
-        assert_transition(&env, id.clone(), old_status, InvoiceStatus::Overdue, dummy_actor);
-        
+        assert_transition(
+            &env,
+            id.clone(),
+            old_status,
+            InvoiceStatus::Overdue,
+            dummy_actor,
+        );
+
         invoice.status = InvoiceStatus::Overdue;
         invoices.set(id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -763,10 +789,16 @@ impl RegistryContract {
         if invoice.originator != originator {
             env.panic_with_error(ContractError::Unauthorized);
         }
-        
+
         let old_status = invoice.status;
-        assert_transition(&env, invoice_id.clone(), old_status, InvoiceStatus::Disputed, originator.clone());
-        
+        assert_transition(
+            &env,
+            invoice_id.clone(),
+            old_status,
+            InvoiceStatus::Disputed,
+            originator.clone(),
+        );
+
         invoice.status = InvoiceStatus::Disputed;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -796,9 +828,11 @@ impl RegistryContract {
         }
 
         let old_status = invoice.status;
-        let actor = signers.get(0).unwrap_or_else(|| env.panic_with_error(ContractError::Unauthorized));
+        let actor = signers
+            .get(0)
+            .unwrap_or_else(|| env.panic_with_error(ContractError::Unauthorized));
         assert_transition(&env, invoice_id.clone(), old_status, target_status, actor);
-        
+
         invoice.status = target_status;
         invoices.set(invoice_id, invoice.clone());
         save_invoices(&env, &invoices);
@@ -1064,8 +1098,7 @@ impl RegistryContract {
     pub fn set_attestation_validity(env: Env, signers: Vec<Address>, validity_secs: u64) {
         assert_not_paused(&env);
         assert_admin(&env, &signers);
-        if !(MIN_ATTESTATION_VALIDITY_SECS..=MAX_ATTESTATION_VALIDITY_SECS)
-            .contains(&validity_secs)
+        if !(MIN_ATTESTATION_VALIDITY_SECS..=MAX_ATTESTATION_VALIDITY_SECS).contains(&validity_secs)
         {
             env.panic_with_error(ContractError::InvalidInput);
         }
@@ -1251,7 +1284,13 @@ impl RegistryContract {
     ) -> VerificationStatus {
         let attestations = load_verifications(&env, &invoice_id);
         let threshold = Self::get_verifier_threshold(env.clone());
-        type_status(&env, &attestations, v_type, threshold, env.ledger().timestamp())
+        type_status(
+            &env,
+            &attestations,
+            v_type,
+            threshold,
+            env.ledger().timestamp(),
+        )
     }
 
     /// Verification status of the invoice as a whole.

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -608,7 +608,10 @@ fn test_constructor_cannot_be_reinvoked() {
         &soroban_sdk::Symbol::new(&env, "__constructor"),
         args,
     );
-    assert!(result.is_err(), "constructor must not be re-invokable post-deploy");
+    assert!(
+        result.is_err(),
+        "constructor must not be re-invokable post-deploy"
+    );
 }
 
 #[test]
@@ -699,7 +702,10 @@ fn test_multisig_requires_threshold_distinct_signatures() {
 
     // A single signer is no longer enough once threshold is 2.
     let result = client.try_pause(&one(&env, &admin));
-    assert!(result.is_err(), "one of two required signatures must not pause");
+    assert!(
+        result.is_err(),
+        "one of two required signatures must not pause"
+    );
     assert!(!client.contract_is_paused());
 
     // Two distinct configured signers together clear the threshold.
@@ -731,7 +737,10 @@ fn test_multisig_rejects_non_signer_address() {
     bad.push_back(admin.clone());
     bad.push_back(outsider);
     let result = client.try_pause(&bad);
-    assert!(result.is_err(), "a non-signer address must not count toward the threshold");
+    assert!(
+        result.is_err(),
+        "a non-signer address must not count toward the threshold"
+    );
 }
 
 #[test]
@@ -753,7 +762,10 @@ fn test_multisig_rejects_duplicate_signer_in_same_call() {
     dup.push_back(admin.clone());
     dup.push_back(admin.clone());
     let result = client.try_pause(&dup);
-    assert!(result.is_err(), "a duplicated signer must not satisfy a threshold of two");
+    assert!(
+        result.is_err(),
+        "a duplicated signer must not satisfy a threshold of two"
+    );
 }
 
 #[test]
@@ -767,7 +779,10 @@ fn test_set_signers_unauthorized_panics() {
     let new_signers = one(&env, &Address::generate(&env));
 
     let result = client.try_set_signers(&one(&env, &outsider), &new_signers, &1u32);
-    assert!(result.is_err(), "a non-signer must not be able to reconfigure the admin set");
+    assert!(
+        result.is_err(),
+        "a non-signer must not be able to reconfigure the admin set"
+    );
 }
 
 #[test]
@@ -807,7 +822,10 @@ fn test_set_signers_rejects_empty_and_duplicate_signers() {
     dup_signers.push_back(admin.clone());
     dup_signers.push_back(admin.clone());
     let result = client.try_set_signers(&one(&env, &admin), &dup_signers, &2u32);
-    assert!(result.is_err(), "a duplicate address would let one key count twice");
+    assert!(
+        result.is_err(),
+        "a duplicate address would let one key count twice"
+    );
 }
 
 #[test]
@@ -837,6 +855,178 @@ fn test_transfer_admin_collapses_multisig_back_to_single_admin() {
     // Single-admin bootstrap behavior is restored: one signature suffices.
     client.pause(&one(&env, &new_admin));
     assert!(client.contract_is_paused());
+}
+
+// ─── Threshold boundary tests (issue #128 acceptance criteria) ─────────────────
+//
+// These tests explicitly cover the "exactly N, N-1, N+1" threshold
+// boundary: a 2-of-3 set, a 1-of-1 set, and a 3-of-3 set. Each case
+// verifies that exactly N signers succeed, N-1 signers fail, and
+// (where applicable) N+1 signers also succeed.
+
+/// 2-of-3 threshold: exactly 2 signers (N) must authorize, 1 (N-1) must not,
+/// and 3 (N+1) must also succeed.
+#[test]
+fn test_threshold_2_of_3_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut signers_3 = soroban_sdk::Vec::new(&env);
+    signers_3.push_back(admin.clone());
+    signers_3.push_back(b.clone());
+    signers_3.push_back(c.clone());
+    client.set_signers(&one(&env, &admin), &signers_3, &2u32);
+
+    // N-1 (1 of 2 required) must fail.
+    let result = client.try_set_fee(&one(&env, &admin), &100u32);
+    assert!(
+        result.is_err(),
+        "N-1 (1 of 2) must not authorize a fee change"
+    );
+
+    // N (exactly 2 of 2 required) must succeed.
+    let mut exactly_2 = soroban_sdk::Vec::new(&env);
+    exactly_2.push_back(admin.clone());
+    exactly_2.push_back(b.clone());
+    client.set_fee(&exactly_2, &100u32);
+    assert_eq!(client.get_fee(), 100);
+
+    // N+1 (3 of 2 required) must also succeed.
+    let mut all_3 = soroban_sdk::Vec::new(&env);
+    all_3.push_back(admin.clone());
+    all_3.push_back(b.clone());
+    all_3.push_back(c.clone());
+    client.set_fee(&all_3, &200u32);
+    assert_eq!(client.get_fee(), 200);
+}
+
+/// 1-of-1 threshold: exactly 1 signer (N) must authorize, 0 (N-1) must not.
+#[test]
+fn test_threshold_1_of_1_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    // Bootstrap mode is already 1-of-1.
+    // N-1 (0 signers) must fail.
+    let empty: soroban_sdk::Vec<Address> = soroban_sdk::Vec::new(&env);
+    let result = client.try_set_fee(&empty, &50u32);
+    assert!(
+        result.is_err(),
+        "N-1 (0 of 1) must not authorize a fee change"
+    );
+
+    // N (exactly 1 of 1 required) must succeed.
+    client.set_fee(&one(&env, &admin), &50u32);
+    assert_eq!(client.get_fee(), 50);
+}
+
+/// 3-of-3 threshold: exactly 3 signers (N) must authorize, 2 (N-1) must not.
+#[test]
+fn test_threshold_3_of_3_boundary() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut signers_3 = soroban_sdk::Vec::new(&env);
+    signers_3.push_back(admin.clone());
+    signers_3.push_back(b.clone());
+    signers_3.push_back(c.clone());
+    client.set_signers(&one(&env, &admin), &signers_3, &3u32);
+
+    // N-1 (2 of 3 required) must fail.
+    let mut two = soroban_sdk::Vec::new(&env);
+    two.push_back(admin.clone());
+    two.push_back(b.clone());
+    let result = client.try_set_fee(&two, &100u32);
+    assert!(
+        result.is_err(),
+        "N-1 (2 of 3) must not authorize a fee change"
+    );
+
+    // N (exactly 3 of 3 required) must succeed.
+    let mut all_3 = soroban_sdk::Vec::new(&env);
+    all_3.push_back(admin.clone());
+    all_3.push_back(b.clone());
+    all_3.push_back(c.clone());
+    client.set_fee(&all_3, &100u32);
+    assert_eq!(client.get_fee(), 100);
+}
+
+/// 2-of-3 threshold tested on a non-pause admin op (set_rate) to verify
+/// the threshold check is applied uniformly across all admin-gated functions.
+#[test]
+fn test_threshold_boundary_on_set_rate() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut signers_3 = soroban_sdk::Vec::new(&env);
+    signers_3.push_back(admin.clone());
+    signers_3.push_back(b.clone());
+    signers_3.push_back(c.clone());
+    client.set_signers(&one(&env, &admin), &signers_3, &2u32);
+
+    // N-1 (1 of 2) must fail.
+    let result = client.try_set_rate(&one(&env, &admin), &RiskTier::A, &500u32);
+    assert!(result.is_err(), "N-1 must not authorize a rate change");
+
+    // N (exactly 2 of 2) must succeed.
+    let mut exactly_2 = soroban_sdk::Vec::new(&env);
+    exactly_2.push_back(admin.clone());
+    exactly_2.push_back(c.clone());
+    client.set_rate(&exactly_2, &RiskTier::A, &500u32);
+    assert_eq!(client.get_rate(&RiskTier::A), 500);
+}
+
+/// set_signers itself is threshold-gated by the current config. Test that
+/// N-1 signers cannot reconfigure the admin set.
+#[test]
+fn test_threshold_boundary_on_set_signers() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    let mut signers_3 = soroban_sdk::Vec::new(&env);
+    signers_3.push_back(admin.clone());
+    signers_3.push_back(b.clone());
+    signers_3.push_back(c.clone());
+    client.set_signers(&one(&env, &admin), &signers_3, &2u32);
+
+    let new_admin = Address::generate(&env);
+    let new_signers = one(&env, &new_admin);
+
+    // N-1 (1 of 2) must fail.
+    let result = client.try_set_signers(&one(&env, &admin), &new_signers, &1u32);
+    assert!(result.is_err(), "N-1 must not authorize set_signers");
+
+    // N (exactly 2 of 2) must succeed.
+    let mut exactly_2 = soroban_sdk::Vec::new(&env);
+    exactly_2.push_back(admin.clone());
+    exactly_2.push_back(b.clone());
+    client.set_signers(&exactly_2, &new_signers, &1u32);
+    let cfg = client.get_admin_config();
+    assert_eq!(cfg.threshold, 1);
+    assert_eq!(cfg.signers.get(0).unwrap(), new_admin);
 }
 
 // ─── Pause tests ──────────────────────────────────────────────────────────────
@@ -923,7 +1113,10 @@ fn test_pause_blocks_all_registry_state_changes() {
 
     fn assert_paused<F: FnOnce()>(f: F) {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        assert!(result.is_err(), "state-changing function should panic while paused");
+        assert!(
+            result.is_err(),
+            "state-changing function should panic while paused"
+        );
     }
 
     assert_paused(|| {
@@ -967,7 +1160,11 @@ fn test_pause_blocks_all_registry_state_changes() {
         client.raise_dispute(&invoice_id, &originator);
     });
     assert_paused(|| {
-        client.resolve_dispute(&one(&env, &admin), &invoice_id, &invofi_common::InvoiceStatus::Cancelled);
+        client.resolve_dispute(
+            &one(&env, &admin),
+            &invoice_id,
+            &invofi_common::InvoiceStatus::Cancelled,
+        );
     });
     assert_paused(|| {
         client.blacklist_address(&one(&env, &admin), &other);
@@ -1521,14 +1718,16 @@ fn test_state_machine_financed_to_disputed_to_resolved() {
     assert_eq!(disputed.status, InvoiceStatus::Disputed);
 
     // Disputed -> Financed (admin resolution)
-    let resolved = client.resolve_dispute(&one(&env, &admin), &invoice_id, &InvoiceStatus::Financed);
+    let resolved =
+        client.resolve_dispute(&one(&env, &admin), &invoice_id, &InvoiceStatus::Financed);
     assert_eq!(resolved.status, InvoiceStatus::Financed);
 
     // Financed -> Disputed (again)
     client.raise_dispute(&invoice_id, &originator);
 
     // Disputed -> Cancelled (admin resolution)
-    let resolved2 = client.resolve_dispute(&one(&env, &admin), &invoice_id, &InvoiceStatus::Cancelled);
+    let resolved2 =
+        client.resolve_dispute(&one(&env, &admin), &invoice_id, &InvoiceStatus::Cancelled);
     assert_eq!(resolved2.status, InvoiceStatus::Cancelled);
 }
 
@@ -1670,7 +1869,10 @@ fn test_transition_history_recorded() {
 
     // Query transition history
     let history = client.get_transition_history(&invoice_id);
-    assert!(!history.is_empty(), "Transition history should not be empty");
+    assert!(
+        !history.is_empty(),
+        "Transition history should not be empty"
+    );
     assert_eq!(history.len(), 1, "Should have one transition recorded");
 
     let first = history.first().unwrap();
@@ -1790,10 +1992,7 @@ fn test_transition_events_emitted() {
 
     let events = env.events().all();
     // Should have transition events
-    assert!(
-        !events.is_empty(),
-        "Should emit events on state transition"
-    );
+    assert!(!events.is_empty(), "Should emit events on state transition");
 }
 
 // ─── Verification oracle (issue #181) ────────────────────────────────────────
@@ -2866,7 +3065,10 @@ fn test_eviction_cannot_fire_without_a_departed_record_to_take() {
         let mut found = 0u32;
         for a in c.get_verifications(&invoice_id).iter() {
             if a.verifier == first && a.v_type == VerificationType::BusinessRegistration {
-                assert!(a.valid_until < env.ledger().timestamp(), "record must be lapsed");
+                assert!(
+                    a.valid_until < env.ledger().timestamp(),
+                    "record must be lapsed"
+                );
                 found += 1;
             }
         }
@@ -2983,7 +3185,6 @@ fn count_events(env: &Env, name: Symbol) -> u32 {
     count
 }
 
-
 #[test]
 fn test_live_approval_below_threshold_reads_pending_not_expired() {
     let env = Env::default();
@@ -3004,8 +3205,7 @@ fn test_live_approval_below_threshold_reads_pending_not_expired() {
         &evidence_hash(&env, 1),
         &true,
     );
-    env.ledger()
-        .set_timestamp(1_000_000 + 7_776_000 + 1);
+    env.ledger().set_timestamp(1_000_000 + 7_776_000 + 1);
 
     // Verifier two now attests, so the type holds one live approval against a
     // threshold of two.
@@ -3058,8 +3258,7 @@ fn test_expired_reads_only_when_no_live_statement_remains() {
         &evidence_hash(&env, 1),
         &true,
     );
-    env.ledger()
-        .set_timestamp(1_000_000 + 7_776_000 + 1);
+    env.ledger().set_timestamp(1_000_000 + 7_776_000 + 1);
 
     assert_eq!(
         client.get_verification_status(&invoice_id, &VerificationType::TaxCompliance),
@@ -3124,4 +3323,3 @@ fn test_rotated_out_verifiers_cannot_lock_an_invoice() {
         VerificationStatus::Verified
     );
 }
-


### PR DESCRIPTION
## Summary
Add `register_invoices(originator, Vec<InvoiceInput>)` to the registry contract, enabling businesses to register up to 20 invoices in a single transaction for bulk onboarding. All inputs are validated up front — the batch either commits atomically or reverts with a panic naming the offending invoice. The single-invoice `register_invoice` path is unchanged.

Key design decisions:
- **Batch limit (20):** each invoice is ~128 bytes stored in a persistent `Map`, so 20 invoices add ~2.5 KiB — well within Soroban's 64 KiB entry cap. The validation loop stays inside the 40 M instruction budget.
- **Two-phase commit:** Phase 1 validates every input without writing state; Phase 2 commits all invoices. Intra-batch duplicate ID detection is included.
- **Single originator per batch:** the caller provides one `originator` address; every `InvoiceInput.originator` must match, and the caller must `require_auth`.
- **Events:** one `inv_reg` per invoice (matching single registration) plus one `inv_breg` summary event carrying the count.

## Type of change
- [x] Bug fix
- [x] New contract function
- [x] Data type change
- [x] Test addition
- [x] Chore / docs

## Checklist
- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes (CI)
- [x] Soroban Scout security analysis passes (CI)
- [x] `stellar contract build` succeeds
- [x] New functions have corresponding tests
- [x] Breaking changes are documented

## Related issues
Closes #65