### PR TITLE
feat(registry): configurable protocol-fee recipient (#99)

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -878,6 +878,9 @@ pub trait RegistryInterface {
 
     /// Read the admin address.
     fn get_admin(env: Env) -> Address;
+
+    /// Read the protocol-fee recipient address.
+    fn get_fee_recipient(env: Env) -> Address;
 }
 
 // ─── Financing Cross-Contract Interface ──────────────────────────────────────

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -292,6 +292,30 @@ impl RegistryContract {
         invofi_common::initialize_contract_version(&env, env!("CARGO_PKG_VERSION"));
     }
 
+    /// Returns the configured protocol-fee recipient address.
+    pub fn get_fee_recipient(env: Env) -> Address {
+        env.storage()
+            .instance()
+            .get(&symbol_short!("feercpt"))
+            .unwrap_or_else(|| {
+                // Fallback for deployments that pre-date the explicit fee recipient.
+                Self::get_admin(env.clone())
+            })
+    }
+
+    /// Set the address that receives protocol fees. Admin only.
+    pub fn set_fee_recipient(env: Env, signers: Vec<Address>, recipient: Address) {
+        assert_not_paused(&env);
+        assert_admin(&env, &signers);
+        env.storage()
+            .instance()
+            .set(&symbol_short!("feercpt"), &recipient);
+        env.events().publish(
+            (symbol_short!("fee_rcpt"),),
+            recipient.clone(),
+        );
+    }
+
     /// Returns the primary admin address (the first configured signer).
     /// Panics if not yet initialized. In single-admin bootstrap mode this is
     /// the only signer; under true M-of-N it is a convenience for tooling

--- a/registry/src/test.rs
+++ b/registry/src/test.rs
@@ -1276,6 +1276,48 @@ fn test_set_fee_too_high_panics() {
 }
 
 // ─── Blacklist tests ───────────────────────────────────────────────────────────
+// ─── Fee recipient tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_default_fee_recipient_is_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_fee_recipient(), admin);
+}
+
+#[test]
+fn test_set_and_get_fee_recipient() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_fee_recipient(), admin);
+    client.set_fee_recipient(&one(&env, &admin), &new_recipient);
+    assert_eq!(client.get_fee_recipient(), new_recipient);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_set_fee_recipient_unauthorized_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let not_admin = Address::generate(&env);
+    let new_recipient = Address::generate(&env);
+    let contract_id = env.register(RegistryContract, (admin.clone(),));
+    let client = super::RegistryContractClient::new(&env, &contract_id);
+
+    client.set_fee_recipient(&one(&env, &not_admin), &new_recipient);
+}
+
+// ─── Blacklist tests ───────────────────────────────────────────────────────────
 
 #[test]
 fn test_blacklist_and_unblacklist() {

--- a/repayment/src/lib.rs
+++ b/repayment/src/lib.rs
@@ -445,15 +445,10 @@ impl RepaymentContract {
         // CEI: External interaction. Safe because this contract has no local state to protect.
         token_client.transfer(&repayer, &offer.lender, &lender_amount);
         if fee_amount > 0 {
-            // Fees settle to the primary signer (the first configured admin
-            // address) — the same recipient as before under single-admin
-            // bootstrap mode; see ADR-0010.
-            let admin: Address = invofi_common::load_admin_config(&env)
-                .signers
-                .get(0)
-                .unwrap_or_else(|| panic!("Not initialized"));
             // CEI: External interaction. Safe because this contract has no local state to protect.
-            token_client.transfer(&repayer, &admin, &fee_amount);
+            // Fees settle to the configurable protocol-fee recipient (default: admin).
+            let fee_recipient: Address = registry_client.get_fee_recipient();
+            token_client.transfer(&repayer, &fee_recipient, &fee_amount);
         }
 
         // ── Store payment record ───────────────────────────────────────────


### PR DESCRIPTION
Closes #99

Adds a configurable protocol-fee recipient address to the Registry contract:

- set_fee_recipient(address) is admin-gated (same threshold pattern as set_fee) and emits a ee_rcpt governance event.
- get_fee_recipient() returns the configured address, defaulting to the admin for existing deployments.
- Repayment now routes fee transfers to egistry.get_fee_recipient() instead of always using the primary admin signer.

Fee rate and collection math are unchanged per the issue scope.

cargo test -p invofi-registry and cargo build --workspace pass.