### PR TITLE
test(financing): audit & proptest interest-rate cap on all term paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and are enforced by commitlint in CI.
 ## [Unreleased]
 
 ### Added
+- **Interest-rate cap audit & proptest (issue #122)** — verified `MAX_INTEREST_BPS`
+  (10 000 bps = 100%) is enforced on all three term-setting entrypoints:
+  `create_offer` (inline assertion), `amend_offer`, and `counter_offer`
+  (via `assert_terms_valid`). Added proptest that confirms the cap holds across
+  random rate/amount/duration combos, and unit tests for the negotiation path.
+  Updated security-self-review docs to mark the follow-up as resolved.
 - **Multisig threshold boundary tests (issue #128)** — six new tests covering
   the exact N, N-1, N+1 threshold boundaries for M-of-N admin governance
   (ADR-0010). Tests verify: 2-of-3 (N-1 fails, N succeeds, N+1 succeeds),

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -175,7 +175,7 @@ const PENDING_UPGRADE_KEY: Symbol = symbol_short!("__upgrade");
 /// Parses a numeric semantic version in exactly `MAJOR.MINOR.PATCH` form.
 pub fn parse_semantic_version(env: &Env, value: &String) -> SemanticVersion {
     let len = value.len() as usize;
-    if len < 5 || len > 32 {
+    if !(5..=32).contains(&len) {
         env.panic_with_error(ContractError::InvalidVersion);
     }
 

--- a/docs/security-self-review.md
+++ b/docs/security-self-review.md
@@ -149,7 +149,10 @@ Three hardening follow-ups are noted for the audit phase (§7).
    (persist `Accepted` before the external transfer) once the token
    contract is itself audited — currently protected by allowance
    consumption, but the reorder removes reliance on that property.
-2. Cap `interest_rate` at a documented maximum (e.g. `MAX_INTEREST_BPS`) in
+2. ~~Cap `interest_rate` at a documented maximum (e.g. `MAX_INTEREST_BPS`) in
    `create_offer` to bound `yield_amount` arithmetic from input, not just
-   overflow-checks.
+   overflow-checks.~~ **DONE** — `MAX_INTEREST_BPS` (10 000 bps = 100%) is
+   enforced on all three term-setting entrypoints: `create_offer` (inline
+   assertion), `amend_offer`, and `counter_offer` (via `assert_terms_valid`).
+   Proptest confirms the cap holds across random inputs.
 3. Mainnet must be preceded by the SCF Audit Bank (or equivalent) audit.

--- a/financing/src/proptest.rs
+++ b/financing/src/proptest.rs
@@ -246,4 +246,86 @@ proptest! {
             prop_assert_eq!(pos_client.balance(&lender), 0);
             prop_assert_eq!(fin.get_stats().total_financed, 0);
         }
+
+    /// The interest-rate cap (`MAX_INTEREST_BPS`) must be enforced on every
+    /// term-setting entrypoint: `create_offer`, `amend_offer`, and
+    /// `counter_offer`.  Random valid rates are accepted; any rate one above
+    /// the cap is rejected on all three paths.
+    #[test]
+    fn test_interest_rate_cap_enforced_on_all_paths(
+        valid_rate in 1u32..=10_000u32,
+        principal in 10_000_000i128..100_000_000_000i128,
+        duration in 86_400u64..31_536_000u64,
+    ) {
+        let env = Env::default();
+        env.mock_all_auths();
+        env.ledger().set_timestamp(1_000_000);
+
+        let admin = Address::generate(&env);
+        let originator = Address::generate(&env);
+        let lender = Address::generate(&env);
+        let token_id = Address::generate(&env);
+
+        let registry_id = env.register(RegistryContract, (admin.clone(),));
+        let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
+        let financing_id = env.register(FinancingContract, (admin.clone(), registry_id.clone(), token_id.clone()));
+        let fin = crate::FinancingContractClient::new(&env, &financing_id);
+
+        // Register invoice (amount must be >= principal for the offer to be valid)
+        let invoice_amount = principal.max(10_000_000);
+        let invoice_id = symbol_short!("inv_rc");
+        reg.register_invoice(&invoice_id, &originator, &invoice_amount, &symbol_short!("USD"), &2_000_000u64);
+
+        // ── 1. create_offer with valid rate must succeed ────────────────────
+        let offer = fin.create_offer(
+            &symbol_short!("off_rc"),
+            &invoice_id,
+            &lender,
+            &principal,
+            &symbol_short!("USD"),
+            &valid_rate,
+            &duration,
+        );
+        prop_assert_eq!(offer.interest_rate, valid_rate);
+
+        // ── 2. create_offer with rate = MAX + 1 must be rejected ───────────
+        let over_rate = invofi_common::MAX_INTEREST_BPS + 1;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            fin.create_offer(
+                &symbol_short!("off_over"),
+                &invoice_id,
+                &lender,
+                &principal,
+                &symbol_short!("USD"),
+                &over_rate,
+                &duration,
+            );
+        }));
+        prop_assert!(result.is_err(), "create_offer: rate {} above cap must be rejected", over_rate);
+
+        // ── 3. amend_offer with rate = MAX + 1 must be rejected ─────────────
+        let offer_id = symbol_short!("off_amd");
+        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &valid_rate, &duration);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            fin.amend_offer(&offer_id, &lender, &0u32, &principal, &over_rate, &duration);
+        }));
+        prop_assert!(result.is_err(), "amend_offer: rate {} above cap must be rejected", over_rate);
+
+        // ── 4. counter_offer with rate = MAX + 1 must be rejected ───────────
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            fin.counter_offer(&offer_id, &originator, &0u32, &principal, &over_rate, &duration);
+        }));
+        prop_assert!(result.is_err(), "counter_offer: rate {} above cap must be rejected", over_rate);
+
+        // ── 5. All stored offers must have rate <= MAX_INTEREST_BPS ──────────
+        let all_offers = fin.get_all_offers();
+        for stored_offer in all_offers.iter() {
+            prop_assert!(
+                stored_offer.interest_rate <= invofi_common::MAX_INTEREST_BPS,
+                "stored offer rate {} exceeds MAX_INTEREST_BPS {}",
+                stored_offer.interest_rate,
+                invofi_common::MAX_INTEREST_BPS,
+            );
+        }
+    }
 }

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -2759,3 +2759,104 @@ fn test_plain_accept_without_a_negotiation_emits_no_closure() {
         NegotiationStatus::None
     );
 }
+
+// ── Interest-rate cap enforcement across all term-setting paths ────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_amend_offer_interest_rate_above_cap_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("inv_rc");
+    let offer_id = symbol_short!("off_rc");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // Amend with rate = MAX_INTEREST_BPS + 1 must be rejected.
+    fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &(invofi_common::MAX_INTEREST_BPS + 1),
+        &1_296_000u64,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_counter_offer_interest_rate_above_cap_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("inv_cc");
+    let offer_id = symbol_short!("off_cc");
+    let (_reg, fin, _admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // Counter-offer with rate = MAX_INTEREST_BPS + 1 must be rejected.
+    fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &(invofi_common::MAX_INTEREST_BPS + 1),
+        &1_296_000u64,
+    );
+}
+
+#[test]
+fn test_amend_offer_interest_rate_at_cap_passes() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("inv_rk");
+    let offer_id = symbol_short!("off_rk");
+    let (_reg, fin, _admin, _originator, lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // Amend with rate = MAX_INTEREST_BPS must succeed.
+    let amended = fin.amend_offer(
+        &offer_id,
+        &lender,
+        &0u32,
+        &1_000_000_000i128,
+        &invofi_common::MAX_INTEREST_BPS,
+        &1_296_000u64,
+    );
+    assert_eq!(amended.interest_rate, invofi_common::MAX_INTEREST_BPS);
+}
+
+#[test]
+fn test_counter_offer_interest_rate_at_cap_records_in_history() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let invoice_id = symbol_short!("inv_ck");
+    let offer_id = symbol_short!("off_ck");
+    let (_reg, fin, _admin, originator, _lender, _token) =
+        setup_negotiation(&env, &invoice_id, &offer_id, 1_000_000_000);
+
+    // Counter-offer with rate = MAX_INTEREST_BPS must succeed.
+    // counter_offer records in negotiation history — the offer's rate
+    // is unchanged (it is the lender's standing position).
+    let countered = fin.counter_offer(
+        &offer_id,
+        &originator,
+        &0u32,
+        &1_000_000_000i128,
+        &invofi_common::MAX_INTEREST_BPS,
+        &1_296_000u64,
+    );
+    // offer.status is still Pending (counter-offer doesn't auto-accept here)
+    assert_eq!(countered.status, OfferStatus::Pending);
+    // The rate is recorded in negotiation history
+    let history = fin.get_negotiation(&offer_id);
+    assert_eq!(history.len(), 1);
+    assert_eq!(history.get(0).unwrap().interest_rate, invofi_common::MAX_INTEREST_BPS);
+}


### PR DESCRIPTION
## Summary
Verify that `MAX_INTEREST_BPS` (10 000 bps = 100%) is enforced on every term-setting entrypoint: `create_offer` (inline assertion), `amend_offer`, and `counter_offer` (both via `assert_terms_valid`). Add a proptest that confirms the cap holds across random rate/amount/duration combos, and unit tests for the negotiation path.

Closes #122

## Changes
- **`financing/src/test.rs`** — 4 new unit tests: negative tests for `amend_offer` and `counter_offer` rejecting rate above cap; positive tests confirming rate at cap is accepted via both paths.
- **`financing/src/proptest.rs`** — 1 new proptest (`test_interest_rate_cap_enforced_on_all_paths`) that exercises all 3 entrypoints with random valid rates, asserts rejection of `MAX_INTEREST_BPS + 1` on every path, and verifies stored offers never exceed the cap.
- **`docs/security-self-review.md`** — Mark the rate-cap follow-up (§7.2) as resolved, documenting all 3 enforcement points.
- **`CHANGELOG.md`** — Added entry for issue #122.
- **`common/src/lib.rs`** — Drive-by fix for pre-existing `clippy::manual_range_contains` lint (one-liner).

## Testing
- Full workspace tests: 391/391 passed (`cargo test --target $HOST`)
- Clippy clean: `cargo clippy --target wasm32v1-none -- -D warnings`
- New tests added:
  - `test_amend_offer_interest_rate_above_cap_panics` (negative)
  - `test_counter_offer_interest_rate_above_cap_panics` (negative)
  - `test_amend_offer_interest_rate_at_cap_passes` (happy path)
  - `test_counter_offer_interest_rate_at_cap_records_in_history` (happy path)
  - `test_interest_rate_cap_enforced_on_all_paths` (proptest, 2000 cases in CI)

## Checklist
- [x] Follows CONTRIBUTING.md conventions
- [x] All acceptance criteria from #122 are met
- [x] Existing tests pass unchanged
- [x] New tests cover happy path, named edge cases, and negative cases
- [x] CI is green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum interest rate of 10,000 basis points across offers, amendments, and counter-offers.
  * Confirmed that rates at the maximum are accepted, while higher rates are rejected.

* **Tests**
  * Added comprehensive automated coverage for interest-rate limits across offer creation and negotiation flows.
  * Added randomized testing to verify that stored offers always comply with the cap.

* **Documentation**
  * Updated security audit documentation and changelog entries to reflect the completed review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->