### PR TITLE
feat: add optional offer expiry to financing offers

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -149,6 +149,9 @@ pub enum ContractError {
 
     /// No retained previous executable is available for rollback.
     RollbackUnavailable = 12,
+r
+    /// The offer has passed its expiration deadline and can no longer be accepted.
+    OfferExpired = 13,
 }
 
 /// Numeric components of a strict `MAJOR.MINOR.PATCH` version.

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -149,7 +149,7 @@ pub enum ContractError {
 
     /// No retained previous executable is available for rollback.
     RollbackUnavailable = 12,
-r
+
     /// The offer has passed its expiration deadline and can no longer be accepted.
     OfferExpired = 13,
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -74,6 +74,9 @@ pub enum ContractError {
 
     /// The caller's address is on the blacklist.
     Blacklisted = 8,
+
+    /// The offer's expiry deadline has passed and it can no longer be accepted.
+    OfferExpired = 9,
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -127,6 +130,9 @@ pub struct FinancingOffer {
     pub interest_rate: u32,
     /// Financing duration in seconds
     pub duration: u64,
+    /// Optional Unix timestamp after which the offer can no longer be accepted.
+    /// `0` means the offer never expires (backward compatible).
+    pub expires_at: u64,
     pub status: OfferStatus,
     /// Unix timestamp when the offer was accepted; 0 if not yet accepted
     pub funded_at: u64,

--- a/financing/src/lib.rs
+++ b/financing/src/lib.rs
@@ -269,6 +269,7 @@ impl FinancingContract {
         currency: Symbol,
         interest_rate: u32,
         duration: u64,
+        expires_at: u64,
     ) -> FinancingOffer {
         assert_not_paused(&env);
         lender.require_auth();
@@ -319,6 +320,7 @@ impl FinancingContract {
             currency,
             interest_rate,
             duration,
+            expires_at,
             status: OfferStatus::Pending,
             funded_at: 0,
             amount_repaid: 0,
@@ -392,6 +394,12 @@ impl FinancingContract {
             .unwrap_or_else(|| env.panic_with_error(ContractError::NotFound));
         if offer.status != OfferStatus::Pending {
             env.panic_with_error(ContractError::InvalidTransition);
+        }
+
+        // Reject stale offers whose deadline has passed. An offer with
+        // expires_at == 0 never expires (backward compatible).
+        if offer.expires_at != 0 && env.ledger().timestamp() >= offer.expires_at {
+            env.panic_with_error(ContractError::OfferExpired);
         }
 
         // Cross-contract: read invoice from registry

--- a/financing/src/proptest.rs
+++ b/financing/src/proptest.rs
@@ -106,12 +106,12 @@ proptest! {
             // Over the invoice amount must be rejected.
             let over = invoice_amount + overshoot;
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                fin.create_offer(&symbol_short!("off_over"), &invoice_id, &lender, &over, &symbol_short!("USD"), &500u32, &604_800u64)
+                fin.create_offer(&symbol_short!("off_over"), &invoice_id, &lender, &over, &symbol_short!("USD"), &500u32, &604_800u64, &0u64)
             }));
             prop_assert!(result.is_err(), "offer above invoice amount must be rejected");
 
             // Exactly the invoice amount must succeed.
-            let offer = fin.create_offer(&symbol_short!("off_ok"), &invoice_id, &lender, &invoice_amount, &symbol_short!("USD"), &500u32, &604_800u64);
+            let offer = fin.create_offer(&symbol_short!("off_ok"), &invoice_id, &lender, &invoice_amount, &symbol_short!("USD"), &500u32, &604_800u64, &0u64);
             prop_assert_eq!(offer.amount, invoice_amount);
         }
 
@@ -143,8 +143,8 @@ proptest! {
             reg.register_invoice(&invoice_id, &originator, &principal, &symbol_short!("USD"), &2_000_000u64);
 
             let half = principal / 2;
-            fin.create_offer(&symbol_short!("off_a"), &invoice_id, &lender_a, &half, &symbol_short!("USD"), &500u32, &604_800u64);
-            fin.create_offer(&symbol_short!("off_b"), &invoice_id, &lender_b, &half, &symbol_short!("USD"), &500u32, &604_800u64);
+            fin.create_offer(&symbol_short!("off_a"), &invoice_id, &lender_a, &half, &symbol_short!("USD"), &500u32, &604_800u64, &0u64);
+            fin.create_offer(&symbol_short!("off_b"), &invoice_id, &lender_b, &half, &symbol_short!("USD"), &500u32, &604_800u64, &0u64);
 
             // Fund lender_a and accept their offer.
             let asset_client = soroban_sdk::token::StellarAssetClient::new(&env, &token_id);
@@ -199,7 +199,7 @@ proptest! {
                 let inv_id = soroban_sdk::Symbol::new(&env, &std::format!("inv{}", i));
                 let off_id = soroban_sdk::Symbol::new(&env, &std::format!("off{}", i));
                 reg.register_invoice(&inv_id, &originator, amount, &symbol_short!("USD"), &2_000_000u64);
-                fin.create_offer(&off_id, &inv_id, &lender, amount, &symbol_short!("USD"), &500u32, &604_800u64);
+                fin.create_offer(&off_id, &inv_id, &lender, amount, &symbol_short!("USD"), &500u32, &604_800u64, &0u64);
                 asset_client.mint(&lender, amount);
                 token_client.approve(&lender, &financing_id, amount, &(env.ledger().sequence() + 1000));
                 fin.accept_offer(&off_id, &originator);
@@ -241,7 +241,7 @@ proptest! {
             reg.register_invoice(&invoice_id, &originator, &principal, &symbol_short!("USD"), &2_000_000u64);
 
             let offer_id = symbol_short!("off_wd");
-            fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &500u32, &604_800u64);
+            fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &500u32, &604_800u64, &0u64);
             fin.withdraw_offer(&offer_id, &lender);
 
             prop_assert_eq!(pos_client.balance(&lender), 0);
@@ -286,6 +286,7 @@ proptest! {
             &symbol_short!("USD"),
             &valid_rate,
             &duration,
+            &0u64,
         );
         prop_assert_eq!(offer.interest_rate, valid_rate);
 
@@ -300,13 +301,14 @@ proptest! {
                 &symbol_short!("USD"),
                 &over_rate,
                 &duration,
+                &0u64,
             );
         }));
         prop_assert!(result.is_err(), "create_offer: rate {} above cap must be rejected", over_rate);
 
         // ── 3. amend_offer with rate = MAX + 1 must be rejected ─────────────
         let offer_id = symbol_short!("off_amd");
-        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &valid_rate, &duration);
+        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &valid_rate, &duration, &0u64);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             fin.amend_offer(&offer_id, &lender, &0u32, &principal, &over_rate, &duration);
         }));

--- a/financing/src/proptest.rs
+++ b/financing/src/proptest.rs
@@ -65,7 +65,8 @@ proptest! {
             &symbol_short!("USD"),
             &interest_rate,
             &duration,
-         0);
+            &0u64,
+        );
 
         assert_eq!(offer.interest_rate, interest_rate);
         assert_eq!(offer.amount, principal);

--- a/financing/src/proptest.rs
+++ b/financing/src/proptest.rs
@@ -55,7 +55,7 @@ proptest! {
             &symbol_short!("USD"),
             &interest_rate,
             &duration,
-        );
+         0);
 
         assert_eq!(offer.interest_rate, interest_rate);
         assert_eq!(offer.amount, principal);

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -91,7 +91,7 @@ fn test_create_and_get_offer() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
 
     assert_eq!(offer.id, offer_id);
     assert_eq!(offer.invoice_id, invoice_id);
@@ -131,7 +131,7 @@ fn test_create_offer_zero_amount() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-    );
+     0);
 }
 
 #[test]
@@ -162,7 +162,7 @@ fn test_create_offer_interest_rate_too_high_panics() {
         &symbol_short!("USDC"),
         &10_001u32,
         &86_400u64,
-    );
+     0);
 }
 
 #[test]
@@ -193,7 +193,7 @@ fn test_create_offer_short_duration_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &3_600u64,
-    );
+     0);
 }
 
 #[test]
@@ -224,7 +224,7 @@ fn test_max_offer_duration_rejected() {
         &symbol_short!("USDC"),
         &500_u32,
         &31_622_400_u64,
-    );
+     0);
 }
 
 #[test]
@@ -254,12 +254,12 @@ fn test_create_offer_self_dealing_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-    );
+     0);
 }
 
 #[test]
 #[should_panic(expected = "Error(Contract, #8)")]
-fn test_blacklisted_cannot_create_offer() {
+fn test_blacklisted_cannot_create_offer(, 0) {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -286,7 +286,7 @@ fn test_blacklisted_cannot_create_offer() {
         &symbol_short!("XLM"),
         &200u32,
         &86_400u64,
-    );
+     0);
 }
 
 // ─── Accept / Reject tests ──────────────────────────────────────────────────
@@ -332,7 +332,7 @@ fn test_accept_offer() {
         &symbol_short!("USDC"),
         &300u32,
         &(1_296_000u64),
-    );
+     0);
 
     let accepted = fin.accept_offer(&offer_id, &originator);
     assert_eq!(accepted.status, OfferStatus::Accepted);
@@ -345,6 +345,189 @@ fn test_accept_offer() {
     let token_client = token::TokenClient::new(&env, &token_id);
     assert_eq!(token_client.balance(&lender), 0);
     assert_eq!(token_client.balance(&originator), amount);
+}
+
+#[test]
+fn test_create_offer_stores_expires_at() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let token = Address::generate(&env);
+    let (reg, fin) = setup_contracts(&env, &admin, &token);
+
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    reg.register_invoice(
+        &symbol_short!("inv_x1"),
+        &originator,
+        &10_000_000i128,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    let offer = fin.create_offer(
+        &symbol_short!("off_x1"),
+        &symbol_short!("inv_x1"),
+        &lender,
+        &10_000_000i128,
+        &symbol_short!("USDC"),
+        &500u32,
+        &86_400u64,
+        &1_500_000u64,
+    );
+    assert_eq!(offer.expires_at, 1_500_000u64);
+}
+
+#[test]
+fn test_accept_offer_before_expiry_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv_x2");
+    let offer_id = symbol_short!("off_x2");
+    let amount: i128 = 1_000_000_000;
+
+    let token_id = create_token(&env);
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
+
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), registry_id.clone(), token_id.clone()),
+    );
+    let fin = super::FinancingContractClient::new(&env, &financing_id);
+
+    reg.set_financing_contract(&admin, &financing_id);
+    mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
+
+    reg.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    // Expires 1000s after the current ledger time.
+    fin.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &300u32,
+        &1_296_000u64,
+        &1_001_000u64,
+    );
+
+    // Still before the deadline -> acceptance succeeds.
+    env.ledger().set_timestamp(1_000_500);
+    let accepted = fin.accept_offer(&offer_id, &originator);
+    assert_eq!(accepted.status, OfferStatus::Accepted);
+}
+
+#[test]
+#[should_panic]
+fn test_accept_offer_after_expiry_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv_x3");
+    let offer_id = symbol_short!("off_x3");
+    let amount: i128 = 1_000_000_000;
+
+    let token_id = create_token(&env);
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
+
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), registry_id.clone(), token_id.clone()),
+    );
+    let fin = super::FinancingContractClient::new(&env, &financing_id);
+
+    reg.set_financing_contract(&admin, &financing_id);
+    mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
+
+    reg.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    fin.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &300u32,
+        &1_296_000u64,
+        &1_001_000u64,
+    );
+
+    // Past the deadline -> acceptance must revert.
+    env.ledger().set_timestamp(1_002_000);
+    fin.accept_offer(&offer_id, &originator);
+}
+
+#[test]
+#[should_panic]
+fn test_accept_offer_at_expiry_boundary_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set_timestamp(1_000_000);
+
+    let admin = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let lender = Address::generate(&env);
+    let invoice_id = symbol_short!("inv_x4");
+    let offer_id = symbol_short!("off_x4");
+    let amount: i128 = 1_000_000_000;
+
+    let token_id = create_token(&env);
+    let registry_id = env.register(RegistryContract, (admin.clone(),));
+    let reg = invofi_registry::RegistryContractClient::new(&env, &registry_id);
+
+    let financing_id = env.register(
+        FinancingContract,
+        (admin.clone(), registry_id.clone(), token_id.clone()),
+    );
+    let fin = super::FinancingContractClient::new(&env, &financing_id);
+
+    reg.set_financing_contract(&admin, &financing_id);
+    mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
+
+    reg.register_invoice(
+        &invoice_id,
+        &originator,
+        &amount,
+        &symbol_short!("USDC"),
+        &3_000_000u64,
+    );
+    fin.create_offer(
+        &offer_id,
+        &invoice_id,
+        &lender,
+        &amount,
+        &symbol_short!("USDC"),
+        &300u32,
+        &1_296_000u64,
+        &1_001_000u64,
+    );
+
+    // Exactly at the deadline is considered expired.
+    env.ledger().set_timestamp(1_001_000);
+    fin.accept_offer(&offer_id, &originator);
 }
 
 #[test]
@@ -377,7 +560,7 @@ fn test_reject_offer() {
         &symbol_short!("XLM"),
         &200u32,
         &(864_000u64),
-    );
+     0);
 
     let rejected = fin.reject_offer(&offer_id, &originator);
     assert_eq!(rejected.status, OfferStatus::Rejected);
@@ -413,7 +596,7 @@ fn test_withdraw_offer() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
 
     let withdrawn = fin.withdraw_offer(&symbol_short!("off_w1"), &lender);
     assert_eq!(withdrawn.status, OfferStatus::Rejected);
@@ -448,7 +631,7 @@ fn test_withdraw_offer_wrong_lender_panics() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
     fin.withdraw_offer(&symbol_short!("off_w2"), &other);
 }
 
@@ -481,7 +664,7 @@ fn test_get_offers_by_invoice() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
     fin.create_offer(
         &symbol_short!("off_g1b"),
         &symbol_short!("inv_g1"),
@@ -490,7 +673,7 @@ fn test_get_offers_by_invoice() {
         &symbol_short!("USDC"),
         &400u32,
         &86_400u64,
-    );
+     0);
 
     let offers = fin.get_offers_by_invoice(&symbol_short!("inv_g1"));
     assert_eq!(offers.len(), 2);
@@ -524,7 +707,7 @@ fn test_get_offers_by_lender() {
         &symbol_short!("XLM"),
         &200u32,
         &86_400u64,
-    );
+     0);
     fin.create_offer(
         &symbol_short!("off_l2"),
         &symbol_short!("inv_l1"),
@@ -533,7 +716,7 @@ fn test_get_offers_by_lender() {
         &symbol_short!("XLM"),
         &300u32,
         &86_400u64,
-    );
+     0);
 
     let lender_offers = fin.get_offers_by_lender(&lender);
     assert_eq!(lender_offers.len(), 1);
@@ -569,7 +752,7 @@ fn test_get_offers_count() {
         &symbol_short!("USDC"),
         &300_u32,
         &86_400_u64,
-    );
+     0);
     assert_eq!(fin.get_offers_count(), 1);
 }
 
@@ -600,7 +783,7 @@ fn test_get_offers_by_status_filters_correctly() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
     fin.create_offer(
         &symbol_short!("off2"),
         &symbol_short!("inv1"),
@@ -609,7 +792,7 @@ fn test_get_offers_by_status_filters_correctly() {
         &symbol_short!("USDC"),
         &400u32,
         &86_400u64,
-    );
+     0);
 
     let pending = fin.get_offers_by_status(&OfferStatus::Pending);
     assert_eq!(pending.len(), 2);
@@ -648,7 +831,7 @@ fn test_get_pending_offers_by_invoice_excludes_rejected() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
     fin.create_offer(
         &symbol_short!("off2"),
         &symbol_short!("inv1"),
@@ -657,7 +840,7 @@ fn test_get_pending_offers_by_invoice_excludes_rejected() {
         &symbol_short!("USDC"),
         &250u32,
         &86_400u64,
-    );
+     0);
 
     let pending = fin.get_pending_offers_by_invoice(&symbol_short!("inv1"));
     assert_eq!(pending.len(), 2);
@@ -698,7 +881,7 @@ fn test_get_offers_paginated() {
             &symbol_short!("USDC"),
             &rate,
             &86_400u64,
-        );
+         0);
     }
 
     let page1 = fin.get_offers_paginated(&0_u32, &2_u32);
@@ -740,7 +923,7 @@ fn test_update_offer_status_and_amount_repaid() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
 
     // Register a fake repayment contract (auth is mocked)
     let repayment_id = env.register(
@@ -789,7 +972,7 @@ fn test_update_lender_stats_repaid() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-    );
+     0);
 
     let stats_before = fin.get_lender_stats(&lender);
     assert_eq!(stats_before.offers_repaid, 0);
@@ -882,7 +1065,7 @@ fn test_get_offer_duration_limits() {
 
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
-fn test_pause_blocks_create_offer() {
+fn test_pause_blocks_create_offer(, 0) {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -911,7 +1094,7 @@ fn test_pause_blocks_create_offer() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
 }
 
 #[test]
@@ -943,7 +1126,7 @@ fn test_pause_blocks_all_financing_state_changes() {
             &symbol_short!("USDC"),
             &500u32,
             &86_400u64,
-        );
+         0);
     });
     assert_paused(|| {
         fin.withdraw_offer(&symbol_short!("offx2"), &lender);
@@ -1034,7 +1217,7 @@ fn test_accept_offer_mints_position_token() {
         &symbol_short!("USDC"),
         &300u32,
         &1_296_000u64,
-    );
+     0);
 
     fin.accept_offer(&offer_id, &originator);
 
@@ -1091,7 +1274,7 @@ fn test_accept_offer_without_position_token_still_works() {
         &symbol_short!("USDC"),
         &300u32,
         &1_296_000u64,
-    );
+     0);
 
     let accepted = fin.accept_offer(&offer_id, &originator);
     assert_eq!(accepted.status, OfferStatus::Accepted);
@@ -1133,7 +1316,7 @@ fn setup_offer_for_schedule<'a>(
         &symbol_short!("USDC"),
         &500u32, // 5.00% per installment slice
         &(31_536_000u64),
-    );
+     0);
 
     (reg, fin, originator, lender)
 }

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -96,7 +96,8 @@ fn test_create_and_get_offer() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
 
     assert_eq!(offer.id, offer_id);
     assert_eq!(offer.invoice_id, invoice_id);
@@ -136,7 +137,8 @@ fn test_create_offer_zero_amount() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 }
 
 #[test]
@@ -167,7 +169,8 @@ fn test_create_offer_interest_rate_too_high_panics() {
         &symbol_short!("USDC"),
         &10_001u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 }
 
 #[test]
@@ -229,7 +232,8 @@ fn test_create_offer_short_duration_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &3_600u64,
-     0);
+        &0u64,
+    );
 }
 
 #[test]
@@ -260,7 +264,8 @@ fn test_max_offer_duration_rejected() {
         &symbol_short!("USDC"),
         &500_u32,
         &31_622_400_u64,
-     0);
+        &0u64,
+    );
 }
 
 #[test]
@@ -290,12 +295,13 @@ fn test_create_offer_self_dealing_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 }
 
 #[test]
 #[should_panic(expected = "Error(Contract, #8)")]
-fn test_blacklisted_cannot_create_offer(, 0) {
+fn test_blacklisted_cannot_create_offer() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -322,7 +328,8 @@ fn test_blacklisted_cannot_create_offer(, 0) {
         &symbol_short!("XLM"),
         &200u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 }
 
 // ─── Accept / Reject tests ──────────────────────────────────────────────────
@@ -368,7 +375,8 @@ fn test_accept_offer() {
         &symbol_short!("USDC"),
         &300u32,
         &(1_296_000u64),
-     0);
+        &0u64,
+    );
 
     let accepted = fin.accept_offer(&offer_id, &originator);
     assert_eq!(accepted.status, OfferStatus::Accepted);
@@ -438,7 +446,7 @@ fn test_accept_offer_before_expiry_succeeds() {
     );
     let fin = super::FinancingContractClient::new(&env, &financing_id);
 
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
 
     reg.register_invoice(
@@ -490,7 +498,7 @@ fn test_accept_offer_after_expiry_panics() {
     );
     let fin = super::FinancingContractClient::new(&env, &financing_id);
 
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
 
     reg.register_invoice(
@@ -540,7 +548,7 @@ fn test_accept_offer_at_expiry_boundary_panics() {
     );
     let fin = super::FinancingContractClient::new(&env, &financing_id);
 
-    reg.set_financing_contract(&admin, &financing_id);
+    reg.set_financing_contract(&one(&env, &admin), &financing_id);
     mint_and_approve(&env, &token_id, &financing_id, &lender, amount);
 
     reg.register_invoice(
@@ -596,7 +604,8 @@ fn test_reject_offer() {
         &symbol_short!("XLM"),
         &200u32,
         &(864_000u64),
-     0);
+        &0u64,
+    );
 
     let rejected = fin.reject_offer(&offer_id, &originator);
     assert_eq!(rejected.status, OfferStatus::Rejected);
@@ -632,7 +641,8 @@ fn test_withdraw_offer() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     let withdrawn = fin.withdraw_offer(&symbol_short!("off_w1"), &lender);
     assert_eq!(withdrawn.status, OfferStatus::Rejected);
@@ -667,7 +677,8 @@ fn test_withdraw_offer_wrong_lender_panics() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
     fin.withdraw_offer(&symbol_short!("off_w2"), &other);
 }
 
@@ -700,7 +711,8 @@ fn test_get_offers_by_invoice() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
     fin.create_offer(
         &symbol_short!("off_g1b"),
         &symbol_short!("inv_g1"),
@@ -709,7 +721,8 @@ fn test_get_offers_by_invoice() {
         &symbol_short!("USDC"),
         &400u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     let offers = fin.get_offers_by_invoice(&symbol_short!("inv_g1"));
     assert_eq!(offers.len(), 2);
@@ -743,7 +756,8 @@ fn test_get_offers_by_lender() {
         &symbol_short!("XLM"),
         &200u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
     fin.create_offer(
         &symbol_short!("off_l2"),
         &symbol_short!("inv_l1"),
@@ -752,7 +766,8 @@ fn test_get_offers_by_lender() {
         &symbol_short!("XLM"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     let lender_offers = fin.get_offers_by_lender(&lender);
     assert_eq!(lender_offers.len(), 1);
@@ -788,7 +803,8 @@ fn test_get_offers_count() {
         &symbol_short!("USDC"),
         &300_u32,
         &86_400_u64,
-     0);
+        &0u64,
+    );
     assert_eq!(fin.get_offers_count(), 1);
 }
 
@@ -819,7 +835,8 @@ fn test_get_offers_by_status_filters_correctly() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
     fin.create_offer(
         &symbol_short!("off2"),
         &symbol_short!("inv1"),
@@ -828,7 +845,8 @@ fn test_get_offers_by_status_filters_correctly() {
         &symbol_short!("USDC"),
         &400u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     let pending = fin.get_offers_by_status(&OfferStatus::Pending);
     assert_eq!(pending.len(), 2);
@@ -867,7 +885,8 @@ fn test_get_pending_offers_by_invoice_excludes_rejected() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
     fin.create_offer(
         &symbol_short!("off2"),
         &symbol_short!("inv1"),
@@ -876,7 +895,8 @@ fn test_get_pending_offers_by_invoice_excludes_rejected() {
         &symbol_short!("USDC"),
         &250u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     let pending = fin.get_pending_offers_by_invoice(&symbol_short!("inv1"));
     assert_eq!(pending.len(), 2);
@@ -917,7 +937,8 @@ fn test_get_offers_paginated() {
             &symbol_short!("USDC"),
             &rate,
             &86_400u64,
-         0);
+            &0u64,
+    );
     }
 
     let page1 = fin.get_offers_paginated(&0_u32, &2_u32);
@@ -959,7 +980,8 @@ fn test_update_offer_status_and_amount_repaid() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     // Register a fake repayment contract (auth is mocked)
     let repayment_id = env.register(
@@ -1008,7 +1030,8 @@ fn test_update_lender_stats_repaid() {
         &symbol_short!("USDC"),
         &300u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 
     let stats_before = fin.get_lender_stats(&lender);
     assert_eq!(stats_before.offers_repaid, 0);
@@ -1148,7 +1171,7 @@ fn test_financing_set_signers_requires_threshold() {
 
 #[test]
 #[should_panic(expected = "Error(Contract, #4)")]
-fn test_pause_blocks_create_offer(, 0) {
+fn test_pause_blocks_create_offer() {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().set_timestamp(1_000_000);
@@ -1177,7 +1200,8 @@ fn test_pause_blocks_create_offer(, 0) {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
 }
 
 #[test]
@@ -1212,7 +1236,8 @@ fn test_pause_blocks_all_financing_state_changes() {
             &symbol_short!("USDC"),
             &500u32,
             &86_400u64,
-         0);
+            &0u64,
+    );
     });
     assert_paused(|| {
         fin.withdraw_offer(&symbol_short!("offx2"), &lender);
@@ -1306,7 +1331,8 @@ fn test_accept_offer_mints_position_token() {
         &symbol_short!("USDC"),
         &300u32,
         &1_296_000u64,
-     0);
+        &0u64,
+    );
 
     fin.accept_offer(&offer_id, &originator);
 
@@ -1363,7 +1389,8 @@ fn test_accept_offer_without_position_token_still_works() {
         &symbol_short!("USDC"),
         &300u32,
         &1_296_000u64,
-     0);
+        &0u64,
+    );
 
     let accepted = fin.accept_offer(&offer_id, &originator);
     assert_eq!(accepted.status, OfferStatus::Accepted);
@@ -1405,7 +1432,8 @@ fn setup_offer_for_schedule<'a>(
         &symbol_short!("USDC"),
         &500u32, // 5.00% per installment slice
         &(31_536_000u64),
-     0);
+        &0u64,
+    );
 
     (reg, fin, originator, lender)
 }

--- a/financing/src/test.rs
+++ b/financing/src/test.rs
@@ -200,6 +200,7 @@ fn test_create_offer_interest_rate_at_cap_passes() {
         &symbol_short!("USDC"),
         &invofi_common::MAX_INTEREST_BPS,
         &86_400u64,
+        &0u64,
     );
     assert_eq!(offer.interest_rate, invofi_common::MAX_INTEREST_BPS);
 }
@@ -1877,6 +1878,7 @@ fn setup_negotiation<'a>(
         &symbol_short!("USDC"),
         &500u32,
         &(1_296_000u64),
+        &0u64,
     );
 
     (reg, fin, admin, originator, lender, token_id)

--- a/integration/src/proptest.rs
+++ b/integration/src/proptest.rs
@@ -30,7 +30,7 @@ proptest! {
         let invoice_id = symbol_short!("inv_e2e");
         let offer_id = symbol_short!("off_e2e");
         p.reg.register_invoice(&invoice_id, &p.originator, &principal, &symbol_short!("USD"), &2_000_000u64);
-        p.fin.create_offer(&offer_id, &invoice_id, &p.lender, &principal, &symbol_short!("USD"), &interest_rate, &2_592_000u64);
+        p.fin.create_offer(&offer_id, &invoice_id, &p.lender, &principal, &symbol_short!("USD"), &interest_rate, &2_592_000u64, &0u64);
         mint_and_approve(&env, &p.token_id, &p.financing_id, &p.lender, principal);
         p.fin.accept_offer(&offer_id, &p.originator);
 

--- a/integration/src/test.rs
+++ b/integration/src/test.rs
@@ -186,7 +186,7 @@ fn test_registry_financing_accept_offer_transitions_invoice() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     assert_eq!(offer.status, OfferStatus::Pending);
 
     // Step 3: Originator accepts the offer.
@@ -233,7 +233,7 @@ fn test_registry_financing_offer_on_financed_invoice_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-    );
+     0);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -278,7 +278,7 @@ fn test_financing_repayment_full_repay_syncs_state() {
         &symbol_short!("USDC"),
         &interest_rate,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Fund originator for repayment.
@@ -327,7 +327,7 @@ fn test_financing_repayment_partial_keeps_financed() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Partial repayment (half).
@@ -367,7 +367,7 @@ fn test_financing_repayment_on_pending_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-    );
+     0);
     // Offer NOT accepted — invoice is still Pending.
     p.rep.repay_invoice(
         &symbol_short!("inv_np"),
@@ -419,7 +419,7 @@ fn test_repayment_insurance_default_triggers_payout() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Fund the insurance pool.
@@ -480,7 +480,7 @@ fn test_repayment_insurance_reclaim_before_grace_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Past due_date but NOT past the grace period.
@@ -531,7 +531,7 @@ fn test_repayment_reputation_success_on_full_repay() {
         &symbol_short!("USDC"),
         &interest_rate,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Fund originator + full repayment.
@@ -575,7 +575,7 @@ fn test_repayment_reputation_default_on_reclaim() {
         mint_and_approve(&env, &p.token_id, &p.financing_id, &p.lender, amount);
 
         p.reg.register_invoice(&inv_id, &p.originator, &amount, &symbol_short!("USDC"), &due);
-        p.fin.create_offer(&off_id, &inv_id, &p.lender, &amount, &symbol_short!("USDC"), &500u32, &2_592_000u64);
+        p.fin.create_offer(&off_id, &inv_id, &p.lender, &amount, &symbol_short!("USDC"), &500u32, &2_592_000u64, 0);
         p.fin.accept_offer(&off_id, &p.originator);
 
         let total = amount + amount * 500 / 10_000;
@@ -606,7 +606,7 @@ fn test_repayment_reputation_default_on_reclaim() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&offer_id, &p.originator);
 
     env.ledger()
@@ -656,7 +656,7 @@ fn test_registry_repayment_overdue_delegates_to_registry() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     p.fin.accept_offer(&symbol_short!("off_ov"), &p.originator);
 
     // After due_date, anyone can mark overdue through Repayment.
@@ -729,7 +729,7 @@ fn test_full_lifecycle_register_offer_accept_repay() {
         &symbol_short!("USDC"),
         &interest_rate,
         &1_296_000u64,
-    );
+     0);
     assert_eq!(offer.status, OfferStatus::Pending);
     assert_eq!(offer.interest_rate, interest_rate);
 

--- a/integration/src/test.rs
+++ b/integration/src/test.rs
@@ -643,6 +643,7 @@ fn test_repayment_reputation_default_on_reclaim() {
             &symbol_short!("USDC"),
             &500u32,
             &2_592_000u64,
+            &0u64,
         );
         p.fin.accept_offer(&off_id, &p.originator);
 

--- a/integration/src/test.rs
+++ b/integration/src/test.rs
@@ -201,7 +201,8 @@ fn test_registry_financing_accept_offer_transitions_invoice() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     assert_eq!(offer.status, OfferStatus::Pending);
 
     // Step 3: Originator accepts the offer.
@@ -249,7 +250,8 @@ fn test_registry_financing_offer_on_financed_invoice_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -295,7 +297,8 @@ fn test_financing_repayment_full_repay_syncs_state() {
         &symbol_short!("USDC"),
         &interest_rate,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Advance 365 days so pro-rata interest = flat yield.
@@ -349,7 +352,8 @@ fn test_financing_repayment_partial_keeps_financed() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Advance 1 day to accrue some interest.
@@ -394,7 +398,8 @@ fn test_financing_repayment_on_pending_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &86_400u64,
-     0);
+        &0u64,
+    );
     // Offer NOT accepted — invoice is still Pending.
     p.rep.repay_invoice(
         &symbol_short!("inv_np"),
@@ -446,7 +451,8 @@ fn test_repayment_insurance_default_triggers_payout() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Fund the insurance pool.
@@ -508,7 +514,8 @@ fn test_repayment_insurance_reclaim_before_grace_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Past due_date but NOT past the grace period.
@@ -560,7 +567,8 @@ fn test_repayment_reputation_success_on_full_repay() {
         &symbol_short!("USDC"),
         &interest_rate,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&offer_id, &p.originator);
 
     // Advance 365 days so pro-rata interest = flat yield.
@@ -672,7 +680,8 @@ fn test_repayment_reputation_default_on_reclaim() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&offer_id, &p.originator);
 
     env.ledger()
@@ -722,7 +731,8 @@ fn test_registry_repayment_overdue_delegates_to_registry() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     p.fin.accept_offer(&symbol_short!("off_ov"), &p.originator);
 
     // After due_date, anyone can mark overdue through Repayment.
@@ -796,7 +806,8 @@ fn test_full_lifecycle_register_offer_accept_repay() {
         &symbol_short!("USDC"),
         &interest_rate,
         &1_296_000u64,
-     0);
+        &0u64,
+    );
     assert_eq!(offer.status, OfferStatus::Pending);
     assert_eq!(offer.interest_rate, interest_rate);
 

--- a/repayment/src/proptest.rs
+++ b/repayment/src/proptest.rs
@@ -90,7 +90,7 @@ proptest! {
             &symbol_short!("USD"),
             &interest_rate,
             &2_592_000u64,
-        );
+         0);
 
         // Mint and approve for lender
         asset_client.mint(&lender, &principal);

--- a/repayment/src/proptest.rs
+++ b/repayment/src/proptest.rs
@@ -100,7 +100,8 @@ proptest! {
             &symbol_short!("USD"),
             &interest_rate,
             &2_592_000u64,
-         0);
+            &0u64,
+        );
 
         // Mint and approve for lender
         asset_client.mint(&lender, &principal);

--- a/repayment/src/proptest.rs
+++ b/repayment/src/proptest.rs
@@ -230,7 +230,7 @@ proptest! {
         reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
         reg.register_invoice(&invoice_id, &originator, &principal, &symbol_short!("USD"), &2_000_000u64);
-        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &interest_rate, &2_592_000u64);
+        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &interest_rate, &2_592_000u64, &0u64);
         asset_client.mint(&lender, &principal);
         token_client.approve(&lender, &financing_id, &principal, &(env.ledger().sequence() + 1000));
         fin.accept_offer(&offer_id, &originator);
@@ -284,7 +284,7 @@ proptest! {
         reg.set_financing_contract(&one(&env, &admin), &financing_id);
 
         reg.register_invoice(&invoice_id, &originator, &principal, &symbol_short!("USD"), &2_000_000u64);
-        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &interest_rate, &31_536_000u64);
+        fin.create_offer(&offer_id, &invoice_id, &lender, &principal, &symbol_short!("USD"), &interest_rate, &31_536_000u64, &0u64);
         asset_client.mint(&lender, &principal);
         token_client.approve(&lender, &financing_id, &principal, &(env.ledger().sequence() + 1000));
         fin.accept_offer(&offer_id, &originator);

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -142,7 +142,7 @@ fn test_repay_invoice_partial_then_full() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&offer_id, &originator);
 
     // Mint repayment funds to originator
@@ -232,7 +232,7 @@ fn test_repay_invoice_overpayment_panics() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&symbol_short!("off_op"), &originator);
 
     let asset_client = token::StellarAssetClient::new(&env, &token_id);
@@ -274,7 +274,7 @@ fn test_repay_unfinanced_invoice_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     // Offer NOT accepted — invoice stays Pending
     rep.repay_invoice(
         &symbol_short!("inv_uf"),
@@ -337,7 +337,7 @@ fn test_repay_zero_amount_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&symbol_short!("off_za"), &originator);
 
     rep.repay_invoice(
@@ -405,7 +405,7 @@ fn test_reclaim_invoice_after_grace_period() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&offer_id, &originator);
 
     // Move past due_date + grace period
@@ -479,7 +479,7 @@ fn test_reclaim_before_grace_period_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&offer_id, &originator);
 
     // Just past due_date, but not past grace period
@@ -542,7 +542,7 @@ fn test_reclaim_on_non_overdue_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&symbol_short!("off_nr"), &originator);
 
     // Invoice is Financed, not Overdue — should panic
@@ -602,7 +602,7 @@ fn test_calculate_total_due() {
         &symbol_short!("XLM"),
         &1_000u32, // 10%
         &86_400u64,
-    );
+     0);
     fin.accept_offer(&symbol_short!("off_td"), &originator);
 
     // principal=10000, yield=10000*1000/10000=1000, total_due=11000, repaid=0
@@ -665,7 +665,7 @@ fn test_calculate_total_due_after_partial() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&symbol_short!("off_tp"), &originator);
 
     let asset_client = token::StellarAssetClient::new(&env, &token_id);
@@ -779,7 +779,7 @@ fn test_pause_blocks_repay_invoice() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-    );
+     0);
     fin.accept_offer(&offer_id, &originator);
 
     rep.pause(&admin);
@@ -920,7 +920,7 @@ fn test_reclaim_triggers_defaulted_payout_and_reputation() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&offer_id, &originator);
 
     // Past due + grace period, then mark overdue.
@@ -1015,7 +1015,7 @@ fn test_full_repay_records_reputation_success() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&offer_id, &originator);
 
     // Originator repays principal + 5% yield in full.
@@ -1064,7 +1064,7 @@ fn test_repayment_get_installment_due_proxy() {
         &symbol_short!("USDC"),
         &500u32,
         &(31_536_000u64),
-    );
+     0);
 
     // 4 weekly installments.
     // installment_principal = 1_200_000_000 / 4 = 300_000_000
@@ -1128,7 +1128,7 @@ fn test_repayment_get_installment_due_zero_after_full_repay() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(31_536_000u64),
-    );
+     0);
 
     let first_due = env.ledger().timestamp() + 604_800;
     fin.schedule_repayment(
@@ -1239,7 +1239,7 @@ fn setup_penalty_case<'a>(env: &'a Env) -> PenCase<'a> {
         &symbol_short!("USDC"),
         &PEN_RATE,
         &(2_592_000u64),
-    );
+     0);
     fin.accept_offer(&symbol_short!("off_pen"), &originator);
 
     // Fund the originator beyond the capped worst case.

--- a/repayment/src/test.rs
+++ b/repayment/src/test.rs
@@ -146,7 +146,8 @@ fn test_repay_invoice_partial_then_full() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&offer_id, &originator);
 
     // Advance 1 day to accrue pro-rata interest.
@@ -259,7 +260,8 @@ fn test_repay_invoice_overpayment_panics() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&symbol_short!("off_op"), &originator);
 
     let asset_client = token::StellarAssetClient::new(&env, &token_id);
@@ -301,7 +303,8 @@ fn test_repay_unfinanced_invoice_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     // Offer NOT accepted — invoice stays Pending
     rep.repay_invoice(
         &symbol_short!("inv_uf"),
@@ -364,7 +367,8 @@ fn test_repay_zero_amount_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&symbol_short!("off_za"), &originator);
 
     rep.repay_invoice(
@@ -432,7 +436,8 @@ fn test_reclaim_invoice_after_grace_period() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&offer_id, &originator);
 
     // Move past due_date + grace period
@@ -506,7 +511,8 @@ fn test_reclaim_before_grace_period_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&offer_id, &originator);
 
     // Just past due_date, but not past grace period
@@ -569,7 +575,8 @@ fn test_reclaim_on_non_overdue_panics() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&symbol_short!("off_nr"), &originator);
 
     // Invoice is Financed, not Overdue — should panic
@@ -629,7 +636,8 @@ fn test_calculate_total_due() {
         &symbol_short!("XLM"),
         &1_000u32, // 10%
         &86_400u64,
-     0);
+        &0u64,
+    );
     fin.accept_offer(&symbol_short!("off_td"), &originator);
 
     // Advance 365 days so pro-rata interest = principal * rate * 365 / 3_650_000
@@ -693,7 +701,8 @@ fn test_calculate_total_due_after_partial() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&symbol_short!("off_tp"), &originator);
 
     // Advance 365 days so pro-rata interest = 1_000_000_000 * 500 * 365 / 3_650_000 = 50_000_000
@@ -841,7 +850,8 @@ fn test_pause_blocks_repay_invoice() {
         &symbol_short!("USDC"),
         &500u32,
         &2_592_000u64,
-     0);
+        &0u64,
+    );
     fin.accept_offer(&offer_id, &originator);
 
     rep.pause(&one(&env, &admin));
@@ -988,7 +998,8 @@ fn test_reclaim_triggers_defaulted_payout_and_reputation() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&offer_id, &originator);
 
     // Past due + grace period, then mark overdue.
@@ -1083,7 +1094,8 @@ fn test_full_repay_records_reputation_success() {
         &symbol_short!("USDC"),
         &500u32,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&offer_id, &originator);
 
     // Advance 365 days so pro-rata interest = 50_000_000 (matches flat yield).
@@ -1135,7 +1147,8 @@ fn test_repayment_get_installment_due_proxy() {
         &symbol_short!("USDC"),
         &500u32,
         &(31_536_000u64),
-     0);
+        &0u64,
+    );
 
     // 4 weekly installments.
     // installment_principal = 1_200_000_000 / 4 = 300_000_000
@@ -1199,7 +1212,8 @@ fn test_repayment_get_installment_due_zero_after_full_repay() {
         &symbol_short!("USDC"),
         &interest_rate,
         &(31_536_000u64),
-     0);
+        &0u64,
+    );
 
     let first_due = env.ledger().timestamp() + 604_800;
     fin.schedule_repayment(
@@ -1314,7 +1328,8 @@ fn setup_penalty_case<'a>(env: &'a Env) -> PenCase<'a> {
         &symbol_short!("USDC"),
         &PEN_RATE,
         &(2_592_000u64),
-     0);
+        &0u64,
+    );
     fin.accept_offer(&symbol_short!("off_pen"), &originator);
 
     // Fund the originator beyond the capped worst case.


### PR DESCRIPTION
## Summary
Offers previously stayed open indefinitely. This adds an optional `expires_at` (u64 Unix timestamp) to the `FinancingOffer` struct so stale offers can no longer be accepted after their deadline.

## Issue
- Closes #108

## Changes
- `common/src/lib.rs`: added `expires_at: u64` to `FinancingOffer` (`0` = no expiry, backward compatible); added `ContractError::OfferExpired = 9` to the panic catalogue.
- `financing/src/lib.rs`: `create_offer` now accepts `expires_at` and stores it; `accept_offer` rejects offers where `expires_at != 0 && ledger.timestamp() >= expires_at` via `panic_with_error(ContractError::OfferExpired)`.
- Updated all in-repo `create_offer` call sites (financing/repayment/integration tests) to pass `0`, preserving existing behavior.
- Added tests: `expires_at` is stored; accept-before-expiry succeeds; accept-after-expiry panics; boundary (`now == expires_at`) panics.

## Validation
- Not run in the agent environment (no Rust/Soroban toolchain installed here). Please run `cargo test` locally; CI will also validate.

## Notes
- Expiry is checked only at accept time; no automatic cleanup/sweeping (per scope). Lenders can still cancel via `withdraw_offer`.
- No new event is emitted on expiry: `accept_offer` reverts via `panic_with_error`, consistent with other rejection paths (e.g. `InvalidTransition`), and the current Protocol Events spec has no expiry event.
- `FinancingOffer` is a `#[contracttype]`; adding a field changes its XDR schema — additive and backward compatible for readers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Financing offers now support expiration timestamps, amendments, counter-offers, negotiation history, configurable deadlines, and automatic acceptance of matching terms.
  * Added threshold-based administration with configurable signers, contract upgrades, post-upgrade actions, and rollback support.
  * Added negotiation status, deadline, and closure information.
* **Bug Fixes**
  * Prevented acceptance of expired offers, including offers expiring at the current time.
  * Added validation for offer amounts and interest-rate limits.
  * Improved event reporting when offers are withdrawn or rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->