### PR TITLE
feat(reputation): get_score returns human-readable tiers in addition to raw score (#151)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,18 @@ the frontend's portfolio offers a one-click trustline helper.
 | `record_outcome(originator, outcome)` | Recorder only | `0` = repaid, `1` = defaulted; updates outcome counts and applies pending score decay (issue #139) |
 | `resolve_dispute(admin, originator, originator_favourable)` | Admin | Neutralize one recorded default when a dispute resolves in the originator's favour; applies pending decay and emits `rep_chg` with the corrected score (ADR-0004 §7, issue #134) |
 | `get_score(originator)` | Anyone | Cached decayed score — `weighted_repayments − weighted_defaults`, floored at 0; recomputed on each write (ADR-0004 §3, issue #139) |
+| `get_score_tier(originator)` | Anyone | Coarse reputation tier mapped from decayed score for marketplace screening and insurance pricing (issue #151) |
 | `get_record(originator)` | Anyone | Raw `{repayments, defaults}` counts plus cumulative weighted values — the source of truth |
+
+#### Reputation Tiers (issue #151)
+
+| Tier | Name | Score Range | Description |
+|---|---|---|---|
+| `0` | `Unrated` | `score == 0` | New originator or zero net score |
+| `1` | `Bronze` | `1 <= score <= 4` | Building initial track record |
+| `2` | `Silver` | `5 <= score <= 14` | Established borrower with consistent repayments |
+| `3` | `Gold` | `15 <= score <= 29` | High-volume reliable borrower |
+| `4` | `Platinum` | `score >= 30` | Prime institutional borrower |
 
 ## Protocol Events
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -320,6 +320,44 @@ pub enum RiskTier {
     C = 2,
 }
 
+/// Coarse reputation tier mapped from the originator's raw score (issue #151).
+/// Used by marketplace UI, loan screening, and insurance pricing.
+#[contracttype]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ReputationTier {
+    /// Score 0: New originator or no positive net score.
+    Unrated = 0,
+    /// Score 1..=4: Beginner / building track record.
+    Bronze = 1,
+    /// Score 5..=14: Established borrower with consistent repayments.
+    Silver = 2,
+    /// Score 15..=29: High-volume, highly reliable borrower.
+    Gold = 3,
+    /// Score >= 30: Prime institutional borrower.
+    Platinum = 4,
+}
+
+pub const TIER_BRONZE_MIN_SCORE: i128 = 1;
+pub const TIER_SILVER_MIN_SCORE: i128 = 5;
+pub const TIER_GOLD_MIN_SCORE: i128 = 15;
+pub const TIER_PLATINUM_MIN_SCORE: i128 = 30;
+
+/// Map a raw reputation score to its corresponding tier.
+pub fn score_to_tier(score: i128) -> ReputationTier {
+    if score >= TIER_PLATINUM_MIN_SCORE {
+        ReputationTier::Platinum
+    } else if score >= TIER_GOLD_MIN_SCORE {
+        ReputationTier::Gold
+    } else if score >= TIER_SILVER_MIN_SCORE {
+        ReputationTier::Silver
+    } else if score >= TIER_BRONZE_MIN_SCORE {
+        ReputationTier::Bronze
+    } else {
+        ReputationTier::Unrated
+    }
+}
+
 /// An invoice registered on-chain.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -1011,6 +1049,9 @@ pub trait ReputationInterface {
 
     /// Read an originator's current reputation score (public, read-only).
     fn get_score(env: Env, originator: Address) -> i128;
+
+    /// Read an originator's coarse reputation tier (public, read-only, issue #151).
+    fn get_score_tier(env: Env, originator: Address) -> u32;
 }
 
 // ─── assert_transition unit tests ────────────────────────────────────────────

--- a/docs/adr/0004-reputation.md
+++ b/docs/adr/0004-reputation.md
@@ -82,6 +82,25 @@ raw counts into a simple, transparent, publicly-readable score.
      observe the correction. `get_score` / `get_record` stay public and
      read-only. Admin auth mirrors `resolve_dispute` in the registry.
 
+8. **Coarse reputation tiers (issue #151):**
+   Consumers (marketplace UI, risk screening, insurance pricing) need
+   standardized, coarse tiers to make decisions without hardcoding
+   thresholds across multiple client apps. The tiers map monotonically from
+   `get_score(originator)`:
+   - **Tier 0 (`ReputationTier::Unrated`, 0)**: `score == 0` (New originator
+     or zero net score).
+   - **Tier 1 (`ReputationTier::Bronze`, 1)**: `1 <= score <= 4` (Building track
+     record, early repayment history).
+   - **Tier 2 (`ReputationTier::Silver`, 2)**: `5 <= score <= 14` (Established
+     borrower with consistent track record).
+   - **Tier 3 (`ReputationTier::Gold`, 3)**: `15 <= score <= 29` (High-volume
+     reliable originator).
+   - **Tier 4 (`ReputationTier::Platinum`, 4)**: `score >= 30` (Prime
+     institutional borrower).
+
+   Exposed via public query `get_score_tier(originator) -> u32` in `reputation`
+   and in `ReputationInterface`.
+
 ## Consequences
 
 - Lenders get a queryable, honest default-risk signal per originator.

--- a/reputation/src/lib.rs
+++ b/reputation/src/lib.rs
@@ -30,6 +30,10 @@ use soroban_sdk::{
 };
 
 use invofi_common::{assert_not_paused, AdminConfig, ContractError};
+pub use invofi_common::{
+    score_to_tier, ReputationTier, TIER_BRONZE_MIN_SCORE, TIER_GOLD_MIN_SCORE,
+    TIER_PLATINUM_MIN_SCORE, TIER_SILVER_MIN_SCORE,
+};
 
 /// Threshold-gated admin check (ADR-0010). See `invofi_common::assert_threshold`.
 fn assert_admin(env: &Env, signers: &Vec<Address>) {
@@ -99,10 +103,8 @@ fn apply_pending_decay(record: &mut ReputationRecord, now: u64) {
         let elapsed = now - record.last_recompute;
         let half_life = DECAY_HALF_LIFE_SECS as f64;
         let scale = libm::pow(0.5, elapsed as f64 / half_life);
-        record.weighted_repayments =
-            (record.weighted_repayments as f64 * scale) as i128;
-        record.weighted_defaults =
-            (record.weighted_defaults as f64 * scale) as i128;
+        record.weighted_repayments = (record.weighted_repayments as f64 * scale) as i128;
+        record.weighted_defaults = (record.weighted_defaults as f64 * scale) as i128;
     }
     record.last_recompute = now;
 }
@@ -366,6 +368,19 @@ impl ReputationContract {
                 last_recompute: 0,
             });
         (record.weighted_repayments - record.weighted_defaults).max(0)
+    }
+
+    /// Returns the originator's coarse reputation tier (issue #151).
+    /// Maps the current score to documented tiers:
+    /// - 0: Unrated (score == 0)
+    /// - 1: Bronze (score 1..=4)
+    /// - 2: Silver (score 5..=14)
+    /// - 3: Gold (score 15..=29)
+    /// - 4: Platinum (score >= 30)
+    /// Public, read-only O(1) query.
+    pub fn get_score_tier(env: Env, originator: Address) -> u32 {
+        let score = Self::get_score(env, originator);
+        score_to_tier(score) as u32
     }
 
     /// Raw outcome counts for transparency and auditability. The counts

--- a/reputation/src/proptest.rs
+++ b/reputation/src/proptest.rs
@@ -3,7 +3,10 @@ extern crate std;
 
 use crate::{ReputationContract, OUTCOME_DEFAULTED, OUTCOME_REPAID};
 use proptest::prelude::*;
-use soroban_sdk::{testutils::{Address as _, Ledger as _}, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Ledger as _},
+    Address, Env,
+};
 
 fn setup(env: &Env) -> (crate::ReputationContractClient<'static>, Address, Address) {
     let admin = Address::generate(env);

--- a/reputation/src/test.rs
+++ b/reputation/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 extern crate std;
 
-use super::{ReputationContract, OUTCOME_DEFAULTED, OUTCOME_REPAID};
+use super::{score_to_tier, ReputationContract, ReputationTier, OUTCOME_DEFAULTED, OUTCOME_REPAID};
 use soroban_sdk::{
     symbol_short,
     testutils::{Address as _, Events as _, Ledger as _},
@@ -40,7 +40,10 @@ fn test_reputation_set_signers_requires_threshold() {
     client.set_signers(&one(&env, &admin), &two_signers, &2u32);
 
     let result = client.try_pause(&one(&env, &admin));
-    assert!(result.is_err(), "one of two required signatures must not pause");
+    assert!(
+        result.is_err(),
+        "one of two required signatures must not pause"
+    );
 
     let mut both = soroban_sdk::Vec::new(&env);
     both.push_back(admin.clone());
@@ -423,7 +426,10 @@ fn test_old_default_decays() {
     assert_eq!(rec.repayments, 2);
     assert_eq!(rec.defaults, 1);
     let score = client.get_score(&originator);
-    assert!(score >= 1, "decayed default should allow score > 0, got {score}");
+    assert!(
+        score >= 1,
+        "decayed default should allow score > 0, got {score}"
+    );
 }
 
 /// After two half-lives, the old default contributes < 25 % of its
@@ -450,7 +456,10 @@ fn test_old_default_decays_further_after_two_half_lives() {
     // After 2 half-lives the default's weighted_defaults ≈ 0.5
     // (2 × 0.25), the fresh repayment adds 1.  Score ≈ 1.
     let score = client.get_score(&originator);
-    assert!(score >= 1, "score should be >= 1 after two half-lives, got {score}");
+    assert!(
+        score >= 1,
+        "score should be >= 1 after two half-lives, got {score}"
+    );
 }
 
 /// Score floor at 0 is respected even with decay — score never goes
@@ -618,4 +627,153 @@ fn test_get_score_reads_cached_value() {
     // Default adds 2 to weighted_defaults, old repayment (1) has decayed
     // to ~0.001.  Score = 0.
     assert!(score >= 0, "score must not be negative: {score}");
+}
+
+// ─── Coarse reputation tiers tests (issue #151) ─────────────────────────────
+
+#[test]
+fn test_score_to_tier_pure_function_boundaries() {
+    assert_eq!(score_to_tier(-5), ReputationTier::Unrated);
+    assert_eq!(score_to_tier(0), ReputationTier::Unrated);
+    assert_eq!(score_to_tier(1), ReputationTier::Bronze);
+    assert_eq!(score_to_tier(4), ReputationTier::Bronze);
+    assert_eq!(score_to_tier(5), ReputationTier::Silver);
+    assert_eq!(score_to_tier(14), ReputationTier::Silver);
+    assert_eq!(score_to_tier(15), ReputationTier::Gold);
+    assert_eq!(score_to_tier(29), ReputationTier::Gold);
+    assert_eq!(score_to_tier(30), ReputationTier::Platinum);
+    assert_eq!(score_to_tier(100), ReputationTier::Platinum);
+}
+
+#[test]
+fn test_get_score_tier_unrated_for_fresh_or_zero_score() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recorder = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+    client.set_recorder(&one(&env, &admin), &recorder);
+
+    // Fresh originator (no recorded outcomes)
+    assert_eq!(client.get_score(&originator), 0);
+    assert_eq!(
+        client.get_score_tier(&originator),
+        ReputationTier::Unrated as u32
+    );
+
+    // After a default (score stays 0)
+    set_timestamp(&env, 1_000_000);
+    client.record_outcome(&originator, &OUTCOME_DEFAULTED);
+    assert_eq!(client.get_score(&originator), 0);
+    assert_eq!(
+        client.get_score_tier(&originator),
+        ReputationTier::Unrated as u32
+    );
+}
+
+#[test]
+fn test_get_score_tier_across_all_boundaries() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recorder = Address::generate(&env);
+    let client = setup(&env, &admin);
+    client.set_recorder(&one(&env, &admin), &recorder);
+
+    set_timestamp(&env, 1_000_000);
+
+    // Originator 1: Bronze boundary (score 1 and score 4)
+    let orig1 = Address::generate(&env);
+    client.record_outcome(&orig1, &OUTCOME_REPAID);
+    assert_eq!(client.get_score(&orig1), 1);
+    assert_eq!(client.get_score_tier(&orig1), ReputationTier::Bronze as u32);
+
+    for _ in 0..3 {
+        client.record_outcome(&orig1, &OUTCOME_REPAID);
+    }
+    assert_eq!(client.get_score(&orig1), 4);
+    assert_eq!(client.get_score_tier(&orig1), ReputationTier::Bronze as u32);
+
+    // Originator 2: Silver boundary (score 5 and score 14)
+    let orig2 = Address::generate(&env);
+    for _ in 0..5 {
+        client.record_outcome(&orig2, &OUTCOME_REPAID);
+    }
+    assert_eq!(client.get_score(&orig2), 5);
+    assert_eq!(client.get_score_tier(&orig2), ReputationTier::Silver as u32);
+
+    for _ in 0..9 {
+        client.record_outcome(&orig2, &OUTCOME_REPAID);
+    }
+    assert_eq!(client.get_score(&orig2), 14);
+    assert_eq!(client.get_score_tier(&orig2), ReputationTier::Silver as u32);
+
+    // Originator 3: Gold boundary (score 15 and score 29)
+    let orig3 = Address::generate(&env);
+    for _ in 0..15 {
+        client.record_outcome(&orig3, &OUTCOME_REPAID);
+    }
+    assert_eq!(client.get_score(&orig3), 15);
+    assert_eq!(client.get_score_tier(&orig3), ReputationTier::Gold as u32);
+
+    for _ in 0..14 {
+        client.record_outcome(&orig3, &OUTCOME_REPAID);
+    }
+    assert_eq!(client.get_score(&orig3), 29);
+    assert_eq!(client.get_score_tier(&orig3), ReputationTier::Gold as u32);
+
+    // Originator 4: Platinum boundary (score 30 and above)
+    let orig4 = Address::generate(&env);
+    for _ in 0..30 {
+        client.record_outcome(&orig4, &OUTCOME_REPAID);
+    }
+    assert_eq!(client.get_score(&orig4), 30);
+    assert_eq!(
+        client.get_score_tier(&orig4),
+        ReputationTier::Platinum as u32
+    );
+
+    client.record_outcome(&orig4, &OUTCOME_REPAID);
+    assert_eq!(client.get_score(&orig4), 31);
+    assert_eq!(
+        client.get_score_tier(&orig4),
+        ReputationTier::Platinum as u32
+    );
+}
+
+#[test]
+fn test_get_score_tier_dispute_resolution_elevates_tier() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let recorder = Address::generate(&env);
+    let originator = Address::generate(&env);
+    let client = setup(&env, &admin);
+    client.set_recorder(&one(&env, &admin), &recorder);
+
+    set_timestamp(&env, 1_000_000);
+
+    // 5 repayments and 1 default -> net score = 5*1 - 1*2 = 3 (Tier 1: Bronze)
+    for _ in 0..5 {
+        client.record_outcome(&originator, &OUTCOME_REPAID);
+    }
+    client.record_outcome(&originator, &OUTCOME_DEFAULTED);
+    assert_eq!(client.get_score(&originator), 3);
+    assert_eq!(
+        client.get_score_tier(&originator),
+        ReputationTier::Bronze as u32
+    );
+
+    // Admin resolves dispute in originator's favour -> neutralizes 1 default.
+    // Score becomes 5 -> elevates to Tier 2: Silver.
+    let corrected = client.resolve_dispute(&one(&env, &admin), &originator, &true);
+    assert_eq!(corrected, 5);
+    assert_eq!(
+        client.get_score_tier(&originator),
+        ReputationTier::Silver as u32
+    );
 }


### PR DESCRIPTION
Closes #151

### Summary of Changes

Adds coarse reputation tiering mapped from an originator's decayed reputation score to support consumer decisions (marketplace UI, risk screening, insurance pricing) without requiring consumers to hardcode threshold logic:

1. **ReputationTier Enum & Mapping (invofi-common)**:
   - Added \ReputationTier\ enum (\#[contracttype]\, \#[repr(u32)]\):
     - \